### PR TITLE
bugfix: avoiding using scientific notation on string numbers

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -304,9 +304,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
     async getEstimatedGas(limit: number): Promise<{ system:ethers.BigNumber, fiat:ethers.BigNumber }> {
         const gasPrice: ethers.BigNumber = await this.getGasPrice();
         const tokenPrice: number = await this.getUsdPrice();
-
-        console.log(typeof tokenPrice.toFixed, typeof tokenPrice, tokenPrice);
-
         const price = ethers.utils.parseUnits(tokenPrice.toFixed(16), 18);
         const system = gasPrice.mul(limit);
         const fiatDouble = system.mul(price);

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/antelope/types';
 import EvmContract from 'src/antelope/stores/utils/contracts/EvmContract';
 import { ethers } from 'ethers';
+import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
 
 
 export default abstract class EVMChainSettings implements ChainSettings {
@@ -304,7 +305,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
     async getEstimatedGas(limit: number): Promise<{ system:ethers.BigNumber, fiat:ethers.BigNumber }> {
         const gasPrice: ethers.BigNumber = await this.getGasPrice();
         const tokenPrice: number = await this.getUsdPrice();
-        const price = ethers.utils.parseUnits(tokenPrice.toFixed(16), 18);
+        const price = ethers.utils.parseUnits(toStringNumber(tokenPrice), 18);
         const system = gasPrice.mul(limit);
         const fiatDouble = system.mul(price);
         const fiat = fiatDouble.div(ethers.utils.parseUnits('1', 18));

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -305,7 +305,9 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const gasPrice: ethers.BigNumber = await this.getGasPrice();
         const tokenPrice: number = await this.getUsdPrice();
 
-        const price = ethers.utils.parseUnits(tokenPrice.toString(), 18);
+        console.log(typeof tokenPrice.toFixed, typeof tokenPrice, tokenPrice);
+
+        const price = ethers.utils.parseUnits(tokenPrice.toFixed(16), 18);
         const system = gasPrice.mul(limit);
         const fiatDouble = system.mul(price);
         const fiat = fiatDouble.div(ethers.utils.parseUnits('1', 18));

--- a/src/antelope/chains/NativeChainSettings.ts
+++ b/src/antelope/chains/NativeChainSettings.ts
@@ -40,6 +40,7 @@ import {
     TokenBalance,
 } from 'src/antelope/types';
 import { ethers } from 'ethers';
+import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
 
 export const DEFAULT_ICON = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjciIGhlaWdodD0iMTgiIHZpZXdCb3g9IjAgMCAyNyAxOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTgiIGN5PSI5IiByPSI4IiBmaWxsPSJ3aGl0ZSIgc3Ryb2tlPSJibGFjayIgc3Ryb2tlLXdpZHRoPSIyIi8+CjxjaXJjbGUgY3g9IjkiIGN5PSI5IiByPSI4IiBmaWxsPSJ3aGl0ZSIgc3Ryb2tlPSJibGFjayIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=';
 
@@ -198,7 +199,7 @@ export default abstract class NativeChainSettings implements ChainSettings {
             const tk = tokens.find((t: TokenClass) => t.symbol === tokeninfo.symbol) as TokenClass;
             let balance = ethers.constants.Zero;
             if (amount > 0 && tk) {
-                balance = ethers.utils.parseUnits(amount.toFixed(16), tk.decimals);
+                balance = ethers.utils.parseUnits(toStringNumber(amount), tk.decimals);
             }
             const tokenBalance = new TokenBalance(tk, balance);
             return tokenBalance;

--- a/src/antelope/chains/NativeChainSettings.ts
+++ b/src/antelope/chains/NativeChainSettings.ts
@@ -198,9 +198,7 @@ export default abstract class NativeChainSettings implements ChainSettings {
             const tk = tokens.find((t: TokenClass) => t.symbol === tokeninfo.symbol) as TokenClass;
             let balance = ethers.constants.Zero;
             if (amount > 0 && tk) {
-                // TODO: avoid cientific notation on amount.toString()
-                // https://github.com/telosnetwork/telos-wallet/issues/359
-                balance = ethers.utils.parseUnits(amount.toString(), tk.decimals);
+                balance = ethers.utils.parseUnits(amount.toFixed(16), tk.decimals);
             }
             const tokenBalance = new TokenBalance(tk, balance);
             return tokenBalance;

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -97,10 +97,14 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         if (this.hasIndexSupport()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
-            return await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
-        } else {
-            return await api.getCoingeckoUsdPrice('telos');
+            const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
+
+            if (fiatPrice !== 0) {
+                return fiatPrice;
+            }
         }
+
+        return await api.getCoingeckoUsdPrice('telos');
     }
 
     getLargeLogoPath(): string {

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -97,10 +97,14 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         if (this.hasIndexSupport()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
-            return await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
-        } else {
-            return await api.getCoingeckoUsdPrice('telos');
+            const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
+
+            if (fiatPrice !== 0) {
+                return fiatPrice;
+            }
         }
+
+        return await api.getCoingeckoUsdPrice('telos');
     }
 
     getLargeLogoPath(): string {

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -198,8 +198,6 @@ export const useBalancesStore = defineStore(store_name, {
                     // TODO: should we notify the user that the transaction succeeded of failed?
                     // https://github.com/telosnetwork/telos-wallet/issues/328
                 });
-            } else {
-                throw new AntelopeError('antelope.evm.error_no_provider');
             }
             return response;
         },
@@ -291,7 +289,6 @@ export const useBalancesStore = defineStore(store_name, {
                         value: amount,
                     },
                 });
-
                 return await sendTransaction(config);
             } else {
 

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -293,13 +293,13 @@ export const useEVMStore = defineStore(store_name, {
         },
         // utils ---
         toWei(value: string | number, decimals = 18): string {
-            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : value.toString(), decimals.toString());
+            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : (+value).toFixed(16), decimals.toFixed(16));
             const amountInWei = bigAmount.toString();
             return amountInWei;
         },
         toBigNumber(value: string | number, decimals?: number): ethers.BigNumber {
             const dec = decimals ? decimals : value.toString().split('.')[1]?.length ?? 0;
-            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : value.toString(), dec.toString());
+            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : (+value).toFixed(16), dec.toFixed(16));
             return bigAmount;
         },
         // Evm Contract Managment

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -53,6 +53,7 @@ import { getAccount } from '@wagmi/core';
 import { usePlatformStore } from 'src/antelope/stores/platform';
 import { checkNetwork } from 'src/antelope/stores/utils/checkNetwork';
 import { useAccountStore } from 'src/antelope/stores/account';
+import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
 
 const onEvmReady = new BehaviorSubject<boolean>(false);
 
@@ -293,13 +294,13 @@ export const useEVMStore = defineStore(store_name, {
         },
         // utils ---
         toWei(value: string | number, decimals = 18): string {
-            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : (+value).toFixed(16), decimals.toFixed(16));
+            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : toStringNumber(value), toStringNumber(decimals));
             const amountInWei = bigAmount.toString();
             return amountInWei;
         },
         toBigNumber(value: string | number, decimals?: number): ethers.BigNumber {
             const dec = decimals ? decimals : value.toString().split('.')[1]?.length ?? 0;
-            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : (+value).toFixed(16), dec.toFixed(16));
+            const bigAmount: ethers.BigNumber = ethers.utils.parseUnits(value === 'string' ? value : toStringNumber(value), toStringNumber(dec));
             return bigAmount;
         },
         // Evm Contract Managment

--- a/src/antelope/stores/utils/currency-utils.ts
+++ b/src/antelope/stores/utils/currency-utils.ts
@@ -13,7 +13,8 @@ export function toStringNumber(value: number | string): string {
     if (typeof value === 'string') {
         return value;
     } else if (typeof value === 'number') {
-        return value.toFixed(18);
+        const num = new Decimal(value);
+        return num.toFixed(18);
     } else {
         throw new Error('Invalid value type: ' + typeof value);
     }

--- a/src/antelope/stores/utils/currency-utils.ts
+++ b/src/antelope/stores/utils/currency-utils.ts
@@ -207,7 +207,7 @@ export function prettyPrintCurrency(
  * @returns {BigNumber} the amount of token two equivalent to the amount of token one
  */
 export function convertCurrency(tokenOneAmount: BigNumber, tokenOneDecimals: number, tokenTwoDecimals: number, conversionFactor: string | number): BigNumber {
-    const conversionRate = conversionFactor.toString();
+    const conversionRate = (+conversionFactor).toFixed(16);
     const leadingZeroesRegex = /^0+/g;
     const trailingZeroesRegex = /0+$/g;
     const floatRegex = /^\d+(\.\d+)?$/g;

--- a/src/antelope/stores/utils/currency-utils.ts
+++ b/src/antelope/stores/utils/currency-utils.ts
@@ -4,6 +4,23 @@ import { formatUnits } from '@ethersproject/units';
 import Decimal from 'decimal.js';
 
 /**
+ * Given a number or string, returns a string representation of the number with up to 18 decimal places
+ * @param value - number or string to convert to string
+ * @returns {string} string representation of the number
+ */
+
+export function toStringNumber(value: number | string): string {
+    if (typeof value === 'string') {
+        return value;
+    } else if (typeof value === 'number') {
+        return value.toFixed(18);
+    } else {
+        throw new Error('Invalid value type: ' + typeof value);
+    }
+}
+
+
+/**
  * Given a locale string, returns the character used to separate integer and decimal portions of a number,
  * e.g "." as in 123.456
  * @param locale - standard locale code, such as "en-US"
@@ -207,7 +224,7 @@ export function prettyPrintCurrency(
  * @returns {BigNumber} the amount of token two equivalent to the amount of token one
  */
 export function convertCurrency(tokenOneAmount: BigNumber, tokenOneDecimals: number, tokenTwoDecimals: number, conversionFactor: string | number): BigNumber {
-    const conversionRate = (+conversionFactor).toFixed(16);
+    const conversionRate = toStringNumber(conversionFactor);
     const leadingZeroesRegex = /^0+/g;
     const trailingZeroesRegex = /0+$/g;
     const floatRegex = /^\d+(\.\d+)?$/g;

--- a/src/antelope/stores/utils/index.ts
+++ b/src/antelope/stores/utils/index.ts
@@ -22,11 +22,13 @@ export const WEI_PRECISION = 18;
  * @returns a string representing the result of the division also as a float number
  */
 export function divideFloat(a: string | number, b: string | number): string {
-    const a_decimals = a.toString().split('.')[1] ? a.toString().split('.')[1].length : 0;
-    const b_decimals = b.toString().split('.')[1] ? b.toString().split('.')[1].length : 0;
+    const a_str = (+a).toFixed(16);
+    const b_str = (+b).toFixed(16);
+    const a_decimals = a_str.split('.')[1] ? a_str.split('.')[1].length : 0;
+    const b_decimals = b_str.split('.')[1] ? b_str.split('.')[1].length : 0;
     const decimals = 2 * Math.max(a_decimals, b_decimals);
-    const A = ethers.utils.parseUnits(a.toString(), decimals);
-    const B = ethers.utils.parseUnits(b.toString(), b_decimals);
+    const A = ethers.utils.parseUnits(a_str, decimals);
+    const B = ethers.utils.parseUnits(b_str, b_decimals);
     const result = A.div(B);
     return formatUnits(result.toString(), decimals-b_decimals);
 }
@@ -38,11 +40,13 @@ export function divideFloat(a: string | number, b: string | number): string {
  * @returns a string representing the result of the multiplication also as a float number
  */
 export function multiplyFloat(a: string | number, b: string | number): string {
-    const a_decimals = a.toString().split('.')[1] ? a.toString().split('.')[1].length : 0;
-    const b_decimals = b.toString().split('.')[1] ? b.toString().split('.')[1].length : 0;
+    const a_str = (+a).toFixed(16);
+    const b_str = (+b).toFixed(16);
+    const a_decimals = a_str.split('.')[1] ? a_str.split('.')[1].length : 0;
+    const b_decimals = b_str.split('.')[1] ? b_str.split('.')[1].length : 0;
     const decimals = a_decimals + b_decimals;
-    const A = ethers.utils.parseUnits(a.toString(), decimals);
-    const B = ethers.utils.parseUnits(b.toString(), decimals);
+    const A = ethers.utils.parseUnits(a_str, decimals);
+    const B = ethers.utils.parseUnits(b_str, decimals);
     const result = A.mul(B);
     return formatUnits(result.toString(), decimals+decimals);
 }

--- a/src/antelope/stores/utils/index.ts
+++ b/src/antelope/stores/utils/index.ts
@@ -7,7 +7,7 @@ import {
     EvmABIEntry,
 } from 'src/antelope/types';
 import { fromUnixTime, format } from 'date-fns';
-
+import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
 import { prettyPrintCurrency } from 'src/antelope/stores/utils/currency-utils';
 
 const REVERT_FUNCTION_SELECTOR = '0x08c379a0';
@@ -22,8 +22,8 @@ export const WEI_PRECISION = 18;
  * @returns a string representing the result of the division also as a float number
  */
 export function divideFloat(a: string | number, b: string | number): string {
-    const a_str = (+a).toFixed(16);
-    const b_str = (+b).toFixed(16);
+    const a_str = toStringNumber(a);
+    const b_str = toStringNumber(b);
     const a_decimals = a_str.split('.')[1] ? a_str.split('.')[1].length : 0;
     const b_decimals = b_str.split('.')[1] ? b_str.split('.')[1].length : 0;
     const decimals = 2 * Math.max(a_decimals, b_decimals);
@@ -40,8 +40,8 @@ export function divideFloat(a: string | number, b: string | number): string {
  * @returns a string representing the result of the multiplication also as a float number
  */
 export function multiplyFloat(a: string | number, b: string | number): string {
-    const a_str = (+a).toFixed(16);
-    const b_str = (+b).toFixed(16);
+    const a_str = toStringNumber(a);
+    const b_str = toStringNumber(b);
     const a_decimals = a_str.split('.')[1] ? a_str.split('.')[1].length : 0;
     const b_decimals = b_str.split('.')[1] ? b_str.split('.')[1].length : 0;
     const decimals = a_decimals + b_decimals;

--- a/src/antelope/types/TokenClass.ts
+++ b/src/antelope/types/TokenClass.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import { formatWei } from 'src/antelope/stores/utils';
+import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
 
 // A type to represent the possible EVM token types
 export const ERC20_TYPE   = 'ERC20';
@@ -122,7 +123,7 @@ export class TokenPrice {
         // get the BigNumber value
         let tokensAmountBn: ethers.BigNumber = ethers.constants.Zero;
         if (typeof tokensAmount === 'string' || typeof tokensAmount === 'number') {
-            tokensAmountBn = ethers.utils.parseUnits((+tokensAmount).toFixed(16), this.decimals);
+            tokensAmountBn = ethers.utils.parseUnits(toStringNumber(tokensAmount), this.decimals);
         } else {
             tokensAmountBn = tokensAmount;
         }
@@ -140,7 +141,7 @@ export class TokenPrice {
         // get the BigNumber value
         let fiatAmountBn: ethers.BigNumber = ethers.constants.Zero;
         if (typeof fiatAmount === 'string' || typeof fiatAmount === 'number') {
-            fiatAmountBn = ethers.utils.parseUnits((+fiatAmount).toFixed(16), this.decimals);
+            fiatAmountBn = ethers.utils.parseUnits(toStringNumber(fiatAmount), this.decimals);
         } else {
             fiatAmountBn = fiatAmount;
         }
@@ -158,7 +159,7 @@ export class TokenPrice {
         // get the BigNumber value
         let tokensAmountBn: ethers.BigNumber = ethers.constants.Zero;
         if (typeof tokensAmount === 'string' || typeof tokensAmount === 'number') {
-            tokensAmountBn = ethers.utils.parseUnits((+tokensAmount).toFixed(16), this.decimals);
+            tokensAmountBn = ethers.utils.parseUnits(toStringNumber(tokensAmount), this.decimals);
         } else {
             tokensAmountBn = tokensAmount;
         }

--- a/src/antelope/types/TokenClass.ts
+++ b/src/antelope/types/TokenClass.ts
@@ -122,7 +122,7 @@ export class TokenPrice {
         // get the BigNumber value
         let tokensAmountBn: ethers.BigNumber = ethers.constants.Zero;
         if (typeof tokensAmount === 'string' || typeof tokensAmount === 'number') {
-            tokensAmountBn = ethers.utils.parseUnits(tokensAmount.toString(), this.decimals);
+            tokensAmountBn = ethers.utils.parseUnits((+tokensAmount).toFixed(16), this.decimals);
         } else {
             tokensAmountBn = tokensAmount;
         }
@@ -140,7 +140,7 @@ export class TokenPrice {
         // get the BigNumber value
         let fiatAmountBn: ethers.BigNumber = ethers.constants.Zero;
         if (typeof fiatAmount === 'string' || typeof fiatAmount === 'number') {
-            fiatAmountBn = ethers.utils.parseUnits(fiatAmount.toString(), this.decimals);
+            fiatAmountBn = ethers.utils.parseUnits((+fiatAmount).toFixed(16), this.decimals);
         } else {
             fiatAmountBn = fiatAmount;
         }
@@ -158,7 +158,7 @@ export class TokenPrice {
         // get the BigNumber value
         let tokensAmountBn: ethers.BigNumber = ethers.constants.Zero;
         if (typeof tokensAmount === 'string' || typeof tokensAmount === 'number') {
-            tokensAmountBn = ethers.utils.parseUnits(tokensAmount.toString(), this.decimals);
+            tokensAmountBn = ethers.utils.parseUnits((+tokensAmount).toFixed(16), this.decimals);
         } else {
             tokensAmountBn = tokensAmount;
         }
@@ -270,6 +270,11 @@ export class TokenBalance {
 
     // amount is an alias for balance
     get amount(): ethers.BigNumber {
+        return this.balance;
+    }
+
+    // value is an alias for balance
+    get value(): ethers.BigNumber {
         return this.balance;
     }
 

--- a/src/antelope/types/TokenClass.ts
+++ b/src/antelope/types/TokenClass.ts
@@ -63,7 +63,12 @@ export class TokenMarketData {
 
     constructor(sourceInfo: MarketSourceInfo) {
         this.info = sourceInfo;
-        this._price = ethers.utils.parseUnits(sourceInfo.price ?? '0', sourceInfo.decimals || 18);
+        try {
+            this._price = ethers.utils.parseUnits(sourceInfo.price ?? '0', sourceInfo.decimals || 18);
+        } catch (e) {
+            console.error('TokenMarketData: error parsing price from MarketSourceInfo. price', sourceInfo.price, 'decimals', sourceInfo.decimals, '\nError:', e);
+            this._price = ethers.constants.Zero;
+        }
     }
 
     // Returns the token price

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -72,7 +72,7 @@ export async function getFiatPriceFromIndexer(
     const diffInMilliseconds = Math.abs(lastPriceUpdated - now);
     const diffInMinutes = diffInMilliseconds / (1000 * 60);
 
-    // ensure indexer data is no more than 10 minutes old; if it is not use coingecko price
+    // use indexer data if it is no more than 10 minutes old
     if (diffInMinutes < 10) {
         return tokenMarketData.price;
     }

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -76,7 +76,7 @@ export async function getFiatPriceFromIndexer(
     if (diffInMinutes < 10) {
         return tokenMarketData.price;
     }
-
+// if indexer data is stale use coingecko data
     return 0;
 }
 

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -72,7 +72,7 @@ export async function getFiatPriceFromIndexer(
     const diffInMilliseconds = Math.abs(lastPriceUpdated - now);
     const diffInMinutes = diffInMilliseconds / (1000 * 60);
 
-    // use indexer data if it is no more than 10 minutes old
+    // only use indexer data if it is no more than 10 minutes old
     if (diffInMinutes < 10) {
         return tokenMarketData.price;
     }

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -62,7 +62,6 @@ export async function getFiatPriceFromIndexer(
         (tokenData: Record<string, string>) => tokenData.address.toLowerCase() === actualTokenAddress.toLowerCase(),
     );
 
-<<<<<<< HEAD
     if (!tokenMarketData.updated || !tokenMarketData.price) {
         return 0;
     }
@@ -79,9 +78,6 @@ export async function getFiatPriceFromIndexer(
     }
     // if indexer data is stale use coingecko data
     return 0;
-=======
-    return +(tokenMarketData?.price ?? 0);
->>>>>>> 4f767c5cc0881a5846866bed2fa8cf3a5c56ebcb
 }
 
 export const getCoingeckoPriceChartData = async (

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -76,7 +76,7 @@ export async function getFiatPriceFromIndexer(
     if (diffInMinutes < 10) {
         return tokenMarketData.price;
     }
-// if indexer data is stale use coingecko data
+    // if indexer data is stale use coingecko data
     return 0;
 }
 

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -62,7 +62,22 @@ export async function getFiatPriceFromIndexer(
         (tokenData: Record<string, string>) => tokenData.address.toLowerCase() === actualTokenAddress.toLowerCase(),
     );
 
-    return tokenMarketData?.price ?? 0;
+    if (!tokenMarketData.updated || !tokenMarketData.price) {
+        return 0;
+    }
+
+    const lastPriceUpdated = (new Date(+tokenMarketData.updated)).getTime();
+    const now = (new Date()).getTime();
+
+    const diffInMilliseconds = Math.abs(lastPriceUpdated - now);
+    const diffInMinutes = diffInMilliseconds / (1000 * 60);
+
+    // ensure indexer data is no more than 10 minutes old; if it is not use coingecko price
+    if (diffInMinutes < 10) {
+        return tokenMarketData.price;
+    }
+
+    return 0;
 }
 
 export const getCoingeckoPriceChartData = async (

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -107,7 +107,7 @@ export default defineComponent({
             return ant.stores.balances.getBalances('logged');
         },
         showContractLink(): boolean {
-            return !!this.token?.address;
+            return this.token?.address !== NativeCurrencyAddress;
         },
         currencyInputSecondaryCurrencyBindings() {
             const useSecondaryCurrency = !!this.fiatConversionRate;

--- a/src/pages/evm/wallet/WalletBalanceRow.vue
+++ b/src/pages/evm/wallet/WalletBalanceRow.vue
@@ -77,8 +77,6 @@ export default defineComponent({
             }
 
             return prettyPrintCurrency(
-                // TODO: avoid cientific notation on this.token.price.str
-                // https://github.com/telosnetwork/telos-wallet/issues/359
                 +this.token.price.str,
                 4,
                 fiatLocale,
@@ -92,8 +90,6 @@ export default defineComponent({
             if (this.tokenHasFiatValue) {
                 return this.tokenBalanceFiat as number;
             } else {
-                // TODO: avoid cientific notation on this.token.price.str
-                // https://github.com/telosnetwork/telos-wallet/issues/359
                 return +this.balance.str;
             }
         },


### PR DESCRIPTION
# Fixes #359
also fixes #386

## Description
The helper function `ethers.utils.parseUnits` parses a string number to create a `BigNumber` representation but this parsing fails when the string contains a scientific notation. This PR takes care of all the cases when this helper is used making sure no string number gets represented in scientific notation.

## Test scenarios
- you need to download this branch and run it in mainnet
```bash
git fetch --all
git checkout 359-sendpage-gets-broken-when-using-big-token-balances-1
echo 'NETWORK="mainnet"' > .env
yarn; yarn dev
```
- login on EVM using an account with some DOUGE token
   - you should see no changes on balances page
- go to send Page
- open dev tools to see console errors
- select DOUGE token
  - it should not break and continue working as expected


<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
