### PR TITLE
28 rex staking

### DIFF
--- a/src/pages/components/balance/RexStaking.vue
+++ b/src/pages/components/balance/RexStaking.vue
@@ -136,6 +136,7 @@ export default {
       staking: true,
       tokenAmount: 0,
       tokenRexBalance: 0,
+      rpc: null,
     };
   },
   computed: {
@@ -151,6 +152,15 @@ export default {
   },
   methods: {
     ...mapActions("rex", ["getRexBalance"]),
+
+    async getTokenAmount() {
+      this.tokenAmount = Number(
+        (
+          await this.rpc.get_currency_balance("eosio.token", this.accountName, "TLOS")
+        )[0].split(" ")[0]
+      );
+      debugger;
+    },
 
     inputBlur() {
       if (isNaN(this.amount)) this.amount = "0";
@@ -218,6 +228,7 @@ export default {
     async tryStake() {
       try {
         await this.stakeRex();
+        await this.getTokenAmount();
         this.$q.notify({
           type: "primary",
           message: `${this.amount} TLOS is staked to REX`,
@@ -248,24 +259,9 @@ export default {
   },
   watch: {},
   async mounted() {
-    //   TODO get rex apr from api, cors issues
-    //       fetch("https://api.staker.one/v1/telos/apr", {
-    //   mode: 'cors',
-    //   headers: {
-    //     'Access-Control-Allow-Origin':'*'
-    //   }})
-    //     .then(res => res.json())
-    //     .then(json => {
-    //       console.log(json);
-    //     });
     this.tokenRexBalance = await this.getRexBalance(this.accountName);
-
-    const rpc = this.$store.$api.getRpc();
-    this.tokenAmount = Number(
-      (
-        await rpc.get_currency_balance("eosio.token", this.accountName, "TLOS")
-      )[0].split(" ")[0]
-    );
+    this.rpc = this.$store.$api.getRpc();
+    await this.getTokenAmount();
   },
 };
 </script>

--- a/src/pages/components/balance/RexStaking.vue
+++ b/src/pages/components/balance/RexStaking.vue
@@ -224,7 +224,6 @@ export default {
         });
         this.amount = "0";
         this.staking = true;
-        this.showDlg = false;
       } catch (error) {
         console.error(error);
         this.$errorNotification(error);

--- a/src/pages/components/balance/RexStaking.vue
+++ b/src/pages/components/balance/RexStaking.vue
@@ -152,7 +152,7 @@ export default {
     ...mapActions("rex", ["getRexBalance"]),
 
     async getTokenAmount() {
-      this.tokenAmount = Number(
+      return Number(
         (
           await this.rpc.get_currency_balance("eosio.token", this.accountName, "TLOS")
         )[0].split(" ")[0]
@@ -225,7 +225,7 @@ export default {
     async tryStake() {
       try {
         await this.stakeRex();
-        await this.getTokenAmount();
+        this.tokenAmount = await this.getTokenAmount();
         this.$q.notify({
           type: "primary",
           message: `${this.amount} TLOS is staked to REX`,
@@ -241,11 +241,11 @@ export default {
     async tryUnstake() {
       try {
         await this.unstakeRex();
+        this.tokenRexBalance = await this.getRexBalance(this.accountName);
         this.$q.notify({
           type: "primary",
           message: `${this.amount} TLOS is withdrawn from REX`,
         });
-        this.tokenRexBalance = await this.getRexBalance(this.accountName);
         this.amount = "0";
       } catch (error) {
         console.error(error);
@@ -263,7 +263,7 @@ export default {
   async mounted() {
     this.tokenRexBalance = await this.getRexBalance(this.accountName);
     this.rpc = this.$store.$api.getRpc();
-    await this.getTokenAmount();
+    this.tokenAmount = await this.getTokenAmount();
   },
 };
 </script>

--- a/src/pages/components/balance/RexStaking.vue
+++ b/src/pages/components/balance/RexStaking.vue
@@ -125,8 +125,6 @@
 
 <script>
 import { mapGetters, mapActions } from "vuex";
-import moment from "moment";
-import { stakeRex } from "src/store/rex/actions";
 
 export default {
   props: ["showRexStakeDlg", "haveEVMAccount", "selectedCoin"],
@@ -159,7 +157,6 @@ export default {
           await this.rpc.get_currency_balance("eosio.token", this.accountName, "TLOS")
         )[0].split(" ")[0]
       );
-      debugger;
     },
 
     inputBlur() {
@@ -248,16 +245,21 @@ export default {
           type: "primary",
           message: `${this.amount} TLOS is withdrawn from REX`,
         });
+        this.tokenRexBalance = await this.getRexBalance(this.accountName);
         this.amount = "0";
-        this.staking = true;
-        this.showDlg = false;
       } catch (error) {
         console.error(error);
         this.$errorNotification(error);
       }
     },
   },
-  watch: {},
+  watch: {
+    showRexStakeDlg(val){
+      if (val){
+        this.staking = true;
+      }
+    }
+  },
   async mounted() {
     this.tokenRexBalance = await this.getRexBalance(this.accountName);
     this.rpc = this.$store.$api.getRpc();
@@ -280,11 +282,8 @@ export default {
   flex-basis: 15rem;
   height: 3rem;
 }
-// .popupCard {
-//   position: relative;
-// }
+
 .exitBtn {
   position: absolute;
-  // right: 0px;
 }
 </style>


### PR DESCRIPTION
# Fixes #28 

## Description
- persists the staking modal on successful tx, updates available amounts, resets to 'stake' tab on open

## Test steps
1. stake/unstake amount
2. see modal persist
3. see available amount to stake/unstake update

1. open stake modal 
2. select 'unstake' tab 
3. close modal 
4. re-open to see reset to 'stake' tab

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
