### PR TITLE
several fixes: balances update everywhere automatically

### DIFF
--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -53,6 +53,9 @@ export default defineComponent({
 
                         // hide the token address from the url
                         this.$router.replace({ name: 'evm-send', params: { token: undefined } });
+                    } else {
+                        // get from balances a fresh token object
+                        token = this.balances.find(t => t.address === token?.address) ?? token;
                     }
 
                     if (!token) {
@@ -69,6 +72,7 @@ export default defineComponent({
                 this.updateEstimatedGas();
             },
             immediate: true,
+            deep: true,
         },
     },
     computed: {

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -23,7 +23,7 @@ watch(allTokens, (newBalances: EvmToken[]) => {
         }
     }
     totalFiatAmount.value = newFiatBalance;
-}, { deep: true });
+}, { deep: true, immediate: true });
 </script>
 
 <template>

--- a/src/pages/home/ConnectWalletOptions.vue
+++ b/src/pages/home/ConnectWalletOptions.vue
@@ -6,7 +6,6 @@ import { Web3Modal } from '@web3modal/html';
 import { EthereumClient } from '@web3modal/ethereum';
 import { useEVMStore, usePlatformStore, useAccountStore, useChainStore } from 'src/antelope';
 import { getNetwork } from '@wagmi/core';
-import { Notify } from 'quasar';
 
 export default defineComponent({
     name: 'ConnectWalletOptions',

--- a/test/jest/__tests__/antelope/stores/balances.spec.ts
+++ b/test/jest/__tests__/antelope/stores/balances.spec.ts
@@ -17,6 +17,7 @@ const tokenSys = {
     tokenId: 1,
 };
 
+const FIAT_BALANCE = ethers.BigNumber.from('123'.concat('1'.repeat(4)));
 const SYSTEM_TOKEN_BALANCE = ethers.BigNumber.from('123'.concat('1'.repeat(18)));
 const TOKEN_BALANCE = ethers.BigNumber.from('321'.concat('9'.repeat(18)));
 
@@ -126,15 +127,17 @@ describe('Antelope Balance Store', () => {
             label: [
                 {
                     ...tokenSys,
+                    balanceBn: SYSTEM_TOKEN_BALANCE,
                     balance: ethers.utils.formatUnits(SYSTEM_TOKEN_BALANCE, 18).slice(0, 8),
                     fullBalance: ethers.utils.formatUnits(SYSTEM_TOKEN_BALANCE, 18),
-                    balanceBn: SYSTEM_TOKEN_BALANCE,
+                    fiatBalance: ethers.utils.formatUnits(FIAT_BALANCE, 4),
                 },
                 {
                     ...tokenList[0],
+                    balanceBn: TOKEN_BALANCE,
                     balance: ethers.utils.formatUnits(TOKEN_BALANCE, 18).slice(0, 8),
                     fullBalance: ethers.utils.formatUnits(TOKEN_BALANCE, 18),
-                    balanceBn: TOKEN_BALANCE,
+                    fiatBalance: '',
                 },
             ],
         };


### PR DESCRIPTION
# Fixes #318

## Description
This PR contains a late push to the [previous #309 PR](https://github.com/telosnetwork/telos-wallet/pull/309) trying to make everything update automatically whenever the Balance Store updates its internal data.

### Balance Store

In the Balance store, we have a new update process that replaces the current instance in the balance list for a brand-new updated copy (`tokenBalance`).

```typescript
processBalanceForToken(label: string, token: EvmToken, balanceBn: BigNumber): void {
    this.trace('processBalanceForToken', label, ethers.utils.formatUnits(balanceBn, token.decimals), token.symbol);
    const balance = `${formatWei(balanceBn, token.decimals, 4)}`;
    const fullBalance = `${formatWei(balanceBn, token.decimals, token.decimals)}`;
    const fiatBalance = token.price > 0 ? `${parseFloat(balance) * token.price}` : '';

    const tokenBalance = {
        ...token,
        balanceBn,
        balance,
        fullBalance,
        fiatBalance,
    } as EvmToken;

    if (this.shouldAddTokenBalance(label, balanceBn, token)) {
        this.addNewBalance(label, tokenBalance);
    } else {
        this.removeBalance(label, tokenBalance);
    }
},
```

https://github.com/telosnetwork/telos-wallet/blob/318-visual-components-donot-reflect-store-balance-update/src/antelope/stores/balances.ts#LL175C1-L194C11

Note: We can have this temporal implementation and see how it develops. It works for now and it will be refactored when we incorporate the new Token class hierarchy to replace the [current Token interface](https://github.com/telosnetwork/telos-wallet/pull/286). So, it's ok to accept this solution even when is not final.

### WalletPage
Here the component sometimes gets ready after any balance update so this code never gets executed unless we force the initialization by adding an` immediate: true` to the parameters.
This Fix solves the [$0.00 total balance](https://user-images.githubusercontent.com/4420760/237332688-c63253a3-bab1-430c-925d-ad235293e032.png) issue. 
```typescript
watch(allTokens, (newBalances: EvmToken[]) => {
    let newFiatBalance = 0;
    for (let balance of newBalances){
        if (balance.fiatBalance){
            newFiatBalance += parseFloat(balance.fiatBalance);
        }
    }
    totalFiatAmount.value = newFiatBalance;
}, { deep: true, immediate: true });

```

https://github.com/telosnetwork/telos-wallet/blob/318-visual-components-donot-reflect-store-balance-update/src/pages/evm/wallet/WalletPage.vue#LL18C1-L26C37

### SendPage
The Send page it holding a discarded instance of a token. We must take a fresh copy on balance update
```typescript
    // get from balances a fresh token object
    token = this.balances.find(t => t.address === token?.address) ?? token;
```

https://github.com/telosnetwork/telos-wallet/blob/318-visual-components-donot-reflect-store-balance-update/src/pages/evm/wallet/SendPage.vue#L56-L59

## Test scenarios

![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/466cb3d4-f29b-4cd8-ae16-c707de7b5ec2)

### Case: connect two accounts
- go to [this link](https://deploy-preview-320--wallet-staging.netlify.app/)
- when login with Metamask, connect two non-zero-balance accounts (like the screenshot)
  - Let's call them accA and accB
- confirm everything on Metamask and finish logging in.
  - You should see the accA balance (including TLOS and STLOS)

### Case: balance tab update
- Requires Case: connect two accounts
- Open your Balance tab page if you are not there (Wallet on the side menu)
- Open your Metamask the switch between accA and accB back and forth.
  - You should see how things get updated in:
    - logged account address
    - total fiat balance
    - system token balance (TLOS)
    - any other erc20 token balance

### Case: Send Page
- Requires Case: connect two accounts
- Open your Balance tab page if you are not there (Wallet on the side menu)
- Press Send in the header
  - you should see the max available TLOS already shown above the input field.
- Open your Metamask the switch between accA and accB back and forth.
  - You should see how things get updated in:
    - max available
    - from address
    - balances in selector options

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
