### PR TITLE
avoiding landing on demo pages on production

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,5 +25,12 @@ export default function (/* { store, ssrContext } */) {
         history: createHistory(process.env.VUE_ROUTER_BASE),
     });
 
+    // this prevents the general public from accessing the demo pages
+    Router.beforeEach((to, from) => {
+        if (to.meta.notInProduction && process.env.NODE_ENV === 'production') {
+            return { name: 'home' };
+        }
+    });
+
     return Router;
 }

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -57,6 +57,7 @@ const routes = [
     {
         path: '/demos',
         name: 'demos',
+        meta: { notInProduction: true },
         component: () => import('pages/demo/DemoLayout.vue'),
         children: [
             {


### PR DESCRIPTION
# Fixes #290 

## Description
The router configuration was changed to prevent users from accessing demo routes on only production. All other deployments should work like they did before.

## Test scenarios
- Go to this [Demo index page](https://deploy-preview-408--wallet-staging.netlify.app/demos)
   - you should be redirected to home page

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
