### PR TITLE
369 sometimes the users balances do not show

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -113,6 +113,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract hasIndexSupport(): boolean;
 
     async getBalances(account: string): Promise<TokenBalance[]> {
+        debugger;
         if (!this.hasIndexSupport()) {
             console.error('Indexer API not supported for this chain:', this.getNetwork());
             return [];

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -113,7 +113,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract hasIndexSupport(): boolean;
 
     async getBalances(account: string): Promise<TokenBalance[]> {
-        debugger;
         if (!this.hasIndexSupport()) {
             console.error('Indexer API not supported for this chain:', this.getNetwork());
             return [];

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -91,6 +91,10 @@ export const useBalancesStore = defineStore(store_name, {
                         if (chain_settings.hasIndexSupport()) {
                             if (account?.account) {
                                 this.__balances[label] = await chain_settings.getBalances(account.account);
+                                // if new account with no index records display default zero TLOS balance
+                                if (this.__balances[label].length === 0){
+                                    await this.updateSystemBalanceForAccount(label, account.account);
+                                }
                                 this.sortBalances(label);
                                 useFeedbackStore().unsetLoading('updateBalancesForAccount');
                             }

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -112,7 +112,7 @@ export const useBalancesStore = defineStore(store_name, {
                                 promises = tokens.map(async (token) => {
                                     fetchBalance({
                                         address: getAccount().address as addressString,
-                                        chainId: getNetwork().chain?.id,
+                                        chainId: +chain_settings.getChainId(),
                                         token: token.address as addressString,
                                     }).then((balanceBn: FetchBalanceResult) => {
                                         this.processBalanceForToken(label, token, balanceBn.value);
@@ -158,7 +158,7 @@ export const useBalancesStore = defineStore(store_name, {
             } else if (localStorage.getItem('wagmi.connected')) {
                 const balanceBn = await fetchBalance({
                     address: getAccount().address as addressString,
-                    chainId: getNetwork().chain?.id,
+                    chainId: +chain_settings.getChainId(),
                 });
                 this.processBalanceForToken(label, token, balanceBn.value);
             } else {

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -278,7 +278,8 @@ export const useEVMStore = defineStore(store_name, {
                             }
                         }
                     } else if ((error as unknown as ExceptionError).code === 4001) {
-                        throw new Error('antelope.evm.switch_chain_rejected');
+                        console.error(new Error('antelope.evm.switch_chain_rejected'));
+                        return false;
                     } else {
                         console.error('Error:', error);
                         throw new Error('antelope.evm.error_switch_chain');

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -130,11 +130,10 @@ export const useEVMStore = defineStore(store_name, {
                     return getAccount().address as string;
                 }
 
-                let checkProvider = await checkNetwork() as ethers.providers.Web3Provider;
+                const checkProvider = await checkNetwork() as ethers.providers.Web3Provider;
 
                 const accounts = await checkProvider.listAccounts();
                 if (accounts.length > 0) {
-                    checkProvider = await this.ensureCorrectChain(checkProvider);
                     return accounts[0];
                 } else {
                     if (!checkProvider.provider.request) {
@@ -144,7 +143,6 @@ export const useEVMStore = defineStore(store_name, {
                     if (accessGranted.length < 1) {
                         return null;
                     }
-                    checkProvider = await this.ensureCorrectChain(checkProvider);
                     return accessGranted[0];
                 }
             } catch (error) {

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -105,12 +105,17 @@ export const useEVMStore = defineStore(store_name, {
                 evm.setSupportsMetaMask(provider?.isMetaMask ?? false);
                 if (provider) {
                     evm.setExternalProvider(provider);
+                    const chainSettings = useChainStore().currentChain.settings;
+                    const network = chainSettings.getNetwork();
                     provider.on('chainChanged', (newNetwork) => {
+                        // if manually switched back to current app network, reload account
+                        if (parseInt(newNetwork, 16) === parseInt(chainSettings.getChainId())){
+                            useAccountStore().loginEVM({ network });
+                        }
                         evm.trace('provider.chainChanged', newNetwork);
                     });
                     provider.on('accountsChanged', async (accounts) => {
                         evm.trace('provider.accountsChanged', accounts);
-                        const network = useChainStore().currentChain.settings.getNetwork();
                         useAccountStore().loginEVM({ network });
                     });
                 }

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -105,16 +105,17 @@ export const useEVMStore = defineStore(store_name, {
                 evm.setSupportsMetaMask(provider?.isMetaMask ?? false);
                 if (provider) {
                     evm.setExternalProvider(provider);
-                    const chainSettings = useChainStore().currentChain.settings;
-                    const network = chainSettings.getNetwork();
+
                     provider.on('chainChanged', (newNetwork) => {
+                        const chainSettings = useChainStore().currentChain.settings;
                         // if manually switched back to current app network, reload account
                         if (parseInt(newNetwork, 16) === parseInt(chainSettings.getChainId())){
-                            useAccountStore().loginEVM({ network });
+                            useAccountStore().loginEVM({ network: chainSettings.getNetwork() });
                         }
                         evm.trace('provider.chainChanged', newNetwork);
                     });
                     provider.on('accountsChanged', async (accounts) => {
+                        const network = useChainStore().currentChain.settings.getNetwork();
                         evm.trace('provider.accountsChanged', accounts);
                         useAccountStore().loginEVM({ network });
                     });

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -107,11 +107,6 @@ export const useEVMStore = defineStore(store_name, {
                     evm.setExternalProvider(provider);
 
                     provider.on('chainChanged', (newNetwork) => {
-                        const chainSettings = useChainStore().currentChain.settings;
-                        // if manually switched back to current app network, reload account
-                        if (parseInt(newNetwork, 16) === parseInt(chainSettings.getChainId())){
-                            useAccountStore().loginEVM({ network: chainSettings.getNetwork() });
-                        }
                         evm.trace('provider.chainChanged', newNetwork);
                     });
                     provider.on('accountsChanged', async (accounts) => {


### PR DESCRIPTION
# Fixes #369 

## Description
see Issue

## Test scenarios

1. login while on wrong network
2. balance(s) should be correct on refresh page while on wrong network
3. balance(s) should be correct on change network
4. for new accounts with no Telos balances, a default zero TLOS balance row should appear.

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages

