### PR TITLE
Fix iOS send bug

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -400,6 +400,8 @@ export default {
         balances: {
             error_at_transfer_tokens: 'An error has occurred trying to transfer tokens',
             error_token_contract_not_found: 'Token contract not found for address {address}',
+            error_system_token_transfer_config: 'Error getting Wagmi system token transfer config',
+            error_token_transfer_config: 'Error getting Wagmi token transfer config',
         },
     },
 };

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -2,7 +2,7 @@
 import { defineComponent } from 'vue';
 import AppPage from 'components/evm/AppPage.vue';
 import UserInfo from 'components/evm/UserInfo.vue';
-import { getAntelope, useAccountStore, useChainStore, useUserStore } from 'src/antelope';
+import { getAntelope, useAccountStore, useBalancesStore, useChainStore, useUserStore } from 'src/antelope';
 import { TransactionResponse, TokenClass, TokenBalance, NativeCurrencyAddress } from 'src/antelope/types';
 import { formatWei, prettyPrintBalance, prettyPrintFiatBalance } from 'src/antelope/stores/utils';
 import { useAppNavStore } from 'src/stores';
@@ -19,6 +19,7 @@ const ant = getAntelope();
 const userStore = useUserStore();
 const accountStore = useAccountStore();
 const chainStore = useChainStore();
+const balanceStore = useBalancesStore();
 const global = useAppNavStore();
 
 export default defineComponent({
@@ -75,6 +76,8 @@ export default defineComponent({
         },
         token: {
             async handler(newToken: TokenClass | null, oldToken: TokenClass | null) {
+                this.updateTokenTransferConfig(this.isFormValid, newToken, this.address, this.amount);
+
                 if (newToken?.address !== oldToken?.address) {
                     this.updateEstimatedGas();
                     this.fiatConversionRate = newToken ? +newToken.price.str : undefined;
@@ -82,6 +85,15 @@ export default defineComponent({
             },
             immediate: true,
             deep: true,
+        },
+        isFormValid(isValid: boolean) {
+            this.updateTokenTransferConfig(isValid, this.token, this.address, this.amount);
+        },
+        address(newAddress) {
+            this.updateTokenTransferConfig(this.isFormValid, this.token, newAddress, this.amount);
+        },
+        amount(newAmount) {
+            this.updateTokenTransferConfig(this.isFormValid, this.token, this.address, newAmount);
         },
     },
     computed: {
@@ -183,6 +195,32 @@ export default defineComponent({
                         ),
                     );
                 }
+            }
+        },
+        updateTokenTransferConfig(formIsValid: boolean, token: TokenClass | null | undefined, address: string, amount: BigNumber) {
+            // due to an issue with metamask/walletconnect on iOS, we must get the wagmi transfer configuration
+            // before the 'Send' button is pressed to reduce the amount of time the click handler takes to execute
+            // see https://github.com/WalletConnect/walletconnect-monorepo/issues/444
+
+            if (!formIsValid || !token?.address || !localStorage.getItem('wagmi.connected')) {
+                balanceStore.clearAllWagmiTokenTransferConfigs('logged');
+                return;
+            }
+
+
+            if (this.token?.isSystem) {
+                balanceStore.prepareWagmiSystemTokenTransferConfig(
+                    'logged',
+                    address,
+                    amount,
+                );
+            } else {
+                balanceStore.prepareWagmiTokenTransferConfig(
+                    'logged',
+                    token,
+                    address,
+                    amount,
+                );
             }
         },
         async startTransfer() {

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -166,6 +166,12 @@ export default defineComponent({
             return !(this.token?.decimals && this.token?.symbol) || this.isLoading;
         },
     },
+    created() {
+        this.clearTokenTransferConfigs();
+    },
+    unmounted() {
+        this.clearTokenTransferConfigs();
+    },
     methods: {
         // TODO: resolve a better dynamic gas estimation. Currently, it's just hardcoded
         // https://github.com/telosnetwork/telos-wallet/issues/274
@@ -197,13 +203,16 @@ export default defineComponent({
                 }
             }
         },
+        clearTokenTransferConfigs() {
+            balanceStore.clearAllWagmiTokenTransferConfigs('logged');
+        },
         updateTokenTransferConfig(formIsValid: boolean, token: TokenClass | null | undefined, address: string, amount: BigNumber) {
             // due to an issue with metamask/walletconnect on iOS, we must get the wagmi transfer configuration
             // before the 'Send' button is pressed to reduce the amount of time the click handler takes to execute
             // see https://github.com/WalletConnect/walletconnect-monorepo/issues/444
 
             if (!formIsValid || !token?.address || !localStorage.getItem('wagmi.connected')) {
-                balanceStore.clearAllWagmiTokenTransferConfigs('logged');
+                this.clearTokenTransferConfigs();
                 return;
             }
 


### PR DESCRIPTION
# Fixes #390 

## Description
There is a bug in prod where attempting to send tokens on iOS opens the app store rather than metamask, causing the transaction to fail. This is due to the fact that the 'Send' button click handler calls several `async` functions, which makes the function take too long--iOS does not allow proper deep linking (to the metamask app in this case) when too much time passes between a user interaction and programmatically opening a deep link.

The fix here is to offload some of the async logic to occur _before_ the user clicks 'Send'. Now, whenever the token, address, form validity, or token amount changes, the Wagmi transfer configuration is fetched and placed in the store if all the parameters are valid (if wagmi is connected -- if it is not, nothing happens). if the parameters are not valid, the transfer configuration is set to null. This logic was occurring after the user pressed 'Send', but now it occurs whenever they change a value on the page, before pressing 'Send'

## Test scenarios
 This PR needs to be tested on all permutations of: Walletconnect, not wallet connect, iOS, android, desktop, sending TLOS, sending a non-TLOS token. I have tested these but they must be validated by others just in case. 

On each platform and sign in method, go to the send page and try to send yourself some TLOS, then send yourself some other token like STLOS or Tether. In all cases, the transfer should go through.

- [ ] WalletConnect (iOS)
- [x] WalletConnect (Android)
- [x] Desktop MetaMask
- [x] Desktop WalletConnect

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
