### PR TITLE
cache and try-catch for coingecko API

### DIFF
--- a/src/antelope/types/PriceData.ts
+++ b/src/antelope/types/PriceData.ts
@@ -16,6 +16,7 @@ export interface PriceHistory {
 export type DateTuple = [number | string, number];
 
 export interface PriceStats {
+  status: number;
   data: {
     [tokenId: string]: {
       last_updated_at: number;

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -36,7 +36,7 @@ export const getCoingeckoUsdPrice = async (
             priceCache[tokenId] = { lastFetchTime: now, lastPrice: price };
             return price;
         } else {
-            console.log(`Error: received status code ${stats.status} from Coingecko.`);
+            console.error(`Error: received status code ${stats.status} from Coingecko.`);
             return 0;
         }
     } catch (error) {

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -5,16 +5,44 @@ import {
     PriceStats,
 } from 'src/antelope/types';
 
+interface CachedPrice {
+    lastFetchTime: number | null,
+    lastPrice: number | null,
+}
 
+const priceCache: { [tokenId: string]: CachedPrice } = {};
 
 export const getCoingeckoUsdPrice = async (
     tokenId: string,
 ): Promise<number> => {
-    const stats: PriceStats = await axios.get(
-        getCoingeckoExchangeStatsUrl(tokenId),
-    );
+    const now = Date.now();
 
-    return stats.data[tokenId].usd;
+    if (priceCache[tokenId] &&
+        priceCache[tokenId].lastFetchTime &&
+        now - (priceCache[tokenId].lastFetchTime as number) < 60 * 1000 &&
+        priceCache[tokenId].lastPrice !== null
+    ) {
+        // If less than a minute has passed since the last fetch, return the cached price.
+        return priceCache[tokenId].lastPrice as number;
+    }
+
+    try {
+        const stats: PriceStats = await axios.get(
+            getCoingeckoExchangeStatsUrl(tokenId),
+        );
+
+        if (stats && stats.status === 200) {
+            const price = stats.data[tokenId].usd;
+            priceCache[tokenId] = { lastFetchTime: now, lastPrice: price };
+            return price;
+        } else {
+            console.log(`Error: received status code ${stats.status} from Coingecko.`);
+            return 0;
+        }
+    } catch (error) {
+        console.error('Error: fetching from Coingecko failed.', error);
+        return 0;
+    }
 };
 
 export const getCoingeckoPriceChartData = async (


### PR DESCRIPTION
# Fixes #340

## Description
Coingecko API gets blocked when the applications fetches repeatedly within a short period of time and that was causing the whole application to crash. To mitigate this problem two solutions were implemented:
1 - **Try-Catch**: Sourrinding the code with try-catch clauses is always a good practice and prevents the app from crashing
2 - **Cache**: a small cache of prices fetched within the last minute is saved to avoid constantly hitting the API.

## Test scenarios
- go to [this link](https://deploy-preview-341--wallet-staging.netlify.app/)
- Login on EVM Testnet
- open developer tools (F12 on Chrome)
- open the Network panel
- you should see an initial fetch on a link like https://api.coingecko.com/api/v3/simple/price?ids=telos...
- you should not see another fetch to Coingecko's API until 1 minute has passed.

- reload the page and wait for it to load de TLOS price
  - if it does, reload the page again
  - if it doent's you will get a Coingecko API error on the console but the token balances still display as usual but with no prices.


<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
