### PR TITLE
#237 | Menu fixes

### DIFF
--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -23,7 +23,7 @@ export default defineComponent({
         },
     },
     watch: {
-        '$q.screen.lt.lg'(newValue, oldValue) {
+        '$q.screen.lt.md'(newValue, oldValue) {
             if (newValue !== oldValue) {
                 this.menuIsOpen = false;
             }
@@ -61,14 +61,14 @@ export default defineComponent({
         }"
     >
         <q-btn
-            v-if="$q.screen.lt.lg"
+            v-if="$q.screen.lt.md"
             flat
             round
             dense
             icon="menu"
             color="black"
             aria-haspopup="menu"
-            :aria-label="$t('open_menu')"
+            :aria-label="$t('nav.open_menu')"
             :tabindex="menuIsOpen ? '-1' : '0'"
             @click="menuIsOpen = !menuIsOpen"
             @keydown.space.enter="menuIsOpen = !menuIsOpen"
@@ -80,8 +80,8 @@ export default defineComponent({
     <div
         :class="{
             'c-app-nav__menu-container': true,
-            'c-app-nav__menu-container--open': menuIsOpen && $q.screen.lt.lg,
-            'c-app-nav__menu-container--desktop': $q.screen.gt.md,
+            'c-app-nav__menu-container--open': menuIsOpen && $q.screen.lt.md,
+            'c-app-nav__menu-container--desktop': $q.screen.gt.sm,
         }"
     >
         <div class="flex justify-between">
@@ -96,14 +96,14 @@ export default defineComponent({
                 @keydown.space.enter="goTo('home')"
             >
             <q-btn
-                v-if="$q.screen.lt.lg"
+                v-if="$q.screen.lt.md"
                 flat
                 round
                 dense
                 icon="menu_open"
                 class="q-ma-md self-start"
                 aria-haspopup="menu"
-                :aria-label="$t('close_menu')"
+                :aria-label="$t('nav.close_menu')"
                 :tabindex="menuItemTabIndex"
                 @click="menuIsOpen = !menuIsOpen"
                 @keydown.space.enter="menuIsOpen = !menuIsOpen"
@@ -234,7 +234,7 @@ export default defineComponent({
         background-color: var(--header-bg-color);
         z-index: 999;
 
-        @media only screen and (min-width: $breakpoint-lg-min) {
+        @media only screen and (min-width: $breakpoint-md-min) {
             left: 300px;
             justify-content: flex-end;
         }

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -108,7 +108,7 @@ export default defineComponent({
         justify-content: center;
         padding: 0 24px 24px;
 
-        @media only screen and (min-width: $breakpoint-lg-min) {
+        @media only screen and (min-width: $breakpoint-md-min) {
             padding: 0 32px 32px;
         }
     }
@@ -127,7 +127,7 @@ export default defineComponent({
     &__body {
         padding: 24px;
 
-        @media only screen and (min-width: $breakpoint-lg-min) {
+        @media only screen and (min-width: $breakpoint-md-min) {
             padding: 32px;
         }
     }

--- a/src/components/evm/UserInfo.vue
+++ b/src/components/evm/UserInfo.vue
@@ -75,7 +75,7 @@ export default defineComponent({
                 role="menuitem"
                 tabindex="0"
                 @click="gotoTeloscan()"
-                @keydown.space.enter="$router.push({ name: 'evm-staking' })"
+                @keypress.space.enter="$router.push({ name: 'evm-staking' })"
             >
                 <InlineSvg
                     :src="require('src/assets/icon--acorn.svg')"
@@ -96,7 +96,7 @@ export default defineComponent({
                 role="menuitem"
                 tabindex="1"
                 @click="logout"
-                @keydown.space.enter="logout"
+                @keypress.space.enter="logout"
             >
                 <InlineSvg
                     :src="require('src/assets/icon--logout.svg')"

--- a/src/layouts/EVMLayout.vue
+++ b/src/layouts/EVMLayout.vue
@@ -24,7 +24,7 @@ export default defineComponent({
     // offset content for fixed header
     margin-top: 64px;
 
-    @media only screen and (min-width: $breakpoint-lg-min) {
+    @media only screen and (min-width: $breakpoint-md-min) {
         // offset content for desktop menu
         margin-left: 300px;
         width: calc(100% - 300px);


### PR DESCRIPTION
# Fixes #237 

## Description
This PR fixes keyboard controls for the menu. it also updates the breakpoints on the site so that the mobile layout is used for small screens, rather than medium and small

## Test scenarios
- go to https://deploy-preview-238--wallet-testnet.netlify.app/
- sign in with metamask
- make your screen small so the mobile layout is used
- tab to the menu button and press space or enter
    - the menu should open
- tab through the menu items
    - tab focus should cycle to the top of the menu when you get to the end
- shift-tab through the menu items
    - focus should cycle to the bottom of the list
- focus the menu icon while the menu is open and press space or enter
    - menu should close

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
-   [x] I have added appropriate test coverage 
