### PR TITLE
56 linter force aliasprevent relative paths on imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     // https://eslint.vuejs.org/user-guide/#why-doesn-t-it-work-on-vue-file
     // required to lint *.vue files
     'vue',
-
+    'no-relative-import-paths'
     // https://github.com/typescript-eslint/typescript-eslint/issues/389#issuecomment-509292674
     // Prettier has not been included as plugin to avoid performance impact
     // add it as an extension for your IDE
@@ -57,6 +57,9 @@ module.exports = {
   rules: {
     'prefer-promise-reject-errors': 'off',
 
+    'no-relative-import-paths/no-relative-import-paths': [
+      'error', { 'allowSameFolder': false, 'rootDir': 'src', 'prefix': '~' }
+    ],
 
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "author": "Ryuhei Matsuda <ryuheimat3@gmail.com>",
   "private": true,
   "scripts": {
-    "dev" : "quasar dev",
+    "dev": "quasar dev",
     "build": "quasar build",
     "lint": "eslint --ext .js,.vue ./",
+    "lint:fix": "eslint --fix --ext .js,.vue src",
     "test": "echo \"No test specified\" && exit 0"
   },
   "dependencies": {
@@ -51,6 +52,7 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-no-relative-import-paths": "^1.5.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-quasar": "^1.0.0",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -10,6 +10,7 @@
 const ESLintPlugin = require('eslint-webpack-plugin')
 const nodePolyfillWebpackPlugin = require('node-polyfill-webpack-plugin')
 const env = require("./env");
+const path = require('path');
 
 module.exports = function(/* ctx */) {
   return {
@@ -50,6 +51,16 @@ module.exports = function(/* ctx */) {
           .plugin('eslint-webpack-plugin')
           .use(ESLintPlugin, [{ extensions: ['js', 'vue'] }]);
         chain.plugin('node-polyfill').use(nodePolyfillWebpackPlugin);
+      },
+
+      // https://quasar.dev/quasar-cli/cli-documentation/handling-webpack
+      extendWebpack(cfg) {
+
+        cfg.resolve.alias = {
+          ...cfg.resolve.alias,
+          '~': path.resolve(__dirname, 'src'),
+        };
+
       },
 
       // transpile: false,

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
     <router-view />
 </template>
 <script>
-import { vxm } from "./store/index.js";
+import { vxm } from "~/store/index.js";
 
 export default {
   name: "App",

--- a/src/api/TokenApi.js
+++ b/src/api/TokenApi.js
@@ -1,5 +1,5 @@
 import { __awaiter } from "tslib";
-import RequestApi from "./RequestApi";
+import RequestApi from "~/api/RequestApi";
 class TokenApi {
     constructor() {
         console.log("Token Api created");

--- a/src/api/eosBancorCalc.js
+++ b/src/api/eosBancorCalc.js
@@ -2,7 +2,7 @@ import { __awaiter } from "tslib";
 import { Decimal } from "decimal.js";
 import { Asset, asset_to_number, asset } from "eos-common";
 import _ from "lodash";
-import { compareString } from "./helpers";
+import { compareString } from "~/api/helpers";
 export function calculateReturn(balanceFrom, balanceTo, amount) {
     if (!balanceFrom.symbol.isEqual(amount.symbol))
         throw new Error("From symbol does not match amount symbol");

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -1,8 +1,8 @@
 import { __awaiter } from "tslib";
-import { vxm } from "../store";
+import { vxm } from "~/store";
 import { Asset, asset_to_number, number_to_asset, Sym } from "eos-common";
-import { rpc } from "./rpc";
-import { sortByNetworkTokens } from "./sortByNetworkTokens";
+import { rpc } from "~/api/rpc";
+import { sortByNetworkTokens } from "~/api/sortByNetworkTokens";
 export const networkTokens = ["TLOS"];
 export const isOdd = (num) => num % 2 == 1;
 export const multiSteps = ({ items, onUpdate }) => __awaiter(void 0, void 0, void 0, function* () {

--- a/src/api/multiContractTx.js
+++ b/src/api/multiContractTx.js
@@ -1,6 +1,6 @@
 import { __awaiter } from "tslib";
-import { vxm } from "../store/";
-import { multiContractAction } from "../contracts/multi";
+import { vxm } from "~/store";
+import { multiContractAction } from "~/contracts/multi";
 class MultiContractTx {
     constructor(contractName, getAuth) {
         this.contractName = contractName;

--- a/src/api/singleContractTx.js
+++ b/src/api/singleContractTx.js
@@ -1,4 +1,4 @@
-import { composeMemo } from "./eosBancorCalc";
+import { composeMemo } from "~/api/eosBancorCalc";
 export const liquidateAction = (smartTokenAmount, smartTokenContract, expectedReserve, relayContract, userAccount) => ({
     account: smartTokenContract,
     name: "transfer",

--- a/src/api/sortByNetworkTokens.js
+++ b/src/api/sortByNetworkTokens.js
@@ -1,4 +1,4 @@
-import { networkTokens, compareString } from "./helpers";
+import { networkTokens, compareString } from "~/api/helpers";
 export const sortByNetworkTokens = (arr, selector, order = networkTokens) => {
     const allTokenSymbols = arr.map(selector);
     const atLeastOneNetworkTokenIncluded = order.some(networkSymbol => allTokenSymbols.includes(networkSymbol));

--- a/src/api/telosd.js
+++ b/src/api/telosd.js
@@ -1,6 +1,6 @@
 import { __awaiter } from "tslib";
 import { asset, check, symbol_code, number_to_asset, SymbolCode, asset_to_number, Asset, Sym, Name } from "eos-common";
-import { compareString } from "./helpers";
+import { compareString } from "~/api/helpers";
 export function get_bancor_output(base_reserve, quote_reserve, quantity) {
     const out = (quantity * quote_reserve) / (base_reserve + quantity);
     if (out < 0)

--- a/src/pages/Balance.vue
+++ b/src/pages/Balance.vue
@@ -205,19 +205,19 @@
 <script>
 import BigNumber from "bignumber.js";
 import { mapGetters, mapActions } from "vuex";
-import Coin from "./components/balance/Coin";
-import Collectables from "./components/balance/Collectables";
-import Send from "./components/balance/Send";
-import SendAmount from "./components/balance/SendAmount";
-import Receive from "./components/balance/Receive";
-import BuyAmount from "./components/balance/BuyAmount";
-import ShareAddress from "./components/balance/ShareAddress";
-import QRScanner from "./components/balance/QRScanner";
-import History from "./components/balance/History";
-import Exchange from "./components/balance/Exchange";
-import DepositEVM from "./components/balance/DepositEVM";
-import WithdrawEVM from "./components/balance/WithdrawEVM";
-import RexStaking from "./components/balance/RexStaking";
+import Coin from "~/pages/components/balance/Coin";
+import Collectables from "~/pages/components/balance/Collectables";
+import Send from "~/pages/components/balance/Send";
+import SendAmount from "~/pages/components/balance/SendAmount";
+import Receive from "~/pages/components/balance/Receive";
+import BuyAmount from "~/pages/components/balance/BuyAmount";
+import ShareAddress from "~/pages/components/balance/ShareAddress";
+import QRScanner from "~/pages/components/balance/QRScanner";
+import History from "~/pages/components/balance/History";
+import Exchange from "~/pages/components/balance/Exchange";
+import DepositEVM from "~/pages/components/balance/DepositEVM";
+import WithdrawEVM from "~/pages/components/balance/WithdrawEVM";
+import RexStaking from "~/pages/components/balance/RexStaking";
 import { copyToClipboard } from "quasar";
 
 const GETTING_STARTED_URL = "https://www.telos.net/#getting-started";

--- a/src/pages/Streaming.vue
+++ b/src/pages/Streaming.vue
@@ -86,7 +86,7 @@ export default {
       console.log("Connected to Hyperion Stream!");
     });
   },
-  destroyed() {
+  unmounted() {
     if (this.client) this.client.disconnect();
 
     this.client = null;

--- a/src/pages/components/balance/Exchange.vue
+++ b/src/pages/components/balance/Exchange.vue
@@ -365,8 +365,8 @@
 <script>
 import { mapGetters, mapActions } from "vuex";
 import moment from "moment";
-import SelectCoin from "./SelectCoin";
-import { vxm } from "../../../store";
+import SelectCoin from "~/pages/components/balance/SelectCoin";
+import { vxm } from "~/store";
 import tokenAvatar from "src/components/TokenAvatar";
 
 export default {

--- a/src/pages/components/balance/QRScanner.vue
+++ b/src/pages/components/balance/QRScanner.vue
@@ -37,7 +37,7 @@
 import { mapGetters, mapActions } from 'vuex';
 import moment from 'moment';
 import { QrcodeStream } from 'vue-qrcode-reader'
-import { accountName } from '../../../store/account/getters';
+import { accountName } from '~/store/account/getters';
 
 export default {
   props: ['showQRScannerDlg', 'coins'],

--- a/src/pages/components/balance/SelectCoin.vue
+++ b/src/pages/components/balance/SelectCoin.vue
@@ -125,7 +125,7 @@
 
 <script>
 import { mapGetters, mapActions } from "vuex";
-import { vxm } from "../../../store";
+import { vxm } from "~/store";
 import moment from "moment";
 import tokenAvatar from "src/components/TokenAvatar";
 

--- a/src/pages/components/balance/SendAmount.vue
+++ b/src/pages/components/balance/SendAmount.vue
@@ -205,7 +205,7 @@
 <script>
 import { mapGetters, mapActions } from "vuex";
 import moment from "moment";
-import SendToAddress from "./SendToAddress";
+import SendToAddress from "~/pages/components/balance/SendToAddress";
 import { setInterval } from "timers";
 import { isNumber } from "util";
 import BigNumber from "bignumber.js";

--- a/src/pages/components/balance/SendToAddress.vue
+++ b/src/pages/components/balance/SendToAddress.vue
@@ -250,7 +250,7 @@
 <script>
 import { mapGetters, mapActions } from "vuex";
 import moment from "moment";
-import SendConfirm from "./SendConfirm";
+import SendConfirm from "~/pages/components/balance/SendConfirm";
 import tokenAvatar from "src/components/TokenAvatar";
 
 export default {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import routes from './routes'
+import routes from '~/router/routes'
 
 
 /*** TODO: remove if not being used */

--- a/src/store/account/actions.js
+++ b/src/store/account/actions.js
@@ -1,4 +1,4 @@
-import { vxm } from "../../store";
+import { vxm } from "~/store";
 import BigNumber from "bignumber.js";
 
 export const login = async function(

--- a/src/store/account/index.js
+++ b/src/store/account/index.js
@@ -1,7 +1,7 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import state from '~/store/account/state'
+import * as getters from '~/store/account/getters'
+import * as mutations from '~/store/account/mutations'
+import * as actions from '~/store/account/actions'
 
 export default {
   namespaced: true,

--- a/src/store/evm/index.js
+++ b/src/store/evm/index.js
@@ -1,7 +1,7 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import state from '~/store/evm/state'
+import * as getters from '~/store/evm/getters'
+import * as mutations from '~/store/evm/mutations'
+import * as actions from '~/store/evm/actions'
 
 export default {
   namespaced: true,

--- a/src/store/general/index.js
+++ b/src/store/general/index.js
@@ -1,7 +1,7 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import state from '~/store/general/state'
+import * as getters from '~/store/general/getters'
+import * as mutations from '~/store/general/mutations'
+import * as actions from '~/store/general/actions'
 
 export default {
   namespaced: true,

--- a/src/store/global/index.js
+++ b/src/store/global/index.js
@@ -1,7 +1,7 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import state from '~/store/global/state'
+import * as getters from '~/store/global/getters'
+import * as mutations from '~/store/global/mutations'
+import * as actions from '~/store/global/actions'
 
 export default {
   namespaced: true,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,17 +1,17 @@
 import { createStore } from 'vuex';
-import account from "./account";
-import general from "./general";
-import global from "./global";
-import resources from "./resources";
-import evm from "./evm";
-import rex from "./rex";
-import { GeneralModule } from "./modules/general";
-import { EosTransitModule } from "./modules/wallet/tlosWallet";
-import { TlosBancorModule } from "./modules/swap/tlosBancor";
-import { BancorModule } from "./modules/swap/index";
-import { WalletModule } from "./modules/wallet/index";
-import { NetworkModule } from "./modules/network/index";
-import { TlosNetworkModule } from "./modules/network/tlosNetwork";
+import account from "~/store/account";
+import general from "~/store/general";
+import global from "~/store/global";
+import resources from "~/store/resources";
+import evm from "~/store/evm";
+import rex from "~/store/rex";
+import { GeneralModule } from "~/store/modules/general";
+import { EosTransitModule } from "~/store/modules/wallet/tlosWallet";
+import { TlosBancorModule } from "~/store/modules/swap/tlosBancor";
+import { BancorModule } from "~/store/modules/swap/index";
+import { WalletModule } from "~/store/modules/wallet/index";
+import { NetworkModule } from "~/store/modules/network/index";
+import { TlosNetworkModule } from "~/store/modules/network/tlosNetwork";
 import { createProxy, extractVuexModule } from "vuex-class-component";
 
 

--- a/src/store/modules/network/index.js
+++ b/src/store/modules/network/index.js
@@ -1,7 +1,7 @@
 import { __awaiter, __decorate } from "tslib";
 import { createModule, action } from "vuex-class-component";
-import { vxm } from "../../../store";
-import { store } from "../../../store";
+import { vxm } from "~/store";
+import { store } from "~/store";
 const VuexModule = createModule({
     strict: false
 });

--- a/src/store/modules/network/tlosNetwork.js
+++ b/src/store/modules/network/tlosNetwork.js
@@ -5,12 +5,12 @@ import {
     getTokenBalances,
     compareString,
     compareToken
-} from "../../../api/helpers";
-import { vxm } from "../../../store";
+} from "~/api/helpers";
+import { vxm } from "~/store";
 import _ from "lodash";
-import { multiContract } from "../../../api/multiContractTx";
+import { multiContract } from "~/api/multiContractTx";
 import { Asset, asset_to_number, number_to_asset, Sym } from "eos-common";
-import { Chain } from "../../../store/modules/wallet/tlosWallet";
+import { Chain } from "~/store/modules/wallet/tlosWallet";
 const requiredProps = ["balance", "contract", "symbol"];
 const pickBalanceReturn = data => {
     const res = _.pick(data, requiredProps);

--- a/src/store/modules/swap/index.js
+++ b/src/store/modules/swap/index.js
@@ -1,10 +1,10 @@
 import { __awaiter, __decorate } from "tslib";
 import { createModule, action, mutation } from "vuex-class-component";
-import { vxm } from "../../../store";
-import { store } from "../../../store";
-import { compareString, updateArray } from "../../../api/helpers";
-import { fetchUsdPriceOfTlos } from "../../../api/helpers";
-import { defaultModule } from "../../../router";
+import { vxm } from "~/store";
+import { store } from "~/store";
+import { compareString, updateArray } from "~/api/helpers";
+import { fetchUsdPriceOfTlos } from "~/api/helpers";
+import { defaultModule } from "~/router";
 const VuexModule = createModule({
     strict: false
 });

--- a/src/store/modules/swap/tlosBancor.js
+++ b/src/store/modules/swap/tlosBancor.js
@@ -12,7 +12,7 @@ import {
     getBalance,
     getTokenMeta,
     updateArray
-} from "../../../api/helpers";
+} from "~/api/helpers";
 import {
     Asset,
     asset_to_number,
@@ -20,9 +20,9 @@ import {
     Sym as Symbol,
     Sym
 } from "eos-common";
-import { multiContract } from "../../../api/multiContractTx";
-import { vxm } from "../../../store";
-import { rpc } from "../../../api/rpc";
+import { multiContract } from "~/api/multiContractTx";
+import { vxm } from "~/store";
+import { rpc } from "~/api/rpc";
 import {
     calculateFundReturn,
     composeMemo,
@@ -30,11 +30,11 @@ import {
     findNewPath,
     findReturn,
     relaysToConvertPaths
-} from "../../../api/eosBancorCalc";
+} from "~/api/eosBancorCalc";
 import _ from "lodash";
-import { getHardCodedRelays } from "./staticRelays";
-import { sortByNetworkTokens } from "../../../api/sortByNetworkTokens";
-import { liquidateAction, hydrateAction } from "../../../api/singleContractTx";
+import { getHardCodedRelays } from "~/store/modules/swap/staticRelays";
+import { sortByNetworkTokens } from "~/api/sortByNetworkTokens";
+import { liquidateAction, hydrateAction } from "~/api/singleContractTx";
 const compareAgnosticToBalanceParam = (agnostic, balance) =>
     compareString(balance.contract, agnostic.contract) &&
     compareString(agnostic.symbol, balance.symbol);

--- a/src/store/modules/wallet/index.js
+++ b/src/store/modules/wallet/index.js
@@ -1,7 +1,7 @@
 import { __awaiter, __decorate } from "tslib";
 import { createModule, action } from "vuex-class-component";
-import { vxm } from "../../../store/index";
-import { store } from "../../../store";
+import { vxm } from "~/store/index";
+import { store } from "~/store";
 const VuexModule = createModule({
     strict: false
 });

--- a/src/store/modules/wallet/tlosWallet.js
+++ b/src/store/modules/wallet/tlosWallet.js
@@ -1,6 +1,6 @@
 import { __awaiter, __decorate } from "tslib";
 import { createModule, mutation, action } from "vuex-class-component";
-import { vxm } from "../../../store";
+import { vxm } from "~/store";
 export var Chain;
 (function (Chain) {
     Chain[(Chain["telos"] = 0)] = "telos";

--- a/src/store/resources/index.js
+++ b/src/store/resources/index.js
@@ -1,7 +1,7 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import state from '~/store/resources/state'
+import * as getters from '~/store/resources/getters'
+import * as mutations from '~/store/resources/mutations'
+import * as actions from '~/store/resources/actions'
 
 export default {
   namespaced: true,

--- a/src/store/rex/index.js
+++ b/src/store/rex/index.js
@@ -1,7 +1,7 @@
-import state from './state'
-import * as getters from './getters'
-import * as mutations from './mutations'
-import * as actions from './actions'
+import state from '~/store/rex/state'
+import * as getters from '~/store/rex/getters'
+import * as mutations from '~/store/rex/mutations'
+import * as actions from '~/store/rex/actions'
 
 export default {
   namespaced: true,


### PR DESCRIPTION
# Fixes #56 

## Description
The rule no-relative-import-paths was added and configured to restrict the import to only use absolute paths like this examples:
- `'~/store'`
- `'~/assets/telosLogo.svg'`
- `'src/components/TokenAvatar'`

A new configuration rule was needed to support the `'~/'` prefix as replacement for `'/src/'`
https://github.com/telosnetwork/telos-wallet/blob/56-linter-force-aliasprevent-relative-paths-on-imports/quasar.conf.js#L57-L64