### PR TITLE
bugfix: calculate fiatBalance using token decimals

### DIFF
--- a/src/antelope/stores/feedback.ts
+++ b/src/antelope/stores/feedback.ts
@@ -105,7 +105,7 @@ export const createTraceFunction = (store_name: string) => function(action: stri
 };
 
 
-export const isTracingAll = () => true;
+export const isTracingAll = () => false;
 export const createInitFunction = (store_name: string, debug?: boolean) => function() {
     useFeedbackStore().setDebug(store_name, debug ?? isTracingAll());
 };


### PR DESCRIPTION
# Fixes #382

## Description
calculate fiatBalance using token decimals instead of fixed 18

## Test scenarios
You need to have an account with USDT


<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
