### PR TITLE
repairing the total balance calculation

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -111,7 +111,7 @@ export default {
         buy: "Buy",
         total: "Total",
         rate: "rate",
-        max: "Max",
+        max: "Max Available (liquid)",
         send: "Send",
         receive: "Receive",
         liquid: "Liquid",

--- a/src/store/account/actions.js
+++ b/src/store/account/actions.js
@@ -119,6 +119,7 @@ export const logout = async function({ commit }) {
 
 export const getAccountData = async function({ commit, dispatch }) {
   if (!this.state.account.accountName) {
+    commit("setData", undefined);
     return;
   }
 

--- a/src/store/account/actions.js
+++ b/src/store/account/actions.js
@@ -32,6 +32,7 @@ export const login = async function(
       if (this.$router.currentRoute.path === "/") {
         await this.$router.push({ path: "/balance" });
       }
+      dispatch("getAccountData");
       dispatch("getAccountProfile");
       vxm.tlosWallet.wallet = {
         auth: {
@@ -105,6 +106,7 @@ export const logout = async function({ commit }) {
   localStorage.removeItem("account");
 
   commit("setProfile", undefined);
+  commit("setData", undefined);
   commit("setAccountName");
   commit("setEvmAddress", null);
   commit("setEvmBalance", null)
@@ -112,6 +114,16 @@ export const logout = async function({ commit }) {
   if (this.$router.currentRoute.path !== "/") {
     this.$router.push({ path: "/" });
   }
+};
+
+
+export const getAccountData = async function({ commit, dispatch }) {
+  if (!this.state.account.accountName) {
+    return;
+  }
+
+  const data = await this.$api.getAccount(this.state.account.accountName);
+  commit("setData", data);
 };
 
 export const getUserProfile = async function({ commit }, accountName) {

--- a/src/store/account/getters.js
+++ b/src/store/account/getters.js
@@ -8,3 +8,4 @@ export const isJustViewer = ({ justViewer }) => justViewer;
 export const hasProfile = ({ profiles, accountName }) => profiles.hasOwnProperty(accountName);
 export const myProfile = ({ profiles, accountName }) => profiles[accountName];
 export const profiles = ({ profiles }) => profiles;
+export const data = ({ data }) => data;

--- a/src/store/account/mutations.js
+++ b/src/store/account/mutations.js
@@ -28,3 +28,7 @@ export const setProfile = (state, profile = undefined) => {
   }
   state.profiles[profile.account_name] = profile;
 };
+
+export const setData = (state, status) => {
+  state.data = status;
+};

--- a/src/store/account/state.js
+++ b/src/store/account/state.js
@@ -7,6 +7,7 @@ export default function() {
     hasProfile: false,
     profiles: {},
     autoLogin: false,
-    loading: {}
+    loading: {},
+    data: null
   };
 }

--- a/src/store/resources/actions.js
+++ b/src/store/resources/actions.js
@@ -19,7 +19,29 @@ export const getBalanceFromChain = async function({ commit }, payload) {
         }
       }
     } catch (error) {
-      commit("general/setErrorMsg", error.message || error, { root: true });
+      commit("general/setErrorMsg", error.message || error, { roo: rue });
       return `0 ${payload.sym}`;
     }
   };
+
+
+export const getTotalResources = async function({ commit }, payload) {
+  let result = 0;
+  // CPU self delegation
+  if (typeof this.state.account.data?.self_delegated_bandwidth?.cpu_weight == "string") {
+    result += parseFloat(this.state.account.data.self_delegated_bandwidth.cpu_weight.split(" ")[0]);
+  }
+  // NET self delegation
+  if (typeof this.state.account.data?.self_delegated_bandwidth?.net_weight == "string") {
+    result += parseFloat(this.state.account.data.self_delegated_bandwidth.net_weight.split(" ")[0]);
+  }
+  // CPU refunding
+  if (typeof this.state.account.data?.refund_request?.cpu_amount == "string") {
+    result += parseFloat(this.state.account.data.refund_request.cpu_amount.split(" ")[0]);
+  }
+  // NET refunding
+  if (typeof this.state.account.data?.refund_request?.net_amount == "string") {
+    result += parseFloat(this.state.account.data.refund_request.net_amount.split(" ")[0]);
+  }
+  return result;
+};

--- a/src/store/rex/actions.js
+++ b/src/store/rex/actions.js
@@ -1,7 +1,7 @@
 // Get pool info from chain by id, put into store
 export const getRexBalance = async function ({ commit, dispatch }, account) {
     try {
-        const rexbal = await this.$api.getTableRows({
+        const rexbalRows = await this.$api.getTableRows({
             code: "eosio", // Contract that we target
             scope: "eosio", // Account that owns the data
             table: "rexbal", // Table name
@@ -10,17 +10,51 @@ export const getRexBalance = async function ({ commit, dispatch }, account) {
             reverse: false, // Optional: Get reversed data
             show_payer: false, // Optional: Show ram payer
         });
-        // console.log(rexbal.rows[0]);
+        const rexbal = rexbalRows.rows[0];
 
-        // commit("setRexBalance", rexbal.rows[0]);
-        if (rexbal.rows[0]) {
-            return Number(rexbal.rows[0].vote_stake.split(" ")[0]);
+        const rexpoolRows = await this.$api.getTableRows({
+            code: 'eosio',
+            scope: 'eosio',
+            table: 'rexpool',
+            json: true,
+            reverse: false
+        });
+        const rexpool = rexpoolRows.rows[0];
+
+        const rexfundRows = await this.$api.getTableRows({
+            code: 'eosio',
+            scope: 'eosio',
+            table: 'rexfund',
+            limit: '1',
+            lower_bound: account, // Lower bound of data
+            upper_bound: account, // Upper bound of data
+            reverse: false,
+        });
+        const rexfund = rexfundRows.rows[0];
+
+        if (rexbal) {
+
+            const totalRex = Number(rexpool.total_rex.split(' ')[0]);
+            const totalLendable = Number(rexpool.total_lendable.split(' ')[0]);
+            const tlosRexRatio = totalRex > 0 ? totalLendable / totalRex : 1;
+            const rexBalance =
+                rexbal && rexbal.rex_balance
+                ? parseFloat(rexbal.rex_balance.split(' ')[0])
+                : 0;
+            const rexFundBalance =
+                rexfund && rexfund.balance
+                ? Number(rexfund.balance.split(' ')[0])
+                : 0.0;
+            let coreBalance = totalRex > 0 ? tlosRexRatio * rexBalance : 0.0;
+            coreBalance += rexFundBalance;
+
+            return coreBalance;
         } else {
             return 0;
         }
 
     } catch (error) {
-        console.error("getRexBalance");
+        console.error("getRexBalance", error);
         commit("general/setErrorMsg", error.message || error, { root: true });
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,6 +1708,16 @@
     stream "^0.0.2"
     text-encoding "^0.7.0"
 
+"@telosnetwork/ual-cleos@1.13.1":
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/@telosnetwork/ual-cleos/-/ual-cleos-1.13.1.tgz#2da6b6838d78ebaf3a802bdf7b089769208d1ca6"
+  integrity sha512-Hr7kDnoNYix6DibcTEBK/+/V1/kIT0rvWoOZU5iRa6wtkHU3/zXNIYoaAyblQovEeoGfZaLyFT7DSJ0OUSuiJg==
+  dependencies:
+    eosjs "^22.1.0"
+    text-encoding "^0.7.0"
+    typescript "^4.7.4"
+    universal-authenticator-library "0.3.0"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -9192,6 +9202,11 @@ typescript@4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+typescript@^4.7.4:
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 u2f-api@0.2.7:
   version "0.2.7"


### PR DESCRIPTION
# Fixes #94 

## Description
The calculation was fixed as described in issue #94. The display part was not implemented due to a previous discussion where we agreed to skip that part because it will be refactored anyway in the near future.

## Test scenarios
Let's call `myaccount` any account you control with the following balances:
- has some TLOS staking for NET and CPU
- some refunding TLOS (when you unstake)
- some TLOS staked in REX with unclaimed profits
- some liquid deposits (funds) in REX,
- some liquid in EVM,
- and finally some liquid TLOS. 

### test scenarios 1
- Log in using  `myaccount` in web-wallet
- explore the same account using OBE.
- The total balance should only differ in Liquid EVM amount

### test scenarios 2
- Log in using  `myaccount` in web-wallet
- Move any TLOS from any of the balances without losing ownership (do not transfer)
- Refresh the website
- The total balance should be the same as before the balance movement.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented on my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
