### PR TITLE
updating balances once transaction confirms

### DIFF
--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -205,10 +205,9 @@ export const useBalancesStore = defineStore(store_name, {
                         if (account?.account) {
                             this.updateBalancesForAccount('logged', account);
                         }
-                        // TODO: should we notify the user that the transaction succeeded?
-                    } else {
-                        // TODO: should we do something if the transaction failed?
                     }
+                    // TODO: should we notify the user that the transaction succeeded of failed?
+                    // https://github.com/telosnetwork/telos-wallet/issues/328
                 });
             } else {
                 throw new AntelopeError('antelope.evm.error_no_provider');

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -72,7 +72,8 @@ export const useBalancesStore = defineStore(store_name, {
             // update logged balances every 10 seconds only if the user is logged
             setInterval(() => {
                 if (useAccountStore().loggedAccount) {
-                    useBalancesStore().updateBalancesForAccount('logged', useAccountStore().loggedAccount);
+                    // useBalancesStore().updateBalancesForAccount('logged', useAccountStore().loggedAccount);
+                    console.error('RESTORE ME');
                 }
             }, 10000);
 
@@ -157,7 +158,7 @@ export const useBalancesStore = defineStore(store_name, {
                 });
                 this.processBalanceForToken(label, token, balanceBn.value);
             } else {
-                console.error('No provider');
+                throw new AntelopeError('antelope.evm.error_no_provider');
             }
         },
         shouldAddTokenBalance(label: string, balanceBn: BigNumber, token: EvmToken): boolean {
@@ -192,6 +193,29 @@ export const useBalancesStore = defineStore(store_name, {
                 this.removeBalance(label, tokenBalance);
             }
         },
+        async subscribeForTransactionReceipt(response: TransactionResponse): Promise<TransactionResponse> {
+            this.trace('subscribeForTransactionReceipt', response.hash);
+            const provider = toRaw(useEVMStore().rpcProvider);
+            if (provider) {
+                // instead of await, we use then() to return the response immediately
+                // and perform the balance update in the background
+                provider.waitForTransaction(response.hash).then((receipt: ethers.providers.TransactionReceipt) => {
+                    this.trace('subscribeForTransactionReceipt', response.hash, 'receipt:', receipt.status, receipt);
+                    if (receipt.status === 1) {
+                        const account = useAccountStore().loggedAccount;
+                        if (account?.account) {
+                            this.updateBalancesForAccount('logged', account);
+                        }
+                        // TODO: should we notify the user that the transaction succeeded?
+                    } else {
+                        // TODO: should we do something if the transaction failed?
+                    }
+                });
+            } else {
+                throw new AntelopeError('antelope.evm.error_no_provider');
+            }
+            return response;
+        },
         async transferTokens(token: Token, to: string, amount: BigNumber, memo?: string): Promise<TransactionResponse> {
             this.trace('transferTokens', token, to, amount.toString(), memo);
             const label = 'logged';
@@ -201,11 +225,13 @@ export const useBalancesStore = defineStore(store_name, {
                 if (chain.settings.isNative()) {
                     const chain_settings = chain.settings as NativeChainSettings;
                     const account = useAccountStore().loggedAccount;
-                    return await this.transferNativeTokens(chain_settings, account, token as NativeToken, to, amount, memo ?? '');
+                    return await this.transferNativeTokens(chain_settings, account, token as NativeToken, to, amount, memo ?? '')
+                        .then(this.subscribeForTransactionReceipt);
                 } else {
                     const chain_settings = chain.settings as EVMChainSettings;
                     const account = useAccountStore().loggedAccount;
-                    return await this.transferEVMTokens(chain_settings, account, token as EvmToken, to, amount);
+                    return await this.transferEVMTokens(chain_settings, account, token as EvmToken, to, amount)
+                        .then(this.subscribeForTransactionReceipt);
                 }
             } catch (error) {
                 console.error('Error: ', errorToString(error));

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -72,8 +72,7 @@ export const useBalancesStore = defineStore(store_name, {
             // update logged balances every 10 seconds only if the user is logged
             setInterval(() => {
                 if (useAccountStore().loggedAccount) {
-                    // useBalancesStore().updateBalancesForAccount('logged', useAccountStore().loggedAccount);
-                    console.error('RESTORE ME');
+                    useBalancesStore().updateBalancesForAccount('logged', useAccountStore().loggedAccount);
                 }
             }, 10000);
 

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -53,6 +53,9 @@ export default defineComponent({
 
                         // hide the token address from the url
                         this.$router.replace({ name: 'evm-send', params: { token: undefined } });
+                    } else {
+                        // get from balances a fresh token object
+                        token = this.balances.find(t => t.address === token?.address) ?? token;
                     }
 
                     if (!token) {
@@ -69,6 +72,7 @@ export default defineComponent({
                 this.updateEstimatedGas();
             },
             immediate: true,
+            deep: true,
         },
     },
     computed: {

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -23,7 +23,7 @@ watch(allTokens, (newBalances: EvmToken[]) => {
         }
     }
     totalFiatAmount.value = newFiatBalance;
-}, { deep: true });
+}, { deep: true, immediate: true });
 </script>
 
 <template>

--- a/src/pages/home/ConnectWalletOptions.vue
+++ b/src/pages/home/ConnectWalletOptions.vue
@@ -6,7 +6,6 @@ import { Web3Modal } from '@web3modal/html';
 import { EthereumClient } from '@web3modal/ethereum';
 import { useEVMStore, usePlatformStore, useAccountStore, useChainStore } from 'src/antelope';
 import { getNetwork } from '@wagmi/core';
-import { Notify } from 'quasar';
 
 export default defineComponent({
     name: 'ConnectWalletOptions',

--- a/test/jest/__tests__/antelope/stores/balances.spec.ts
+++ b/test/jest/__tests__/antelope/stores/balances.spec.ts
@@ -17,6 +17,7 @@ const tokenSys = {
     tokenId: 1,
 };
 
+const FIAT_BALANCE = ethers.BigNumber.from('123'.concat('1'.repeat(4)));
 const SYSTEM_TOKEN_BALANCE = ethers.BigNumber.from('123'.concat('1'.repeat(18)));
 const TOKEN_BALANCE = ethers.BigNumber.from('321'.concat('9'.repeat(18)));
 
@@ -126,15 +127,17 @@ describe('Antelope Balance Store', () => {
             label: [
                 {
                     ...tokenSys,
+                    balanceBn: SYSTEM_TOKEN_BALANCE,
                     balance: ethers.utils.formatUnits(SYSTEM_TOKEN_BALANCE, 18).slice(0, 8),
                     fullBalance: ethers.utils.formatUnits(SYSTEM_TOKEN_BALANCE, 18),
-                    balanceBn: SYSTEM_TOKEN_BALANCE,
+                    fiatBalance: ethers.utils.formatUnits(FIAT_BALANCE, 4),
                 },
                 {
                     ...tokenList[0],
+                    balanceBn: TOKEN_BALANCE,
                     balance: ethers.utils.formatUnits(TOKEN_BALANCE, 18).slice(0, 8),
                     fullBalance: ethers.utils.formatUnits(TOKEN_BALANCE, 18),
-                    balanceBn: TOKEN_BALANCE,
+                    fiatBalance: '',
                 },
             ],
         };


### PR DESCRIPTION
# Fixes #278

## Description
This PR implements a subscription to wait for the sending token transaction to be confirmed and then update the balances.

## Known issues
- No feedback on the transaction receipt: currently, there's no feedback for the user on whether the transaction did pass or got rejected. If it does, the balances get updated silently.
- I just notice the input got broken after the styling class refactoring recently, but this is not a problem since we will replace the current input for the great new currency input component we have.
![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/5ddb3db9-3be5-428a-8002-14a00ec734a3)

## Test scenarios
- go to [this page](https://deploy-preview-321--wallet-staging.netlify.app/)
- login on EVM
- press send button
- choose any token and remember the balance and send some to another controlled account
  - you should get a success message right the way (but the balance may not change yet)
  - Wait until you get a confirmation message from Metamask
  - You should see your balance update


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
