### PR TITLE
taking TLOS balance using rpc.get_currency_balance

### DIFF
--- a/src/pages/Balance.vue
+++ b/src/pages/Balance.vue
@@ -517,6 +517,22 @@ export default {
         }
       });
 
+      // This patch fixes #46 (because /v2/state/get_tokens currently does not return the TLOS balance)
+      const rpc = this.$store.$api.getRpc();
+      this.coins.forEach(async (coin) => {
+        console.log(coin.account, coin);
+        if (coin.account === "eosio.token" && coin.symbol === "TLOS" && coin.name == "Telos") {
+            coin.amount = Number(
+              (
+                await rpc.get_currency_balance("eosio.token", this.accountName, "TLOS")
+              )[0].split(" ")[0]
+            );
+            coin.rexBalance =
+              (await this.getRexBalance(this.accountName)) || 0;
+            coin.totalAmount = coin.amount;
+        }
+      });
+
       const sortCoin = function (suggestTokens) {
         return function (a, b) {
           const aSymbol = a.symbol.toLowerCase();


### PR DESCRIPTION
# Fixes #46

## Description
The current Hyperion solution was not returning the correct data ad the TLOS balance was missing.
This PR takes the user TLOS balance directly from nodeos using rpc.get_currency_balance
