### PR TITLE
Important tokens are shown even with zero balance

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -97,6 +97,11 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract getWeiPrecision(): number;
     abstract getExplorerUrl(): string;
     abstract getTrustedContractsBucket(): string;
+    abstract getImportantTokensIdList(): string[];
+
+    constructTokenId(token: EvmToken): string {
+        return `${token.symbol}-${token.address}-${this.getChainId()}`;
+    }
 
     getContract(address: string): EvmContract | false | null {
         const key = address.toLowerCase();

--- a/src/antelope/chains/NativeChainSettings.ts
+++ b/src/antelope/chains/NativeChainSettings.ts
@@ -123,8 +123,16 @@ export default abstract class NativeChainSettings implements ChainSettings {
     abstract getTheme(): Theme;
     abstract getFiltersSupported(prop: string): boolean;
 
-    // new methods
+    /**
+     * Retrieves the list of IDs for the important tokens.
+     * These tokens will be displayed even when their balance is zero and will be considered system-basic tokens for the chain.
+     *
+     * @returns An array of strings representing the IDs of the important tokens.
+     * Each ID follows the format: <symbol>-<contract>-<chainId>.
+     */
     abstract getImportantTokensIdList(): string[];
+
+
 
     constructTokenId(token: NativeToken): string {
         return `${token.symbol}-${token.contract}-${this.getNetwork()}`;

--- a/src/antelope/chains/NativeChainSettings.ts
+++ b/src/antelope/chains/NativeChainSettings.ts
@@ -123,6 +123,13 @@ export default abstract class NativeChainSettings implements ChainSettings {
     abstract getTheme(): Theme;
     abstract getFiltersSupported(prop: string): boolean;
 
+    // new methods
+    abstract getImportantTokensIdList(): string[];
+
+    constructTokenId(token: NativeToken): string {
+        return `${token.symbol}-${token.contract}-${this.getNetwork()}`;
+    }
+
     async getApy(): Promise<string> {
         const response = await this.api.get('apy/native');
         return response.data as string;

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -88,7 +88,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     getStlosContractAddress() {
-        return '0xa9991e4daa44922d00a78b6d986cdf628d46c4dd';
+        return '0xa9991E4daA44922D00a78B6D986cDf628d46C4DD';
     }
 
     getWtlosContractAddress() {

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -56,7 +56,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     getSystemToken(): EvmToken {
-        return TOKEN;
+        return { ...TOKEN, tokenId: this.constructTokenId(TOKEN) } as EvmToken;
     }
 
     getUsdPrice(): Promise<number> {
@@ -93,5 +93,13 @@ export default class TelosEVMTestnet extends EVMChainSettings {
 
     getWtlosContractAddress() {
         return '0xaE85Bf723A9e74d6c663dd226996AC1b8d075AA9';
+    }
+
+    getImportantTokensIdList(): string[] {
+        return [
+            this.constructTokenId(TOKEN),
+            this.constructTokenId({ symbol: 'STLOS', address: this.getStlosContractAddress() } as EvmToken),
+            this.constructTokenId({ symbol: 'WTLOS', address: this.getWtlosContractAddress() } as EvmToken),
+        ];
     }
 }

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -56,7 +56,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     getSystemToken(): EvmToken {
-        return TOKEN;
+        return { ...TOKEN, tokenId: this.constructTokenId(TOKEN) } as EvmToken;
     }
 
     getUsdPrice(): Promise<number> {
@@ -93,5 +93,13 @@ export default class TelosEVMTestnet extends EVMChainSettings {
 
     getWtlosContractAddress() {
         return '0xD102cE6A4dB07D247fcc28F366A623Df0938CA9E';
+    }
+
+    getImportantTokensIdList(): string[] {
+        return [
+            this.constructTokenId(TOKEN),
+            this.constructTokenId({ symbol: 'STLOS', address: this.getStlosContractAddress() } as EvmToken),
+            this.constructTokenId({ symbol: 'WTLOS', address: this.getWtlosContractAddress() } as EvmToken),
+        ];
     }
 }

--- a/src/antelope/chains/native/eos/index.ts
+++ b/src/antelope/chains/native/eos/index.ts
@@ -98,4 +98,8 @@ export default class EOS extends NativeChainSettings {
         }
         return true;
     }
+
+    getImportantTokensIdList(): string[] {
+        return [this.constructTokenId(TOKEN)];
+    }
 }

--- a/src/antelope/chains/native/jungle/index.ts
+++ b/src/antelope/chains/native/jungle/index.ts
@@ -93,4 +93,8 @@ export default class TelosTestnet extends NativeChainSettings {
         }
         return true;
     }
+
+    getImportantTokensIdList(): string[] {
+        return [this.constructTokenId(TOKEN)];
+    }
 }

--- a/src/antelope/chains/native/telos-testnet/index.ts
+++ b/src/antelope/chains/native/telos-testnet/index.ts
@@ -112,4 +112,8 @@ export default class TelosTestnet extends NativeChainSettings {
         }
         return true;
     }
+
+    getImportantTokensIdList(): string[] {
+        return [this.constructTokenId(TOKEN)];
+    }
 }

--- a/src/antelope/chains/native/telos/index.ts
+++ b/src/antelope/chains/native/telos/index.ts
@@ -119,4 +119,8 @@ export default class Telos extends NativeChainSettings {
         }
         return true;
     }
+
+    getImportantTokensIdList(): string[] {
+        return [this.constructTokenId(TOKEN)];
+    }
 }

--- a/src/antelope/chains/native/ux/index.ts
+++ b/src/antelope/chains/native/ux/index.ts
@@ -93,4 +93,8 @@ export default class UX extends NativeChainSettings {
         }
         return true;
     }
+
+    getImportantTokensIdList(): string[] {
+        return [this.constructTokenId(TOKEN)];
+    }
 }

--- a/src/antelope/chains/native/wax/index.ts
+++ b/src/antelope/chains/native/wax/index.ts
@@ -93,4 +93,8 @@ export default class EOS extends NativeChainSettings {
         }
         return true;
     }
+
+    getImportantTokensIdList(): string[] {
+        return [this.constructTokenId(TOKEN)];
+    }
 }

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -97,7 +97,7 @@ export const useBalancesStore = defineStore(store_name, {
                         this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
                         const evm = useEVMStore();
 
-                        if(localStorage.getItem('wagmi.connected')){
+                        if (localStorage.getItem('wagmi.connected')) {
                             tokens.map(async (token) => {
                                 const balanceBn = await fetchBalance({
                                     address: getAccount().address as addressString,
@@ -117,7 +117,7 @@ export const useBalancesStore = defineStore(store_name, {
 
                             useFeedbackStore().unsetLoading('updateBalancesForAccount');
                             this.trace('updateBalancesForAccount', 'balances:', toRaw(this.__balances[label]));
-                        }else{
+                        } else {
 
                             const promises = tokens.map(token => evm.getContract(token.address)
                                 .then((contract) => {
@@ -161,13 +161,13 @@ export const useBalancesStore = defineStore(store_name, {
             if (provider) {
                 const balanceBn = await provider.getBalance(address);
                 token = await this.setToken(label, balanceBn);
-            } else if (localStorage.getItem('wagmi.connected')){
+            } else if (localStorage.getItem('wagmi.connected')) {
                 const balanceBn = await fetchBalance({
                     address: getAccount().address as addressString,
                     chainId: getNetwork().chain?.id,
                 });
                 token = await this.setToken(label, balanceBn.value);
-            }else{
+            } else {
                 console.error('No provider');
             }
             return token;
@@ -258,9 +258,9 @@ export const useBalancesStore = defineStore(store_name, {
             try {
                 useFeedbackStore().setLoading('transferEVMTokens');
 
-                if(localStorage.getItem('wagmi.connected')){
+                if (localStorage.getItem('wagmi.connected')) {
                     return await this.transferWalletConnect(token, to, amount);
-                }else{
+                } else {
                     return await this.transferMetaMask(token, to, amount);
                 }
             } catch (error) {
@@ -272,7 +272,7 @@ export const useBalancesStore = defineStore(store_name, {
         },
 
         async transferWalletConnect(token: EvmToken, to: string, amount: BigNumber): Promise<SendTransactionResult>{
-            if(token.isSystem){
+            if (token.isSystem) {
 
                 const config = await prepareSendTransaction({
                     request: {
@@ -282,7 +282,7 @@ export const useBalancesStore = defineStore(store_name, {
                 });
 
                 return await sendTransaction(config);
-            }else{
+            } else {
 
                 const config = await prepareWriteContract({
                     address: token.address as addressString,

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -95,7 +95,6 @@ export const useBalancesStore = defineStore(store_name, {
                         const tokens = await chain_settings.getTokenList();
                         this.updateSystemBalanceForAccount(label, account.account);
                         this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
-<<<<<<< HEAD
                         const evm = useEVMStore();
                         let promises: Promise<void>[] = [];
 
@@ -125,19 +124,6 @@ export const useBalancesStore = defineStore(store_name, {
                                         } catch (e) {
                                             console.error(e);
                                         }
-=======
-                        const promises = tokens.map(token => evm.getContract(token.address)
-                            .then((contract) => {
-                                if (contract) {
-                                    try {
-                                        const contractInstance = contract.getContractInstance();
-                                        const address = account.account;
-                                        return contractInstance.balanceOf(address).then((balanceBn: BigNumber) => {
-                                            this.proccessBalanceForToken(label, token, balanceBn);
-                                        });
-                                    } catch (e) {
-                                        console.error(e);
->>>>>>> 027124c (refactoring balances store)
                                     }
                                 }),
                             );
@@ -153,7 +139,6 @@ export const useBalancesStore = defineStore(store_name, {
                 console.error('Error: ', errorToString(error));
             }
         },
-<<<<<<< HEAD
 
         async updateSystemBalanceForAccount(label: string, address: string): Promise<void> {
             const evm = useEVMStore();
@@ -173,19 +158,6 @@ export const useBalancesStore = defineStore(store_name, {
                 this.processBalanceForToken(label, token, balanceBn.value);
             } else {
                 console.error('No provider');
-=======
-        proccessBalanceForToken(label: string, token: EvmToken, balanceBn: BigNumber): void {
-            token.balanceBn = balanceBn;
-            token.balance = `${formatWei(balanceBn, token.decimals, 4)}`;
-            token.fullBalance = `${formatWei(balanceBn, token.decimals, token.decimals)}`;
-            if (token.price > 0) {
-                token.fiatBalance = `${parseFloat(token.balance) * token.price}`;
-            }
-            if (this.shouldAddTokenBalance(label, balanceBn, token)) {
-                this.addNewBalance(label, token);
-            } else {
-                this.removeBalance(label, token);
->>>>>>> 027124c (refactoring balances store)
             }
         },
         shouldAddTokenBalance(label: string, balanceBn: BigNumber, token: Token): boolean {
@@ -197,7 +169,6 @@ export const useBalancesStore = defineStore(store_name, {
                 return !balanceBn.isNegative() && !balanceBn.isZero();
             }
         },
-<<<<<<< HEAD
         processBalanceForToken(label: string, token: EvmToken, balanceBn: BigNumber): void {
             token.balanceBn = balanceBn;
             token.balance = `${formatWei(balanceBn, token.decimals, 4)}`;
@@ -209,22 +180,6 @@ export const useBalancesStore = defineStore(store_name, {
                 this.addNewBalance(label, token);
             } else {
                 this.removeBalance(label, token);
-=======
-        async updateSystemBalanceForAccount(label: string, address: string): Promise<EvmToken> {
-            const evm = useEVMStore();
-            const chain_settings = useChainStore().getChain(label).settings as EVMChainSettings;
-            const provider = toRaw(evm.rpcProvider);
-            const token = chain_settings.getSystemToken();
-            if (provider) {
-                const [balanceBn, price] = await Promise.all([
-                    provider.getBalance(address),
-                    chain_settings.getUsdPrice(),
-                ]);
-                token.price = price;
-                this.proccessBalanceForToken(label, token, balanceBn);
-            } else {
-                console.error('No provider');
->>>>>>> 027124c (refactoring balances store)
             }
         },
         async transferTokens(token: Token, to: string, amount: BigNumber, memo?: string): Promise<TransactionResponse> {

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -160,6 +160,15 @@ export const useBalancesStore = defineStore(store_name, {
                 console.error('No provider');
             }
         },
+        shouldAddTokenBalance(label: string, balanceBn: BigNumber, token: Token): boolean {
+            const importantTokens = useChainStore().getChain(label).settings.getImportantTokensIdList();
+            if (importantTokens.includes(token.tokenId)) {
+                // if the token is important, we always add it. Even with 0 balance.
+                return true;
+            } else {
+                return !balanceBn.isNegative() && !balanceBn.isZero();
+            }
+        },
         processBalanceForToken(label: string, token: EvmToken, balanceBn: BigNumber): void {
             token.balanceBn = balanceBn;
             token.balance = `${formatWei(balanceBn, token.decimals, 4)}`;
@@ -167,7 +176,7 @@ export const useBalancesStore = defineStore(store_name, {
             if (token.price > 0) {
                 token.fiatBalance = `${parseFloat(token.balance) * token.price}`;
             }
-            if (!token.balanceBn.isNegative() && !token.balanceBn.isZero()) {
+            if (this.shouldAddTokenBalance(label, balanceBn, token)) {
                 this.addNewBalance(label, token);
             } else {
                 this.removeBalance(label, token);
@@ -337,16 +346,24 @@ export const useBalancesStore = defineStore(store_name, {
             this.trace('updateBalance', label, token);
             const index = this.__balances[label].findIndex(b => b.tokenId === token.tokenId);
             if (index >= 0) {
-                this.__balances[label][index] = {
-                    ...this.__balances[label][index],
-                    balance: token.balance,
-                    fullBalance: token.fullBalance,
-                    price: token.price,
-                    fiatBalance: token.fiatBalance,
-                } as Token;
-                this.sortBalances(label);
-                if (useAccountStore().currentIsLogged && label === 'current') {
-                    this.__balances['logged'] = this.__balances[label];
+                if (
+                    token.balance !== this.__balances[label][index].balance ||
+                    token.fullBalance !== this.__balances[label][index].fullBalance ||
+                    token.price !== this.__balances[label][index].price ||
+                    token.fiatBalance !== this.__balances[label][index].fiatBalance
+                ) {
+                    console.error('updateBalance', token.balance, token.fullBalance, token.price,  token.fiatBalance, '-------------------------');
+                    this.__balances[label][index] = {
+                        ...this.__balances[label][index],
+                        balance: token.balance,
+                        fullBalance: token.fullBalance,
+                        price: token.price,
+                        fiatBalance: token.fiatBalance,
+                    } as Token;
+                    this.sortBalances(label);
+                    if (useAccountStore().currentIsLogged && label === 'current') {
+                        this.__balances['logged'] = this.__balances[label];
+                    }
                 }
             }
         },

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -95,6 +95,7 @@ export const useBalancesStore = defineStore(store_name, {
                         const tokens = await chain_settings.getTokenList();
                         this.updateSystemBalanceForAccount(label, account.account);
                         this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
+<<<<<<< HEAD
                         const evm = useEVMStore();
                         let promises: Promise<void>[] = [];
 
@@ -124,6 +125,19 @@ export const useBalancesStore = defineStore(store_name, {
                                         } catch (e) {
                                             console.error(e);
                                         }
+=======
+                        const promises = tokens.map(token => evm.getContract(token.address)
+                            .then((contract) => {
+                                if (contract) {
+                                    try {
+                                        const contractInstance = contract.getContractInstance();
+                                        const address = account.account;
+                                        return contractInstance.balanceOf(address).then((balanceBn: BigNumber) => {
+                                            this.proccessBalanceForToken(label, token, balanceBn);
+                                        });
+                                    } catch (e) {
+                                        console.error(e);
+>>>>>>> 027124c (refactoring balances store)
                                     }
                                 }),
                             );
@@ -139,6 +153,7 @@ export const useBalancesStore = defineStore(store_name, {
                 console.error('Error: ', errorToString(error));
             }
         },
+<<<<<<< HEAD
 
         async updateSystemBalanceForAccount(label: string, address: string): Promise<void> {
             const evm = useEVMStore();
@@ -158,6 +173,19 @@ export const useBalancesStore = defineStore(store_name, {
                 this.processBalanceForToken(label, token, balanceBn.value);
             } else {
                 console.error('No provider');
+=======
+        proccessBalanceForToken(label: string, token: EvmToken, balanceBn: BigNumber): void {
+            token.balanceBn = balanceBn;
+            token.balance = `${formatWei(balanceBn, token.decimals, 4)}`;
+            token.fullBalance = `${formatWei(balanceBn, token.decimals, token.decimals)}`;
+            if (token.price > 0) {
+                token.fiatBalance = `${parseFloat(token.balance) * token.price}`;
+            }
+            if (this.shouldAddTokenBalance(label, balanceBn, token)) {
+                this.addNewBalance(label, token);
+            } else {
+                this.removeBalance(label, token);
+>>>>>>> 027124c (refactoring balances store)
             }
         },
         shouldAddTokenBalance(label: string, balanceBn: BigNumber, token: Token): boolean {
@@ -169,6 +197,7 @@ export const useBalancesStore = defineStore(store_name, {
                 return !balanceBn.isNegative() && !balanceBn.isZero();
             }
         },
+<<<<<<< HEAD
         processBalanceForToken(label: string, token: EvmToken, balanceBn: BigNumber): void {
             token.balanceBn = balanceBn;
             token.balance = `${formatWei(balanceBn, token.decimals, 4)}`;
@@ -180,6 +209,22 @@ export const useBalancesStore = defineStore(store_name, {
                 this.addNewBalance(label, token);
             } else {
                 this.removeBalance(label, token);
+=======
+        async updateSystemBalanceForAccount(label: string, address: string): Promise<EvmToken> {
+            const evm = useEVMStore();
+            const chain_settings = useChainStore().getChain(label).settings as EVMChainSettings;
+            const provider = toRaw(evm.rpcProvider);
+            const token = chain_settings.getSystemToken();
+            if (provider) {
+                const [balanceBn, price] = await Promise.all([
+                    provider.getBalance(address),
+                    chain_settings.getUsdPrice(),
+                ]);
+                token.price = price;
+                this.proccessBalanceForToken(label, token, balanceBn);
+            } else {
+                console.error('No provider');
+>>>>>>> 027124c (refactoring balances store)
             }
         },
         async transferTokens(token: Token, to: string, amount: BigNumber, memo?: string): Promise<TransactionResponse> {

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -261,7 +261,7 @@ export const useBalancesStore = defineStore(store_name, {
                 if(localStorage.getItem('wagmi.connected')){
                     return await this.transferWalletConnect(token, to, amount);
                 }else{
-                    return await this.transferToken(token, to, amount);
+                    return await this.transferMetaMask(token, to, amount);
                 }
             } catch (error) {
                 console.error('Error: ', errorToString(error));
@@ -295,7 +295,7 @@ export const useBalancesStore = defineStore(store_name, {
             }
         },
 
-        async transferToken(token: EvmToken, to: string, amount: BigNumber): Promise<EvmTransactionResponse> {
+        async transferMetaMask(token: EvmToken, to: string, amount: BigNumber): Promise<EvmTransactionResponse> {
             const evm = useEVMStore();
 
             if (token.isSystem) {

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -352,7 +352,6 @@ export const useBalancesStore = defineStore(store_name, {
                     token.price !== this.__balances[label][index].price ||
                     token.fiatBalance !== this.__balances[label][index].fiatBalance
                 ) {
-                    console.error('updateBalance', token.balance, token.fullBalance, token.price,  token.fiatBalance, '-------------------------');
                     this.__balances[label][index] = {
                         ...this.__balances[label][index],
                         balance: token.balance,

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -392,6 +392,7 @@ export const useEVMStore = defineStore(store_name, {
                 }
             }
 
+
             // We mark this address as not existing so we don't query it again
             chain_settings.setContractAsNotExisting(addressLower);
 

--- a/src/antelope/types/ChainSettings.ts
+++ b/src/antelope/types/ChainSettings.ts
@@ -13,4 +13,5 @@ export interface ChainSettings {
     getRPCEndpoint(): RpcEndpoint;
     getPriceData(): Promise<PriceChartData>;
     getUsdPrice(): Promise<number>;
+    getImportantTokensIdList(): string[];
 }

--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -104,3 +104,4 @@ $anim-slide-in-left: slide-in-left 0.3s cubic-bezier(0,1.02,1,.99) both
         -webkit-transform: translateX(0)
         transform: translateX(0)
         opacity: 1
+

--- a/src/pages/evm/wallet/ReceivePage.vue
+++ b/src/pages/evm/wallet/ReceivePage.vue
@@ -17,7 +17,7 @@ export default defineComponent({
         AddressQR,
         UserInfo,
     },
-    mounted() {
+    async mounted() {
         global.setShowBackBtn(true);
     },
     methods: {

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -81,20 +81,10 @@ export default defineComponent({
         opacity: 1;
         text-align: center;
         margin-top: 20px;
-        // animation: fade-in 0.4s linear forwards 0.8s;
         transition: opacity 0.4s linear 0.8s;
         &--hide {
             opacity: 0;
         }
-    }
-}
-
-@keyframes fade-in {
-    0% {
-        opacity: 0;
-    }
-    100% {
-        opacity: 1;
     }
 }
 </style>

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -51,7 +51,12 @@ export default defineComponent({
                 class="q-mb-xs"
             />
         </div>
-        <div v-if="loading" class="c-wallet-page--loading">
+        <div
+            :class="{
+                'c-wallet-page__loading': true,
+                'c-wallet-page__loading--hide': !loading
+            }"
+        >
             <q-spinner-dots
                 color="primary"
                 size="2em"
@@ -72,9 +77,24 @@ export default defineComponent({
 }
 
 .c-wallet-page {
-    &--loading {
+    &__loading {
+        opacity: 1;
         text-align: center;
         margin-top: 20px;
+        // animation: fade-in 0.4s linear forwards 0.8s;
+        transition: opacity 0.4s linear 0.8s;
+        &--hide {
+            opacity: 0;
+        }
+    }
+}
+
+@keyframes fade-in {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
     }
 }
 </style>

--- a/src/pages/home/NativeLoginButton.vue
+++ b/src/pages/home/NativeLoginButton.vue
@@ -94,7 +94,7 @@ export default defineComponent({
             try {
                 await this.setEvmState();
             } catch (e) {
-                console.log(e);
+                console.error(e);
             }
         },
 

--- a/test/jest/__tests__/antelope/stores/balances.spec.ts
+++ b/test/jest/__tests__/antelope/stores/balances.spec.ts
@@ -54,6 +54,7 @@ jest.mock('src/antelope/stores/chain', () => ({
                 getTokenList: jest.fn().mockImplementation(() => tokenList),
                 getSystemToken: jest.fn().mockImplementation(() => tokenSys),
                 getUsdPrice: jest.fn().mockImplementation(() => 1),
+                getImportantTokensIdList: jest.fn().mockImplementation(() => []),
             },
         })),
         loggedChain: {


### PR DESCRIPTION
# Fixes #288

## Description
This PR fixes the problem of not showing anything when the explored address does not have any positive balance on any known token. This PR introduces the concept of "important tokens" which is a list of token IDs to be shown even when the balance is zero.

This PR also tries to fix an annoying behavior with the loading spinner showing itself for fractions of seconds when the balances get updated. With some styling, it delays a fade in and out animation which has the effect of hiding the spinner on quick updates.

## Test scenarios
- go to [this link](https://deploy-preview-291--wallet-staging.netlify.app/)
- login into EVM with a brand new address (or zero balance on all token)
- you should see at least three listed tokens: TLOS, STLOS & WTLOS
- if you stay watching for several (more than 10) seconds you should not notice the balances and prices actually got updated.


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
