### PR TITLE
removing temporal menu entries

### DIFF
--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -35,22 +35,6 @@ export default defineComponent({
         },
     },
     methods: {
-        // TODO: this is just for testing and should be removed after approval
-        notify(what: string) {
-            if (what === 'success') {
-                console.log('ant.config.notifySuccessfulTrxHandler()');
-                const chain_settings = ant.stores.chain.loggedEvmChain?.settings;
-                if(!chain_settings) {
-                    return;
-                }
-                ant.config.notifySuccessfulTrxHandler(
-                    `${chain_settings.getExplorerUrl()}/tx/0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef`,
-                );
-            } else if (what === 'error') {
-                ant.config.notifyFailedTrxHandler('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed sed lorem sed nisl.');
-            }
-        },
-        // -------------------------------
         openMenu() {
             this.menuIsOpen = true;
 
@@ -236,43 +220,6 @@ export default defineComponent({
                 />
                 {{ $t('global.sign_out') }}
             </li>
-
-            <!-- TODO: These two items are for testing purposes only. Remove them when done. -->
-            <li
-                class="c-app-nav__menu-item"
-                role="menuitem"
-                :tabindex="menuItemTabIndex"
-                @click="notify('success')"
-                @keypress.space.enter="notify('success')"
-            >
-                <InlineSvg
-                    :src="require('src/assets/icon--check.svg')"
-                    class="c-app-nav__icon"
-                    height="24"
-                    width="24"
-                    aria-hidden="true"
-                />
-                Notify Success !!
-            </li>
-
-            <li
-                class="c-app-nav__menu-item"
-                role="menuitem"
-                :tabindex="menuItemTabIndex"
-                @click="notify('error')"
-                @keypress.space.enter="notify('error')"
-            >
-                <InlineSvg
-                    :src="require('src/assets/icon--cross.svg')"
-                    class="c-app-nav__icon"
-                    height="24"
-                    width="24"
-                    aria-hidden="true"
-                />
-                Notify Failure :(
-            </li>
-            <!-- End of testing items -->
-
 
         </ul>
     </div>


### PR DESCRIPTION
# Fixes #264 

## Description
Removing temporary menu entries

## Test scenarios
- go to [this link](https://deploy-preview-265--wallet-staging.netlify.app/)
- login in EVM
- open the side menu
  - you should not see the two last temporary menu entries to show new notification modals

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
