### PR TITLE
289 bug once you logged with one address on evm you cant log in using another address

### DIFF
--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -48,6 +48,7 @@ import { toRaw } from 'vue';
 import { getAccount } from '@wagmi/core';
 import { usePlatformStore } from 'src/antelope/stores/platform';
 import { useAccountStore } from 'src/antelope/stores/account';
+import { useBalancesStore } from 'src/antelope/stores/balances';
 
 const onEvmReady = new BehaviorSubject<boolean>(false);
 
@@ -103,9 +104,10 @@ export const useEVMStore = defineStore(store_name, {
                     provider.on('chainChanged', (newNetwork) => {
                         evm.trace('provider.chainChanged', newNetwork);
                     });
-                    provider.on('accountsChanged', (accounts) => {
+                    provider.on('accountsChanged', async (accounts) => {
                         const network = useChainStore().currentChain.settings.getNetwork();
-                        useAccountStore().loginEVM({ network });
+                        await useAccountStore().loginEVM({ network });
+                        useBalancesStore().updateBalancesForAccount('logged', useAccountStore().loggedAccount);
                         evm.trace('provider.accountsChanged', accounts);
                     });
                 }

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -47,6 +47,7 @@ import {
 import { toRaw } from 'vue';
 import { getAccount } from '@wagmi/core';
 import { usePlatformStore } from 'src/antelope/stores/platform';
+import { useAccountStore } from 'src/antelope/stores/account';
 
 const onEvmReady = new BehaviorSubject<boolean>(false);
 
@@ -103,6 +104,8 @@ export const useEVMStore = defineStore(store_name, {
                         evm.trace('provider.chainChanged', newNetwork);
                     });
                     provider.on('accountsChanged', (accounts) => {
+                        const network = useChainStore().currentChain.settings.getNetwork();
+                        useAccountStore().loginEVM({ network });
                         evm.trace('provider.accountsChanged', accounts);
                     });
                 }


### PR DESCRIPTION
# Fixes #289 

## Description
 see issue

## Test scenarios

autologin:
1. login with MetaMask account
2. click 'sign out'
3. open metamask and switch accounts (connecting if necessary)
4. login again (w/metamask)
5. address in header and balance(s) should reflect currently selected MetaMask account

account switching while connected:
1. login with MetaMask account
2. without logging out, open MetaMask and switch accounts  (connecting if necessary)
3. see address and balance(s) updated

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
