### PR TITLE
removing fuel when not supported

### DIFF
--- a/env.js
+++ b/env.js
@@ -12,7 +12,7 @@ const sharedEnv = {
 
 const TESTNET = {
   ...sharedEnv,
-  fuelrpc: null, // no Fuel support for Test-net yet
+  FUEL_RPC: "", // no Fuel support for Test-net yet
   APP_NAME: "Telos Web Wallet (testnet)",
   NETWORK_HOST: "testnet.telos.net",
   NETWORK_CHAIN_ID:
@@ -25,11 +25,7 @@ const TESTNET = {
 
 const MAINNET = {
   ...sharedEnv,
-  fuelrpc: {
-    protocol: "https",
-    host: "telos.greymass.com",
-    port: 443
-  },
+  FUEL_RPC: "telos.greymass.com",
   APP_NAME: "Telos Web Wallet",
   NETWORK_HOST: "mainnet.telos.net",
   NETWORK_CHAIN_ID:
@@ -43,3 +39,4 @@ const MAINNET = {
 const env = process.env.NETWORK === "mainnet" ? MAINNET : TESTNET;
 
 module.exports = env;
+console.log("----------------------------------");

--- a/env.js
+++ b/env.js
@@ -39,4 +39,3 @@ const MAINNET = {
 const env = process.env.NETWORK === "mainnet" ? MAINNET : TESTNET;
 
 module.exports = env;
-console.log("----------------------------------");

--- a/src/boot/errorHandling.js
+++ b/src/boot/errorHandling.js
@@ -4,7 +4,9 @@ import { boot } from 'quasar/wrappers';
 const errorNotification = function(error) {
   let errorStr;
   if (error !== undefined) {
-    if (error.startsWith("assertion failure with message:")) {
+    if (typeof error.startsWith !== "function") {
+      errorStr = error;
+    } else if (error.startsWith("assertion failure with message:")) {
       errorStr = error.split("assertion failure with message:")[1];
     } else {
       errorStr = error;


### PR DESCRIPTION
# Fixes #134

## Description
The fuel service is working as expected in the chains that are supported but are introducing problems in the not supported ones. This PR fixes the problem.

## Test scenarios
- Login to testnet
- open the browser inspector and enter tab Network
- modify filters, select: Fetch/XHR
- try to sign any transaction (send tokens, stake or unstake)
- You should not see a POST request like this: https://telos.greymass.com/v1/resource_provider/request_transaction
- You should be able to perform the signing as regularly (without fuel)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
