### PR TITLE
Adding Cleos Auth & button to login as viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Main Net: [wallet.telos.net](https://wallet.telos.net) [![Netlify Status](https:
 
 Test Net: [wallet-dev.telos.net](https://wallet-dev.telos.net) [![Netlify Status](https://api.netlify.com/api/v1/badges/626e6746-848f-4b60-ba52-134e8f71fa39/deploy-status)](https://app.netlify.com/sites/wallet-testnet/deploys)
 
-Development : [staging](https://63963e7a7696c8548b664783--wallet-staging.netlify.app/) [![Netlify Status](https://api.netlify.com/api/v1/badges/b568365c-3e5e-4ebf-8c9b-5bc64c15de6e/deploy-status)](https://app.netlify.com/sites/wallet-staging/deploys)
+Development : [wallet-staging.netlify.app](https://wallet-staging.netlify.app/) [![Netlify Status](https://api.netlify.com/api/v1/badges/b568365c-3e5e-4ebf-8c9b-5bc64c15de6e/deploy-status)](https://app.netlify.com/sites/wallet-staging/deploys)
 
 ## Native Features
 - Account Creation

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@eosrio/hyperion-stream-client": "^0.4.0-beta.5",
     "@quasar/extras": "^1.0.0",
+    "@telosnetwork/ual-cleos": "1.13.1",
     "@telosnetwork/telosevm-js": "0.2.6",
     "axios": "^0.21.1",
     "babel-loader": "^8.1.0",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -108,7 +108,7 @@ module.exports = function(/* ctx */) {
       // directives: [],
 
       // Quasar plugins
-      plugins: ["Notify"]
+      plugins: ["Notify", "Dialog"]
     },
 
     // animations: 'all', // --- includes all animations

--- a/src/boot/api.js
+++ b/src/boot/api.js
@@ -34,7 +34,7 @@ const signTransaction = async function (actions, detail = null) {
 };
 
 const getRpc = function () {
-  return this.$type === "ual" ? this.$ualUser.rpc : this.$defaultApi.rpc;
+  return this.$defaultApi.rpc;
 };
 
 const getTableRows = async function (options) {

--- a/src/boot/ual.js
+++ b/src/boot/ual.js
@@ -2,6 +2,9 @@ import { boot } from 'quasar/wrappers';
 import { UAL } from "universal-authenticator-library";
 import { Anchor } from "ual-anchor";
 import { Wombat } from "ual-wombat";
+import { CleosAuthenticator } from '@telosnetwork/ual-cleos';
+import { Dialog, Notify, copyToClipboard } from 'quasar';
+
 
 export default boot(async ({ app, store }) => {
   const chain = {
@@ -15,9 +18,135 @@ export default boot(async ({ app, store }) => {
     ]
   };
 
+  async function loginHandler() {
+    let accountName = 'eosio';
+    let permission = 'active';
+    if (localStorage.getItem('autoLogin') === 'cleos') {
+      accountName = localStorage.getItem('account');
+    } else {
+      await new Promise((resolve) => {
+        Dialog.create({
+          class: 'cleos-auth-dialog',
+          color: 'primary',
+          title: store.state.account.justViewer ? 'Connect as viewer' : 'Connect to cleos',
+          message: 'Account name',
+          prompt: {
+            model: '',
+            type: 'text',
+          },
+          cancel: true,
+          persistent: true,
+        })
+        .onOk((data) => {
+            accountName = data !== '' ? data : 'eosio';
+        })
+        .onCancel(() => {
+            throw 'Cancelled!';
+        })
+        .onDismiss(() => {
+            resolve(true);
+        });
+      });
+      if (store.state.account.justViewer) {
+        permission = "active";
+      } else {
+        await new Promise((resolve) => {
+          Dialog.create({
+            class: 'cleos-auth-dialog',
+            color: 'primary',
+            title: 'Connect to cleos',
+            message: 'Account permission',
+            options: {
+              type: 'radio',
+              model: [],
+              items: [
+                { label: 'Active', value: 'active' },
+                { label: 'Owner', value: 'owner' },
+              ],
+            },
+            cancel: true,
+            persistent: true,
+          })
+          .onOk((data) => {
+              permission = data;
+          })
+          .onCancel(() => {
+              throw 'Cancelled!';
+          })
+          .onDismiss(() => {
+              resolve(true);
+          });
+        });
+      }
+    }
+    return {
+        accountName,
+        permission,
+    };
+  }
+
+  async function signHandler(trx) {
+    const trxJSON = JSON.stringify(
+      Object.assign(
+        {
+          delay_sec: 0,
+          max_cpu_usage_ms: 0,
+        },
+        trx
+      ),
+      null,
+      4
+    );
+    await new Promise((resolve) => {
+      Dialog.create({
+        class: 'cleos-auth-dialog',
+        color: 'primary',
+        message: `<pre>cleos -u https://${process.env.NETWORK_HOST} push transaction '${trxJSON}'</pre>`,
+        html: true,
+        cancel: true,
+        fullWidth: true,
+        ok: {
+          label: 'Copy',
+        },
+      })
+      .onOk(() => {
+        copyToClipboard(
+          `cleos -u https://${process.env.NETWORK_HOST} push transaction '${trxJSON}'`
+        )
+        .then(() => {
+          Notify.create({
+            color: 'green-4',
+            textColor: 'white',
+            message: 'Copied to clipboard',
+            timeout: 1000,
+          });
+        })
+        .catch(() => {
+          Notify.create({
+            color: 'red-8',
+            textColor: 'white',
+            message: 'Could not copy',
+            timeout: 1000,
+          });
+        });
+      })
+      .onCancel(() => {
+          throw 'Cancelled!';
+      })
+      .onDismiss(() => {
+          resolve(true);
+      });
+    });
+  }
+
   const authenticators = [
     new Wombat([chain], { appName: process.env.APP_NAME }),
-    new Anchor([chain], { appName: process.env.APP_NAME })
+    new Anchor([chain], { appName: process.env.APP_NAME }),
+    new CleosAuthenticator([chain], {
+        appName: process.env.APP_NAME,
+        loginHandler,
+        signHandler,
+    }),
   ];
 
   const ual = new UAL([chain], "ual", authenticators);

--- a/src/boot/ual.js
+++ b/src/boot/ual.js
@@ -28,7 +28,7 @@ export default boot(async ({ app, store }) => {
         Dialog.create({
           class: 'cleos-auth-dialog',
           color: 'primary',
-          title: store.state.account.justViewer ? 'Connect as viewer' : 'Connect to cleos',
+          title: store.state.account.justViewer ? 'Navigate as viewer' : 'Connect to cleos',
           message: 'Account name',
           prompt: {
             model: '',

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -12,6 +12,19 @@
         />
       </div>
 
+      <!-- View any account -->
+      <div class="q-mt-md">
+        <q-btn
+          @click="loginAsJustViewer()"
+          text-color="white"
+          no-caps
+          outline
+          rounded
+          label="View any account"
+          class=" q-pa-sm"
+        />
+      </div>
+
       <!-- Signup Button -->
       <div class="q-mt-md">
         <q-btn
@@ -192,11 +205,15 @@ export default {
       "getAccountProfile",
       "setLoadingWallet"
     ]),
+    async loginAsJustViewer() {
+      let idx = this.$ual.authenticators.map(a => a.getName()).indexOf('cleos');
+      this.onLogin(idx, true);
+    },
     async signUp() {
       this.openUrl("https://app.telos.net/accounts/add");
     },
-    async onLogin(idx) {
-        const error = await this.login({ idx });
+    async onLogin(idx, justViewer = false) {
+        const error = await this.login({ idx, justViewer });
         if (!error) {
           this.showLogin = false;
           await this.$router.push({ path: "/balance" });
@@ -296,6 +313,7 @@ export default {
     },
 
     async checkResources() {
+      if (!accountName) return;
       await this.getRamPrice();
       let account = await this.$store.$api.getAccount(this.accountName);
       this.ramAvail = account.ram_quota - account.ram_usage;
@@ -310,26 +328,13 @@ export default {
       this.resLow = this.ramLow || this.cpuLow || this.netLow;
     }
   },
-  async mounted() {
-    await this.autoLogin(this.$route.query.returnUrl);
-    if (this.isAuthenticated) {
-      await this.createEvmApi();
-      await this.checkResources();
-    }
-    this.authInterval = setInterval(() => {
-      if (this.$store.$account.needAuth) {
-        this.$store.$account.needAuth = false;
-        this.authType = "auth";
-        this.showAuth = true;
-      } else if (this.$store.$account.needConfirm) {
-        this.$store.$account.needConfirm = false;
-        this.authType = "confirm";
-        this.showAuth = true;
+  whatch: {
+    async isAuthenticated() {
+      if (this.isAuthenticated) {
+        await this.createEvmApi();
+        await this.checkResources();
       }
-    }, 500);
-  },
-  beforeUnmount() {
-    if (this.authInterval) clearInterval(this.authInterval);
+    }
   }
 };
 </script>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -18,6 +18,10 @@ body {
   color: $white;
 }
 
+div.cleos-auth-dialog {
+  color: $blackDark;
+}
+
 .main-div {
   background-color: #00000000;
   display: flex;

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -122,7 +122,7 @@ export default {
   methods: {
     ...mapActions("account", [
       "logout",
-      "autoLogin",
+      "memoryAutoLogin",
       "getUserProfile",
     ]),
     checkPath() {
@@ -181,7 +181,8 @@ export default {
     },
   },
   async mounted() {
-    await this.autoLogin(this.$route.query.returnUrl);
+    console.log("MainLayout.mounted()");
+    await this.memoryAutoLogin();// this.autoLogin(this.$route.query.returnUrl);
     this.loadUserProfile();
     this.checkPath();
   },

--- a/src/store/account/actions.js
+++ b/src/store/account/actions.js
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 
 export const login = async function(
   { commit, dispatch },
-  { idx, account, returnUrl }
+  { idx, account, returnUrl, justViewer }
 ) {
   const authenticator = this.$ual.authenticators[idx];
   try {
@@ -25,7 +25,7 @@ export const login = async function(
       this.$type = "ual";
       this.$idx = idx;
       commit("setAccountName", accountName);
-      localStorage.setItem("autoLogin", authenticator.constructor.name);
+      localStorage.setItem('autoLogin', authenticator.getName());
       localStorage.setItem("account", accountName);
       localStorage.setItem("returning", true);
       if (this.$router.currentRoute.path === "/") {
@@ -52,6 +52,20 @@ export const login = async function(
   }
 };
 
+export const memoryAutoLogin = async function ({
+  dispatch,
+  rootState,
+}) {
+  const account = localStorage.getItem('account');
+  if (account) {
+      if (!rootState.account.accountName) {
+          await dispatch('autoLogin', location.pathname);
+      }
+  } else {
+      return null;
+  }
+};
+
 export const autoLogin = async function({ dispatch, commit }, returnUrl) {
   const { authenticator, idx } = getAuthenticator(this.$ual);
   if (authenticator) {
@@ -69,7 +83,7 @@ export const autoLogin = async function({ dispatch, commit }, returnUrl) {
 const getAuthenticator = function(ual, wallet = null) {
   wallet = wallet || localStorage.getItem("autoLogin");
   const idx = ual.authenticators.findIndex(
-    auth => auth.constructor.name === wallet
+    auth => auth.getName() === wallet
   );
   return {
     authenticator: ual.authenticators[idx],
@@ -87,6 +101,7 @@ export const logout = async function({ commit }) {
   this.$account = {};
 
   localStorage.removeItem("autoLogin");
+  localStorage.removeItem("account");
 
   commit("setProfile", undefined);
   commit("setAccountName");
@@ -99,6 +114,7 @@ export const logout = async function({ commit }) {
 };
 
 export const getUserProfile = async function({ commit }, accountName) {
+  console.log("getUserProfile() accountName:", accountName);
   try {
     const profileResult = await this.$api.getTableRows({
       code: "profiles",

--- a/src/store/account/actions.js
+++ b/src/store/account/actions.js
@@ -17,6 +17,7 @@ export const login = async function(
         return;
       }
     }
+    commit("setJustViewer", justViewer);
     const users = await authenticator.login(account);
     if (users.length) {
       const account = users[0];

--- a/src/store/account/getters.js
+++ b/src/store/account/getters.js
@@ -4,6 +4,7 @@ export const evmAddress = ({ evmAddress }) => evmAddress;
 export const evmBalance = ({evmBalance}) => evmBalance;
 export const loading = ({ loading }) => loading;
 export const isAutoLoading = ({ autoLogin }) => autoLogin;
+export const isJustViewer = ({ justViewer }) => justViewer;
 export const hasProfile = ({ profiles, accountName }) => profiles.hasOwnProperty(accountName);
 export const myProfile = ({ profiles, accountName }) => profiles[accountName];
 export const profiles = ({ profiles }) => profiles;

--- a/src/store/account/mutations.js
+++ b/src/store/account/mutations.js
@@ -18,6 +18,10 @@ export const setAutoLogin = (state, status) => {
   state.autoLogin = status;
 };
 
+export const setJustViewer = (state, status) => {
+  state.justViewer = status;
+};
+
 export const setProfile = (state, profile = undefined) => {
   if (!profile) {
     return;

--- a/src/store/account/state.js
+++ b/src/store/account/state.js
@@ -1,5 +1,6 @@
 export default function() {
   return {
+    justViewer: false,
     accountName: null,
     evmAddress: null,
     evmBalance: null,


### PR DESCRIPTION
# Fixes #11

## Description
This issue requires a way to explore the web wallet without actual login with a wallet. The best (fast and easy) way to do that is by logging the user in using cleos under the hud. 

## Screenshots
![image](https://user-images.githubusercontent.com/4420760/207967720-1a35ab76-0337-4815-a5f4-6602193b14f2.png)


## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
