### PR TITLE
fix: remove bottom offset that obscures token selection dropdown

### DIFF
--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -462,7 +462,6 @@ export default defineComponent({
 
     &__view-contract {
         position: absolute;
-        bottom: -24px;
         display: flex;
         align-items: center;
         cursor: pointer;


### PR DESCRIPTION
# Fixes #364 

## Description
See issue

## Test scenarios

- [x] Brave/Chrome Desktop
- [x] Android
- [x] Iphone

