### PR TITLE
26 nft navigation

### DIFF
--- a/src/pages/Balance.vue
+++ b/src/pages/Balance.vue
@@ -98,7 +98,7 @@
               :suggestTokens="suggestTokens"
             />
           </q-tab-panel>
-          <q-tab-panel name="collectables" label="Collectables" :style="'background:  #00000000'">
+          <q-tab-panel name="collectables" label="Collectibles" :style="'background:  #00000000'">
             <Collectables
               :nftTokenTags="nftTokenTags"
               :nftTokenLoadedAll="nftTokenLoadedAll"

--- a/src/pages/Balance.vue
+++ b/src/pages/Balance.vue
@@ -272,7 +272,7 @@ export default {
       nftTokenLoadedAll: false,
       panning: false,
       coinViewHeight: 0,
-      tab: "coins",
+      tab: this.balanceTab,
       interval: null,
       tokenInterval: null,
       selectedCoin: null,


### PR DESCRIPTION
# Fixes #26 

## Description
Fixes navigation issue so regardless of current tab, clicking on the 'nft' tab navigates to the balance table with 'collectibles' tab selected. Updated spelling of 'collectibles' tab label.

## Test scenarios
see issue description

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
