### PR TITLE
311 autologin not triggered on navigation to home route after login walletconnect

### DIFF
--- a/src/boot/wagmi.ts
+++ b/src/boot/wagmi.ts
@@ -5,7 +5,7 @@ import { w3mProvider, w3mConnectors, EthereumClient } from '@web3modal/ethereum'
 
 // create wagmi client and make globally available for autologin
 const projectId = process.env.PROJECT_ID || '';
-const chains = process.env.NETWORK === 'mainnet' ? [telos, telosTestnet] : [telosTestnet, telos];
+const chains = [telos, telosTestnet];
 const { provider } = configureChains(chains, [w3mProvider({ projectId })]);
 
 const wagmi = createClient({

--- a/src/boot/wagmi.ts
+++ b/src/boot/wagmi.ts
@@ -5,7 +5,7 @@ import { w3mProvider, w3mConnectors, EthereumClient } from '@web3modal/ethereum'
 
 // create wagmi client and make globally available for autologin
 const projectId = process.env.PROJECT_ID || '';
-const chains = [telos, telosTestnet];
+const chains = process.env.NETWORK === 'mainnet' ? [telos, telosTestnet] : [telosTestnet, telos];
 const { provider } = configureChains(chains, [w3mProvider({ projectId })]);
 
 const wagmi = createClient({

--- a/src/pages/home/ConnectWalletOptions.vue
+++ b/src/pages/home/ConnectWalletOptions.vue
@@ -68,7 +68,6 @@ export default defineComponent({
                 this.$emit('toggleWalletConnect');
                 if (localStorage.getItem('wagmi.connected')){
                     this.loginEvm();
-
                     const chainSettings = useChainStore().currentChain.settings;
                     const appChainId = chainSettings.getChainId();
                     const networkName = chainSettings.getDisplay();

--- a/src/pages/home/HomePage.vue
+++ b/src/pages/home/HomePage.vue
@@ -27,7 +27,7 @@ export default defineComponent({
         ...mapGetters('account', ['isAuthenticated']),
     },
 
-    async mounted() {
+    beforeMount() {
         // redirect for wallet connect see https://github.com/telosnetwork/telos-wallet/issues/343
         if (localStorage.getItem('wagmi.connected')){
             this.$router.push({ path: 'evm/wallet' });

--- a/src/pages/home/HomePage.vue
+++ b/src/pages/home/HomePage.vue
@@ -26,6 +26,13 @@ export default defineComponent({
     computed: {
         ...mapGetters('account', ['isAuthenticated']),
     },
+
+    async mounted() {
+        // redirect for wallet connect see https://github.com/telosnetwork/telos-wallet/issues/343
+        if (localStorage.getItem('wagmi.connected')){
+            this.$router.push({ path: 'evm/wallet' });
+        }
+    },
 });
 </script>
 


### PR DESCRIPTION
# Fixes #311

## Description
autologin _is_ executing but the redirect callback is not working. see #343 

## Test scenarios
1. login with WalletConnect
2. refresh root/base route
3. see redirect to wallet balances view

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages

