### PR TITLE
#371 | Fix balance text

### DIFF
--- a/src/pages/evm/wallet/WalletBalanceRow.vue
+++ b/src/pages/evm/wallet/WalletBalanceRow.vue
@@ -114,12 +114,7 @@ export default defineComponent({
             if (!this.tokenHasFiatValue) {
                 return '';
             } else {
-                const isMobile = this.$q.screen.lt.sm;
-                if (isMobile) {
-                    return +this.balance.str;
-                } else {
-                    return this.tokenBalanceFiat ?? 0;
-                }
+                return +this.balance.str;
             }
         },
         prettySecondaryAmount(): string {

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -32,7 +32,7 @@ watch(allBalances, (newBalances: TokenBalance[]) => {
     </template>
 
     <template v-slot:balance>
-        <div class="test">
+        <div class="c-wallet-page__row">
             <WalletBalanceRow
                 v-for="(balance, index) in allBalances"
                 :key="`balance-${index}`"

--- a/test/jest/__tests__/pages/evm/wallet/__snapshots__/WalletBalanceRow.spec.ts.snap
+++ b/test/jest/__tests__/pages/evm/wallet/__snapshots__/WalletBalanceRow.spec.ts.snap
@@ -43,7 +43,7 @@ exports[`WalletBalanceRow.vue should render correctly on desktop devices (Staked
         class="c-wallet-balance-row__secondary-amount"
       >
         
-        691.9800 STLOS
+        3,642.0243 STLOS
         
       </span>
     </div>


### PR DESCRIPTION
# Fixes #371

## Description
This PR addresses a bug where the fiat value of a token balance always matches the token balance itself

## Test scenarios
- go to https://deploy-preview-372--wallet-staging.netlify.app/
- sign in
- see that your fiat balance is correct for the token balance

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
