### PR TITLE
#221 | Wallet page header

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -88,6 +88,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract getRPCEndpoint(): RpcEndpoint;
     abstract getPriceData(): Promise<PriceChartData>;
     abstract getUsdPrice(): Promise<number>;
+    abstract getBuyMoreOfTokenLink(): string;
 
     // new methods
     abstract getWeiPrecision(): number;

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -81,4 +81,8 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     getTrustedContractsBucket(): string {
         return CONTRACTS_BUCKET;
     }
+
+    getBuyMoreOfTokenLink(): string {
+        return 'https://www.telos.net/#buy-tlos-simplex';
+    }
 }

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -81,4 +81,8 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     getTrustedContractsBucket(): string {
         return CONTRACTS_BUCKET;
     }
+
+    getBuyMoreOfTokenLink(): string {
+        return 'https://www.telos.net/#buy-tlos-simplex';
+    }
 }

--- a/src/antelope/index.ts
+++ b/src/antelope/index.ts
@@ -1,5 +1,6 @@
 import { App } from 'vue';
 import { Subject } from 'rxjs';
+import { Store } from 'pinia';
 
 import { AntelopeConfig } from 'src/antelope/config/';
 import installPinia from 'src/antelope/stores';
@@ -20,6 +21,13 @@ import { useHistoryStore } from 'src/antelope/stores/history';
 import { useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
 import { useEVMStore } from 'src/antelope/stores/evm';
+
+// provide typings for `this.$store`
+declare module '@vue/runtime-core' {
+    interface ComponentCustomProperties {
+        $store: Store;
+    }
+}
 
 const events = {
     onLoggedIn: new Subject<AccountModel>(),
@@ -73,7 +81,7 @@ export class Antelope {
             contract: useContractStore(),
             balances: useBalancesStore(),
             history: useHistoryStore(),
-            feedbacl: useFeedbackStore(),
+            feedback: useFeedbackStore(),
             platform: usePlatformStore(),
             evm: useEVMStore(),
         };

--- a/src/assets/icon--buy.svg
+++ b/src/assets/icon--buy.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M27 21H21V27H19V21H13V19H19V13H21V19H27V21Z" />
+<rect x="1" y="1" width="38" height="38" rx="19" stroke-width="2"/>
+</svg>

--- a/src/assets/icon--send.svg
+++ b/src/assets/icon--send.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.891 15.013L20.7195 17.8414L14.4121 24.1488L15.8121 25.5913L22.1407 19.2627L24.9621 22.084V15.013L17.891 15.013Z" />
+<rect x="1" y="1" width="38" height="38" rx="19" stroke-width="2"/>
+</svg>

--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -19,7 +19,7 @@ export default defineComponent({
     }),
     computed: {
         menuItemTabIndex() {
-            return this.menuIsOpen ? '0' : '-1';
+            return this.menuIsOpen || this.$q.screen.gt.md ? '0' : '-1';
         },
     },
     watch: {
@@ -68,7 +68,7 @@ export default defineComponent({
             icon="menu"
             color="black"
             aria-haspopup="menu"
-            :aria-label="$t('open_menu')"
+            :aria-label="$t('nav.open_menu')"
             :tabindex="menuIsOpen ? '-1' : '0'"
             @click="menuIsOpen = !menuIsOpen"
             @keydown.space.enter="menuIsOpen = !menuIsOpen"
@@ -103,7 +103,7 @@ export default defineComponent({
                 icon="menu_open"
                 class="q-ma-md self-start"
                 aria-haspopup="menu"
-                :aria-label="$t('close_menu')"
+                :aria-label="$t('nav.close_menu')"
                 :tabindex="menuItemTabIndex"
                 @click="menuIsOpen = !menuIsOpen"
                 @keydown.space.enter="menuIsOpen = !menuIsOpen"

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -101,6 +101,8 @@ export default defineComponent({
     &__header {
         color: var(--header-text-color);
         background: var(--header-bg-color);
+
+        padding-top: 24px;
     }
 
     &__header-content {
@@ -114,6 +116,7 @@ export default defineComponent({
     }
 
     &__tabs {
+        margin-top: 48px;
         flex-grow: 1;
         color: var(--header-text-color);
 

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -15,19 +15,24 @@ export default defineComponent({
             return Array.isArray(this.tabs);
         },
         selectedTab() {
-            return (this.$route.query.tab ?? this.tabs[0] ?? '') as string;
+            return (this.$route.query.tab ?? '') as string;
         },
     },
     watch: {
-        '$route.query.tab': {
+        $route: {
             immediate: true,
-            handler(newValue) {
-                if (this.tabs === null) {
-                    return;
-                }
+            deep: true,
+            handler(newValue, oldValue = null) {
+                const isSameRoute = oldValue === null || newValue?.path === oldValue?.path;
 
-                if (!this.tabs.includes(newValue)) {
-                    this.$router.replace({ query: { tab: this.tabs[0] as string } });
+                if (isSameRoute) {
+                    if (this.tabs === null) {
+                        return;
+                    }
+
+                    if (!this.tabs.includes(newValue.query.tab)) {
+                        this.$router.replace({ query: { tab: this.tabs[0] } });
+                    }
                 }
             },
         },
@@ -44,14 +49,14 @@ export default defineComponent({
 
         <q-tabs
             v-if="showTabs"
-            v-model="selectedTab"
+            :model-value="selectedTab"
             inline-label
             no-caps
             indicator-color="primary"
             class="c-app-page__tabs"
         >
             <q-route-tab
-                v-for="tab in tabs"
+                v-for="tab in (tabs ?? [])"
                 :key="tab"
                 :name="tab"
                 :label="tab.charAt(0).toUpperCase() + tab.slice(1)"

--- a/src/components/evm/BigFiatText.vue
+++ b/src/components/evm/BigFiatText.vue
@@ -45,6 +45,7 @@ export default defineComponent({
     line-height: 48px;
     font-weight: 600;
     font-size: 32px;
+    text-align: center;
 
     @media screen and (min-width: 360px) {
         font-size: 40px;

--- a/src/components/evm/BigFiatText.vue
+++ b/src/components/evm/BigFiatText.vue
@@ -1,0 +1,53 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'BigFiatText',
+    props: {
+        amount: {
+            type: Number,
+            required: true,
+        },
+    },
+    computed: {
+        // TODO use dynamic fiat to get symbol
+        // https://github.com/telosnetwork/telos-wallet/issues/215
+        symbol() {
+            return '$';
+        },
+        prettyAmount() {
+            let formatted = this.amount.toLocaleString('en-us');
+
+            if (formatted.indexOf('.') !== -1) {
+                const formattedInteger = formatted.split('.')[0];
+                const formattedFraction = this.amount.toFixed(2).split('.')[1];
+
+                formatted = `${formattedInteger}.${formattedFraction}`;
+
+            } else {
+                formatted = `${formatted}.00`;
+            }
+
+            return `${this.symbol} ${formatted}`;
+        },
+    },
+});
+</script>
+
+<template>
+<div class="c-big-fiat-text">
+    {{ prettyAmount }}
+</div>
+</template>
+
+<style lang="scss">
+.c-big-fiat-text {
+    line-height: 48px;
+    font-weight: 600;
+    font-size: 32px;
+
+    @media screen and (min-width: 360px) {
+        font-size: 40px;
+    }
+}
+</style>

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -47,6 +47,17 @@ export default {
         logout: 'Log Out',
         teloscan: 'Teloscan',
     },
+    evm_wallet: {
+        send_icon_alt: 'Send icon',
+        receive_icon_alt: 'Receive icon',
+        buy_icon_alt: 'Buy more tokens icon',
+        send: 'Send',
+        receive: 'Receive',
+        buy: 'Buy',
+        link_to_send_aria: 'Link to Send page',
+        link_to_receive_aria: 'Link to Receive page',
+        link_to_buy_aria: 'External link to buy tokens',
+    },
     global: {
         native: 'Native',
         telos_evm: 'Telos EVM',

--- a/src/pages/evm/wallet/ReceivePage.vue
+++ b/src/pages/evm/wallet/ReceivePage.vue
@@ -1,0 +1,21 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import AppPage from 'components/evm/AppPage.vue';
+
+export default defineComponent({
+    name: 'ReceivePage',
+    components: {
+        AppPage,
+    },
+});
+</script>
+
+<template>
+<AppPage>
+    <p class="text-black">Receive page</p>
+</AppPage>
+</template>
+
+<style lang="scss">
+
+</style>

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -1,0 +1,21 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import AppPage from 'components/evm/AppPage.vue';
+
+export default defineComponent({
+    name: 'SendPage',
+    components: {
+        AppPage,
+    },
+});
+</script>
+
+<template>
+<AppPage>
+    <p class="text-black">Send page</p>
+</AppPage>
+</template>
+
+<style lang="scss">
+
+</style>

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -1,10 +1,12 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import AppPage from 'components/evm/AppPage.vue';
+import WalletPageHeader from 'pages/evm/wallet/WalletPageHeader.vue';
 
 export default defineComponent({
     name: 'WalletPage',
     components: {
+        WalletPageHeader,
         AppPage,
     },
     data: () => ({
@@ -17,7 +19,7 @@ export default defineComponent({
 <template>
 <AppPage :tabs="tabs">
     <template v-slot:header>
-        <div class="c-wallet-page__TEMPORARY">wallet page header stuff</div>
+        <WalletPageHeader />
     </template>
 
     <template v-slot:balance>
@@ -32,12 +34,6 @@ export default defineComponent({
 
 <style lang="scss">
 .c-wallet-page {
-    // used to demonstrate header space - to be removed on page implementation
-    // replace with a component, something like <WalletPageHeader />
-    &__TEMPORARY {
-        height: 300px;
-        width: 100%;
-        text-align: center;
-    }
+
 }
 </style>

--- a/src/pages/evm/wallet/WalletPageHeader.vue
+++ b/src/pages/evm/wallet/WalletPageHeader.vue
@@ -25,6 +25,9 @@ export default defineComponent({
         },
     },
     methods: {
+        goToRoute(name: string) {
+            this.$router.push({ name });
+        },
         goToBuy() {
             window.open(this.buyMoreLink, '_blank')?.focus();
         },
@@ -42,8 +45,8 @@ export default defineComponent({
             tabindex="0"
             role="link"
             :aria-label="$t('evm_wallet.link_to_send_aria')"
-            @keydown.space.enter="$router.push({ name: 'evm-send' })"
-            @click="$router.push({ name: 'evm-send' })"
+            @keypress.space.enter="goToRoute('evm-send')"
+            @click="goToRoute('evm-send')"
         >
             <InlineSvg
                 :src="require('src/assets/icon--send.svg')"
@@ -61,8 +64,8 @@ export default defineComponent({
             tabindex="0"
             role="link"
             :aria-label="$t('evm_wallet.link_to_receive_aria')"
-            @keydown.space.enter="$router.push({ name: 'evm-receive' })"
-            @click="$router.push({ name: 'evm-receive' })"
+            @keypress.space.enter="goToRoute('evm-receive' )"
+            @click="goToRoute('evm-receive')"
         >
             <InlineSvg
                 :src="require('src/assets/icon--send.svg')"

--- a/src/pages/evm/wallet/WalletPageHeader.vue
+++ b/src/pages/evm/wallet/WalletPageHeader.vue
@@ -1,0 +1,152 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+import InlineSvg from 'vue-inline-svg';
+
+import BigFiatText from 'components/evm/BigFiatText.vue';
+import { useChainStore } from 'src/antelope';
+import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+
+export default defineComponent({
+    name: 'WalletPageHeader',
+    components: {
+        BigFiatText,
+        InlineSvg,
+    },
+    computed: {
+        // TODO return real balance
+        // https://github.com/telosnetwork/telos-wallet/issues/176
+        totalBalance() {
+            return 123456.78;
+        },
+        buyMoreLink() {
+            const chainStore = useChainStore();
+            return (chainStore.currentChain.settings as EVMChainSettings).getBuyMoreOfTokenLink();
+        },
+    },
+    methods: {
+        goToBuy() {
+            window.open(this.buyMoreLink, '_blank')?.focus();
+        },
+    },
+});
+</script>
+
+<template>
+<div>
+    <BigFiatText :amount="totalBalance" class="q-mb-xl"/>
+
+    <div class="c-wallet-page-header__links">
+        <div
+            class="c-wallet-page-header__link"
+            tabindex="0"
+            role="link"
+            :aria-label="$t('evm_wallet.link_to_send_aria')"
+            @keydown.space.enter="$router.push({ name: 'evm-send' })"
+            @click="$router.push({ name: 'evm-send' })"
+        >
+            <InlineSvg
+                :src="require('src/assets/icon--send.svg')"
+                aria-hidden="true"
+                :alt="$t('evm_wallet.send_icon_alt')"
+                class="c-wallet-page-header__icon"
+            />
+            <span class="c-wallet-page-header__link-text">
+                {{ $t('evm_wallet.send') }}
+            </span>
+        </div>
+
+        <div
+            class="c-wallet-page-header__link"
+            tabindex="0"
+            role="link"
+            :aria-label="$t('evm_wallet.link_to_receive_aria')"
+            @keydown.space.enter="$router.push({ name: 'evm-receive' })"
+            @click="$router.push({ name: 'evm-receive' })"
+        >
+            <InlineSvg
+                :src="require('src/assets/icon--send.svg')"
+                aria-hidden="true"
+                :alt="$t('evm_wallet.receive_icon_alt')"
+                class="c-wallet-page-header__icon c-wallet-page-header__icon--rotated"
+            />
+            <span class="c-wallet-page-header__link-text">
+                {{ $t('evm_wallet.receive') }}
+            </span>
+        </div>
+
+        <div
+            class="c-wallet-page-header__link"
+            tabindex="0"
+            role="link"
+            :aria-label="$t('evm_wallet.link_to_buy_aria')"
+            @keydown.space.enter="goToBuy"
+            @click="goToBuy"
+        >
+            <InlineSvg
+                :src="require('src/assets/icon--buy.svg')"
+                aria-hidden="true"
+                :alt="$t('evm_wallet.buy_icon_alt')"
+                class="c-wallet-page-header__icon"
+            />
+            <span class="c-wallet-page-header__link-text">
+                {{ $t('evm_wallet.buy') }}
+            </span>
+        </div>
+    </div>
+</div>
+</template>
+
+<style lang="scss">
+.c-wallet-page-header {
+    $this: &;
+
+    &__links {
+        display: flex;
+        gap: 48px;
+        justify-content: center;
+    }
+
+    &__link {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 8px;
+        width: max-content;
+        cursor: pointer;
+    }
+
+    &__icon {
+        transition: transform 0.2s ease;
+
+        &:not(#{$this}__icon--rotated):hover {
+            transform: scale(1.05);
+        }
+
+        // svg overrides
+        path {
+            fill: $primary;
+        }
+
+        rect {
+            stroke: $primary;
+        }
+
+        &--rotated {
+            transform: rotate(180deg);
+            &:hover {
+                transform: scale(1.05) rotate(180deg);
+            }
+        }
+    }
+
+    &__link-text {
+        text-align: center;
+        width: max-content;
+        font-weight: 500;
+        line-height: 24px;
+        font-size: 20px;
+    }
+}
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -29,7 +29,17 @@ const routes = [
             {
                 path: 'wallet',
                 name: 'evm-wallet',
-                component: () => import('pages/evm/WalletPage.vue'),
+                component: () => import('pages/evm/wallet/WalletPage.vue'),
+            },
+            {
+                path: 'send',
+                name: 'evm-send',
+                component: () => import('pages/evm/wallet/SendPage.vue'),
+            },
+            {
+                path: 'receive',
+                name: 'evm-receive',
+                component: () => import('pages/evm/wallet/ReceivePage.vue'),
             },
             {
                 path: 'staking',


### PR DESCRIPTION
# Fixes #172 
# Fixes #221 

## Description

This PR adds the UI for the wallet page header, as well as routing to send and receive. it adds a new evm chain setting so that other evm chains can set their 'buy more tokens' link in the future

note that I tested large values for the USD amounts (100 million) on small screens, and made sure the text fits without overflowing 

## Test scenarios
- go to https://deploy-preview-224--wallet-staging.netlify.app/
- sign into evm
    - on the wallet page, you should see a UI to match the designs
- click Send
    - you should be taken to a blank send page
- click Receive
    - you should be taken to a blank receive page
- click Buy
    - a new tab should open to the telos buy page

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
-   [x] I have added appropriate test coverage 
