### PR TITLE
incorporating the new indexer to fetch the balances

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -9,10 +9,13 @@ import {
     EvmTransaction,
     HyperionAbiSignatureFilter,
     HyperionActionsFilter,
+    IndexerAccountBalances,
+    IndexerTokenMarketData,
     PriceChartData,
 } from 'src/antelope/types';
 import EvmContract from 'src/antelope/stores/utils/EvmContract';
 import { ethers } from 'ethers';
+
 
 export default abstract class EVMChainSettings implements ChainSettings {
     // Short Name of the network
@@ -23,6 +26,9 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // External trusted metadata bucket for EVM contracts
     protected contractsBucket: AxiosInstance = axios.create({ baseURL: this.getHyperionEndpoint() });
+
+    // External indexer API support
+    protected indexer: AxiosInstance = axios.create({ baseURL: this.getIndexerApiEndpoint() });
 
     // Token list promise
     tokenListPromise: Promise<EvmToken[]> | null = null;
@@ -60,9 +66,11 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
         // Axios Request Interceptor
         this.hyperion.interceptors.request.use(requestHandler);
+        this.indexer.interceptors.request.use(requestHandler);
 
         // Axios Response Interceptor
         this.hyperion.interceptors.response.use(responseHandler, erorrHandler);
+        this.indexer.interceptors.response.use(responseHandler, erorrHandler);
 
     }
 
@@ -98,6 +106,66 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract getExplorerUrl(): string;
     abstract getTrustedContractsBucket(): string;
     abstract getImportantTokensIdList(): string[];
+    abstract getIndexerApiEndpoint(): string;
+    abstract hasIndexSupport(): boolean;
+
+    async getAllBalances(account: string): Promise<EvmToken[]> {
+        if (!this.hasIndexSupport()) {
+            console.error('Indexer API not supported for this chain:', this.getNetwork());
+            return [];
+        }
+        return Promise.all([
+            this.indexer.get(`v1/account/${account}/balances`, {
+                params: {
+                    limit: 50,
+                    offset: 0,
+                    includePagination: false,
+                },
+            }),
+            this.getUsdPrice(),
+        ]).then(([response, systemTokenPrice]) => {
+            // parse to IndexerAccountBalances
+            const balances = response.data as IndexerAccountBalances;
+
+            return this.getTokenList().then((tokenList:EvmToken[]) => {
+                const tokens: EvmToken[] = [];
+                for (const result of balances.results) {
+                    const token = tokenList.find(t => t.address.toLowerCase() === result.contract.toLowerCase());
+                    const contractData = balances.contracts[result.contract] ?? {};
+                    const callDataStr = contractData.calldata as unknown as string;
+                    try {
+                        if (typeof callDataStr === 'string') {
+                            const callData = JSON.parse(callDataStr);
+                            contractData.calldata = callData;
+                        } else if (token?.isSystem) {
+                            // system token systemTokenPrice
+                            contractData.calldata = {
+                                price: systemTokenPrice.toString(),
+                            } as IndexerTokenMarketData;
+                        }
+                    } catch (e) {
+                        console.error('Error parsing calldata', `"${callDataStr}"`, e);
+                    }
+
+                    if (token) {
+                        const balance = ethers.BigNumber.from(result.balance);
+                        token.balance = ethers.utils.formatUnits(balance, token.decimals);
+                        token.balanceBn = balance;
+                        token.fullBalance = token.balance;
+                        if (typeof contractData.calldata === 'object') {
+                            token.price = parseFloat(contractData.calldata.price);
+                            token.fiatBalance = (token.price * parseFloat(token.balance)).toFixed(2);
+                        }
+                        tokens.push(token);
+                    }
+                }
+                return tokens;
+            });
+        }).catch((error) => {
+            console.error(error);
+            return [];
+        });
+    }
 
     constructTokenId(token: EvmToken): string {
         return `${token.symbol}-${token.address}-${this.getChainId()}`;
@@ -181,14 +249,17 @@ export default abstract class EVMChainSettings implements ChainSettings {
             return this.tokenListPromise;
         }
 
+        type PartialToken = {chainId:number, logoURI: string, address: string};
+
         const url =  'https://raw.githubusercontent.com/telosnetwork/token-list/main/telosevm.tokenlist.json';
         this.tokenListPromise = axios.get(url)
-            .then(results => results.data.tokens as unknown as {chainId:number, logoURI: string}[])
+            .then(results => results.data.tokens as unknown as PartialToken[])
             .then(tokens => tokens.filter(({ chainId }) => chainId === +this.getChainId()))
             .then(tokens => tokens.map(t => ({
                 ...t,
                 logoURI: t.logoURI?.replace('ipfs://', 'https://w3s.link/ipfs/') ?? require('src/assets/logo--tlos.svg'),
             })))
+            .then(tokens => [this.getSystemToken() as unknown as PartialToken].concat(tokens))
             .then(tokens => tokens.map(t => ({
                 // Token Id - '<symbol>-<address>-<chainId>'
                 tokenId: `${(t as EvmToken).symbol}-${(t as EvmToken).address}-${t.chainId}`,
@@ -204,7 +275,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
                 ...t,
             })))
             .then(tokens => tokens.map(t => t as unknown as EvmToken));
-
 
         return this.tokenListPromise;
     }

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -11,7 +11,7 @@ const TOKEN = {
     name: 'Telos',
     symbol: 'TLOS',
     decimals: 18,
-    address: '',
+    address: '___NATIVE_CURRENCY___',
     logo: LOGO,
     logoURI: LOGO,
     isNative: false,
@@ -102,4 +102,13 @@ export default class TelosEVMTestnet extends EVMChainSettings {
             this.constructTokenId({ symbol: 'WTLOS', address: this.getWtlosContractAddress() } as EvmToken),
         ];
     }
+
+    getIndexerApiEndpoint(): string {
+        return 'https://api.testnet.teloscan.io/';
+    }
+
+    hasIndexSupport(): boolean {
+        return false;
+    }
+
 }

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -11,7 +11,7 @@ const TOKEN = {
     name: 'Telos',
     symbol: 'TLOS',
     decimals: 18,
-    address: '',
+    address: '___NATIVE_CURRENCY___',
     logo: LOGO,
     logoURI: LOGO,
     isNative: false,
@@ -101,5 +101,13 @@ export default class TelosEVMTestnet extends EVMChainSettings {
             this.constructTokenId({ symbol: 'STLOS', address: this.getStlosContractAddress() } as EvmToken),
             this.constructTokenId({ symbol: 'WTLOS', address: this.getWtlosContractAddress() } as EvmToken),
         ];
+    }
+
+    getIndexerApiEndpoint(): string {
+        return 'https://api.teloscan.io/';
+    }
+
+    hasIndexSupport(): boolean {
+        return true;
     }
 }

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -85,43 +85,53 @@ export const useBalancesStore = defineStore(store_name, {
                     const chain_settings = chain.settings as NativeChainSettings;
                     if (account?.account) {
                         this.__balances[label] = await chain_settings.getTokens(account.account);
+                        useFeedbackStore().unsetLoading('updateBalancesForAccount');
                     }
                 } else {
                     const chain_settings = chain.settings as EVMChainSettings;
                     if (account?.account) {
-                        this.__balances[label] = this.__balances[label] ?? [];
-                        const tokens = await chain_settings.getTokenList();
-                        this.updateSystemBalanceForAccount(label, account.account);
-                        this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
-                        const evm = useEVMStore();
-                        let promises: Promise<void>[] = [];
-
-                        if (localStorage.getItem('wagmi.connected')) {
-
-                            promises = tokens.map(async (token) => {
-                                fetchBalance({
-                                    address: getAccount().address as addressString,
-                                    chainId: getNetwork().chain?.id,
-                                    token: token.address as addressString,
-                                }).then((balanceBn: FetchBalanceResult) => {
-                                    this.processBalanceForToken(label, token, balanceBn.value);
-                                });
-                            });
-
+                        if (chain_settings.hasIndexSupport()) {
+                            if (account?.account) {
+                                this.__balances[label] = await chain_settings.getAllBalances(account.account);
+                                this.sortBalances(label);
+                                useFeedbackStore().unsetLoading('updateBalancesForAccount');
+                            }
                         } else {
-                            promises = tokens
-                                .map(token => evm.getERC20TokenBalance(account.account, token.address)
-                                    .then((balanceBn: BigNumber) => {
-                                        this.processBalanceForToken(label, token, balanceBn);
-                                    }),
-                                );
+                            // In case the chain does not support index, we need to fetch the balances using Web3
+                            this.__balances[label] = this.__balances[label] ?? [];
+                            const tokens = await chain_settings.getTokenList();
+                            this.updateSystemBalanceForAccount(label, account.account);
+                            this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
+                            const evm = useEVMStore();
+                            let promises: Promise<void>[] = [];
 
+                            if (localStorage.getItem('wagmi.connected')) {
+
+                                promises = tokens.map(async (token) => {
+                                    fetchBalance({
+                                        address: getAccount().address as addressString,
+                                        chainId: getNetwork().chain?.id,
+                                        token: token.address as addressString,
+                                    }).then((balanceBn: FetchBalanceResult) => {
+                                        this.processBalanceForToken(label, token, balanceBn.value);
+                                    });
+                                });
+
+                            } else {
+                                promises = tokens
+                                    .map(token => evm.getERC20TokenBalance(account.account, token.address)
+                                        .then((balanceBn: BigNumber) => {
+                                            this.processBalanceForToken(label, token, balanceBn);
+                                        }),
+                                    );
+
+                            }
+
+                            Promise.allSettled(promises).then(() => {
+                                useFeedbackStore().unsetLoading('updateBalancesForAccount');
+                                this.trace('updateBalancesForAccount', 'balances:', toRaw(this.__balances[label]));
+                            });
                         }
-
-                        Promise.allSettled(promises).then(() => {
-                            useFeedbackStore().unsetLoading('updateBalancesForAccount');
-                            this.trace('updateBalancesForAccount', 'balances:', toRaw(this.__balances[label]));
-                        });
                     }
                 }
             } catch (error) {

--- a/src/antelope/types/IndexerTypes.ts
+++ b/src/antelope/types/IndexerTypes.ts
@@ -1,0 +1,46 @@
+
+export interface IndexerTokenInfo {
+    symbol: string;
+    creator: string;
+    address: string;
+    fromTrace: boolean;
+    trace_address: string;
+    logoURI: string;
+    supply: string;
+    calldata: IndexerTokenMarketData;
+    decimals: number;
+    name: string;
+    block: number;
+    supportedInterfaces: string[];
+    transaction: string;
+}
+
+export interface IndexerTokenMarketData {
+    name: string;
+    price: string;
+    supply: string;
+    symbol: string;
+    volume: string;
+    holders: string;
+    decimals: number;
+    marketcap: string;
+    max_supply_ibc: string;
+    total_supply_ibc: string;
+    marketdata_updated: string;
+}
+
+export interface IndexerTokenBalance {
+    address: string;
+    balance: string;
+    contract: string;
+    updated: number;
+}
+
+
+export interface IndexerAccountBalances {
+    success: boolean;
+    contracts: {
+        [address: string]: IndexerTokenInfo;
+    };
+    results: IndexerTokenBalance[];
+}

--- a/src/antelope/types/index.ts
+++ b/src/antelope/types/index.ts
@@ -13,6 +13,7 @@ export * from 'src/antelope/types/Filters';
 export * from 'src/antelope/types/PriceData';
 export * from 'src/antelope/types/Proposals';
 export * from 'src/antelope/types/Producers';
+export * from 'src/antelope/types/IndexerTypes';
 export * from 'src/antelope/types/KeyAccounts';
 export * from 'src/antelope/types/Label';
 export * from 'src/antelope/types/Theme';

--- a/test/jest/__tests__/antelope/stores/balances.spec.ts
+++ b/test/jest/__tests__/antelope/stores/balances.spec.ts
@@ -64,6 +64,7 @@ jest.mock('src/antelope/stores/chain', () => ({
                 getSystemToken: jest.fn().mockImplementation(() => tokenSys),
                 getUsdPrice: jest.fn().mockImplementation(() => 1),
                 getImportantTokensIdList: jest.fn().mockImplementation(() => []),
+                hasIndexSupport: jest.fn().mockImplementation(() => false),
             },
         })),
         loggedChain: {


### PR DESCRIPTION
# Fixes #316

## Description
This PR incorporates the indexer as a new way of fetching the token balances for the user. However, since not all blockchains have indexer support, it was also added a parameter to indicate it the blockchain actually has that support or not.
Depending on that parameter the current solution uses the new indexer as a way of fetching the balances and if not, it uses the previous solution using local provider fetching token balances one by one.

Currently, Testnet is set as not supporting indexer while Mainet does.

## Test scenarios - Mainnet
- For this test, you will need to download the branch and run it locally.
- Ensure you have the `.env `file at the very root of the project with the content:
  `NETWORK="mainnet"`

You can use the following terminal commands:
```bash
git clone https://github.com/telosnetwork/telos-wallet.git; cd telos-wallet
git checkout 316-switch-to-use-indexer-to-get-token-balances
cp .env.example .env
yarn; yarn dev
```

- Once you are running locally this branch login normally on EVM (mainnet)
- You should see on your balance page all your production EVM tokens including the fiat price and fiat balance calculated. You should notice that the balances are sorted by fiat balance decreasing.
- Check the Big Fiat number at the top is displaying the correct sum of all token fiat balances.

## Test scenarios - Testnet
- For this test, you can use your local copy but change the content of the `.env` file to:
 `NETWORK="testnet"` 
- Or you can use [this link](https://deploy-preview-333--wallet-staging.netlify.app/)
- Login on EVM (testnet)
  - You should see on test balances as usual. Only TLOS including price and the rest without price data.



## Screenshot
![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/180677a2-6485-49d3-8152-03800507ddba)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
