### PR TITLE
Handle tokens with zero precision (i.e. whole number amounts)

### DIFF
--- a/src/pages/Balance.vue
+++ b/src/pages/Balance.vue
@@ -528,6 +528,9 @@ export default {
           if (token.symbol === undefined) {
             return;
           }
+          if (token.precision === undefined) {
+            token.precision = 0;
+          }
           this.coins.forEach(async (coin) => {
             if (
               !coin.network &&
@@ -544,7 +547,7 @@ export default {
                 coin.amount = token.amount || 0;
                 coin.totalAmount = coin.amount || 0;
               }
-              coin.precision = token.precision || 4;
+              coin.precision = token.precision;
             }
           });
           // if token not in coins, add it


### PR DESCRIPTION
Code was forcing zero precision to 4.

Also, surprisingly, hyperion `/v2/state/get_tokens` call returns with precision undefined for zero-precision tokens (hyperion bug?). So we need to handle that.
![image](https://user-images.githubusercontent.com/2141014/186778911-b5963b5c-887b-4920-bfe9-eecc986007d4.png)
![image](https://user-images.githubusercontent.com/2141014/186780376-34fb8642-fb37-4d26-b3b4-518e88d03491.png)

*Not* a Hyperion bug, expected behavior (per Igor Lins e Silva):
![image](https://user-images.githubusercontent.com/2141014/187119737-95661d63-baa8-404e-8a5f-11d438955096.png)

