### PR TITLE
making Indexer usage to be a dynamic decision

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -16,11 +16,12 @@ import {
     TokenBalance,
     MarketSourceInfo,
     TokenMarketData,
+    IndexerHealthResponse,
 } from 'src/antelope/types';
 import EvmContract from 'src/antelope/stores/utils/contracts/EvmContract';
 import { ethers } from 'ethers';
 import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
-
+import { getAntelope } from 'src/antelope';
 
 export default abstract class EVMChainSettings implements ChainSettings {
     // Short Name of the network
@@ -34,6 +35,15 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // External indexer API support
     protected indexer: AxiosInstance = axios.create({ baseURL: this.getIndexerApiEndpoint() });
+
+    // indexer health check promise
+    protected _indexerHealthState: {
+        promise: Promise<IndexerHealthResponse> | null;
+        state: IndexerHealthResponse
+    } = {
+        promise: null,
+        state: this.deathHealthResponse,
+    };
 
     // Token list promise
     tokenListPromise: Promise<TokenClass[]> | null = null;
@@ -77,6 +87,64 @@ export default abstract class EVMChainSettings implements ChainSettings {
         this.hyperion.interceptors.response.use(responseHandler, erorrHandler);
         this.indexer.interceptors.response.use(responseHandler, erorrHandler);
 
+        // Check indexer health state periodically
+        this.updateIndexerHealthState();
+        // this setTimeout is a work arround because we can't call getAntelope() function before it initializes
+        setTimeout(() => {
+            setInterval(() => {
+                this.updateIndexerHealthState();
+            }, getAntelope().config.indexerHealthCheckInterval);
+        }, 1000);
+    }
+
+    get deathHealthResponse() {
+        return {
+            success: false,
+            blockNumber: 0,
+            blockTimestamp: '',
+            secondsBehind: Number.POSITIVE_INFINITY,
+        } as IndexerHealthResponse;
+    }
+
+    async updateIndexerHealthState() {
+        // resolve if this chain has indexer api support and is working fine
+
+        const promise =
+            Promise.resolve(this.hasIndexerSupport())
+                .then(hasIndexerSupport =>
+                    hasIndexerSupport ?
+                        this.indexer.get('/v1/health') :
+                        Promise.resolve({ data: this.deathHealthResponse } as AxiosResponse<IndexerHealthResponse>),
+                )
+                .then(response => response.data as unknown as IndexerHealthResponse)
+                .catch((error) => {
+                    console.error('Indexer API not working for this chain:', this.getNetwork(), error);
+                    return this.deathHealthResponse as IndexerHealthResponse;
+                });
+
+        // initial state
+        this._indexerHealthState = {
+            promise,
+            state: this.deathHealthResponse,
+        };
+
+        // update indexer health state
+        promise.then((state) => {
+            this._indexerHealthState.state = state;
+        });
+
+        return promise;
+    }
+
+    isIndexerHealthy(): boolean {
+        return (
+            this._indexerHealthState.state.success &&
+            this._indexerHealthState.state.secondsBehind < getAntelope().config.indexerHealthThreshold
+        );
+    }
+
+    get indexerHealthState(): IndexerHealthResponse {
+        return this._indexerHealthState.state;
     }
 
     isNative() {
@@ -111,10 +179,10 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract getTrustedContractsBucket(): string;
     abstract getImportantTokensIdList(): string[];
     abstract getIndexerApiEndpoint(): string;
-    abstract hasIndexSupport(): boolean;
+    abstract hasIndexerSupport(): boolean;
 
     async getBalances(account: string): Promise<TokenBalance[]> {
-        if (!this.hasIndexSupport()) {
+        if (!this.hasIndexerSupport()) {
             console.error('Indexer API not supported for this chain:', this.getNetwork());
             return [];
         }

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -144,7 +144,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     hasIndexSupport(): boolean {
-        return false;
+        return true;
     }
 
 }

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -94,7 +94,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     async getUsdPrice(): Promise<number> {
-        if (this.hasIndexSupport()) {
+        if (this.hasIndexerSupport()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
             const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
@@ -143,7 +143,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         return INDEXER_ENDPOINT;
     }
 
-    hasIndexSupport(): boolean {
+    hasIndexerSupport(): boolean {
         return true;
     }
 

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -94,7 +94,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     async getUsdPrice(): Promise<number> {
-        if (this.hasIndexSupport()) {
+        if (this.hasIndexerSupport()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
             const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
@@ -143,7 +143,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         return INDEXER_ENDPOINT;
     }
 
-    hasIndexSupport(): boolean {
+    hasIndexerSupport(): boolean {
         return true;
     }
 }

--- a/src/antelope/config/index.ts
+++ b/src/antelope/config/index.ts
@@ -3,6 +3,9 @@ import { App } from 'vue';
 import { getAntelope } from '..';
 
 export class AntelopeConfig {
+    // indexer health threshold --
+    private __indexer_health_threshold = 10;
+
     // notifucation handlers --
     private __notify_error_handler: (message: string) => void = m => alert(`Error: ${m}`);
     private __notify_success_handler: (message: string) => void = alert;
@@ -64,6 +67,10 @@ export class AntelopeConfig {
 
     get app() {
         return this.__app;
+    }
+
+    get indexerHealthThreshold() {
+        return this.__indexer_health_threshold;
     }
 
     get notifyErrorHandler() {

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -101,7 +101,8 @@ export const useBalancesStore = defineStore(store_name, {
                 } else {
                     const chain_settings = chain.settings as EVMChainSettings;
                     if (account?.account) {
-                        if (chain_settings.hasIndexSupport()) {
+                        if (chain_settings.isIndexerHealthy()) {
+                            this.trace('updateBalancesForAccount', 'Indexer OK!');
                             if (account?.account) {
                                 this.__balances[label] = await chain_settings.getBalances(account.account);
                                 // if new account with no index records display default zero TLOS balance
@@ -112,6 +113,7 @@ export const useBalancesStore = defineStore(store_name, {
                                 useFeedbackStore().unsetLoading('updateBalancesForAccount');
                             }
                         } else {
+                            this.trace('updateBalancesForAccount', 'Indexer is NOT healthy!', chain_settings.getNetwork(), toRaw(chain_settings.indexerHealthState));
                             // In case the chain does not support index, we need to fetch the balances using Web3
                             this.__balances[label] = this.__balances[label] ?? [];
                             const tokens = await chain_settings.getTokenList();

--- a/src/antelope/stores/feedback.ts
+++ b/src/antelope/stores/feedback.ts
@@ -105,7 +105,15 @@ export const createTraceFunction = (store_name: string) => function(action: stri
 };
 
 
-export const isTracingAll = () => false;
+// only if we are NOT in production mode search in the url for the trace flag
+// to turn on the Antelope trace mode
+let trace = false;
+if (process.env.NODE_ENV !== 'production') {
+    const urlParams = new URLSearchParams(window.location.search);
+    trace = urlParams.get('trace') === 'true';
+}
+
+export const isTracingAll = () => trace;
 export const createInitFunction = (store_name: string, debug?: boolean) => function() {
     useFeedbackStore().setDebug(store_name, debug ?? isTracingAll());
 };

--- a/src/antelope/types/IndexerTypes.ts
+++ b/src/antelope/types/IndexerTypes.ts
@@ -44,3 +44,10 @@ export interface IndexerAccountBalances {
     };
     results: IndexerTokenBalance[];
 }
+
+export interface IndexerHealthResponse {
+    success: boolean;
+    blockNumber: number;
+    blockTimestamp: string;
+    secondsBehind: number;
+}

--- a/test/jest/__tests__/antelope/stores/balances.spec.ts
+++ b/test/jest/__tests__/antelope/stores/balances.spec.ts
@@ -65,7 +65,7 @@ jest.mock('src/antelope/stores/chain', () => ({
                 getSystemToken: jest.fn().mockImplementation(() => tokenSys),
                 getUsdPrice: jest.fn().mockImplementation(() => 1),
                 getImportantTokensIdList: jest.fn().mockImplementation(() => []),
-                hasIndexSupport: jest.fn().mockImplementation(() => false),
+                hasIndexerSupport: jest.fn().mockImplementation(() => false),
             },
         })),
         loggedChain: {


### PR DESCRIPTION
# Fixes #376

## Description
Although most of the time we can rely on the indexer to work as expected, there will be unexpected moments in which its heath will not be the best and we need an automatic way to switch to the second-best solution for everything the indexer provides us with.

This PR implements an initial query for the current health of all endpoints of all supported chains and updates that information every 5 minutes.

## Test scenarios



<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
-   [ ] I have added appropriate test coverage 
