### PR TITLE
fix: notify user of incorrect network on login via WalletConnect

### DIFF
--- a/src/pages/home/ConnectWalletOptions.vue
+++ b/src/pages/home/ConnectWalletOptions.vue
@@ -5,6 +5,8 @@ import { computed, defineComponent, inject, ref, watch } from 'vue';
 import { Web3Modal } from '@web3modal/html';
 import { EthereumClient } from '@web3modal/ethereum';
 import { useEVMStore, usePlatformStore, useAccountStore, useChainStore } from 'src/antelope';
+import { getNetwork } from '@wagmi/core';
+import { Notify } from 'quasar';
 
 export default defineComponent({
     name: 'ConnectWalletOptions',
@@ -66,6 +68,17 @@ export default defineComponent({
             if (newState.open === false) {
                 this.$emit('toggleWalletConnect');
                 if (localStorage.getItem('wagmi.connected')){
+                    const chainSettings = useChainStore().currentChain.settings;
+                    const appChainId = chainSettings.getChainId();
+                    const appNetworkName = chainSettings.getDisplay();
+                    const walletConnectChainId = getNetwork().chain?.id.toString();
+                    if (appChainId !== walletConnectChainId){
+                        Notify.create({
+                            color: 'negative',
+                            icon: 'error',
+                            message: `Incorrect network detected! Connect to ${appNetworkName} before continuing.`,
+                        });
+                    }
                     this.loginEvm();
                 }
             }


### PR DESCRIPTION
# Fixes #301 

## Description
see issue

## Test scenarios
1. on mobile, open MetaMask and change network to non-telos network
2. Sign in to the application w/WalletConnect
3. See warning notification instructing user to change network before continuing

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
