### PR TITLE
Big token Names display with ellipsis

### DIFF
--- a/src/pages/evm/wallet/WalletBalanceRow.vue
+++ b/src/pages/evm/wallet/WalletBalanceRow.vue
@@ -236,7 +236,7 @@ export default defineComponent({
             :alt="$t('evm_wallet.token_logo_alt')"
         >
         <div>
-            {{ token.name }}
+            <span class="c-wallet-balance-row__token_name">{{ token.name }}</span>
             <br>
             <span class="o-text--small">{{ fiatRateText }}</span>
         </div>
@@ -334,6 +334,13 @@ export default defineComponent({
     &__left-container,
     &__right-container {
         width: max-content;
+    }
+
+    &__token_name {
+        width: calc(100vw - 200px);
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     &__left-container {

--- a/src/pages/evm/wallet/WalletBalanceRow.vue
+++ b/src/pages/evm/wallet/WalletBalanceRow.vue
@@ -337,7 +337,7 @@ export default defineComponent({
     }
 
     &__token_name {
-        width: calc(100vw - 200px);
+        max-width: calc(100vw - 200px);
         display: inline-block;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/test/jest/__tests__/pages/evm/wallet/__snapshots__/WalletBalanceRow.spec.ts.snap
+++ b/test/jest/__tests__/pages/evm/wallet/__snapshots__/WalletBalanceRow.spec.ts.snap
@@ -16,7 +16,11 @@ exports[`WalletBalanceRow.vue should render correctly on desktop devices (Staked
       width="40"
     />
     <div>
-      Staked TLOS 
+      <span
+        class="c-wallet-balance-row__token_name"
+      >
+        Staked TLOS
+      </span>
       <br />
       <span
         class="o-text--small"
@@ -138,7 +142,11 @@ exports[`WalletBalanceRow.vue should render correctly on mobile devices (Staked 
       width="40"
     />
     <div>
-      Staked TLOS 
+      <span
+        class="c-wallet-balance-row__token_name"
+      >
+        Staked TLOS
+      </span>
       <br />
       <span
         class="o-text--small"
@@ -265,7 +273,11 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
       width="40"
     />
     <div>
-      Staked TLOS 
+      <span
+        class="c-wallet-balance-row__token_name"
+      >
+        Staked TLOS
+      </span>
       <br />
       <span
         class="o-text--small"
@@ -390,7 +402,11 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
       width="40"
     />
     <div>
-      Telos 
+      <span
+        class="c-wallet-balance-row__token_name"
+      >
+        Telos
+      </span>
       <br />
       <span
         class="o-text--small"
@@ -517,7 +533,11 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
       width="40"
     />
     <div>
-      Wrapped TLOS 
+      <span
+        class="c-wallet-balance-row__token_name"
+      >
+        Wrapped TLOS
+      </span>
       <br />
       <span
         class="o-text--small"
@@ -644,7 +664,11 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
       width="40"
     />
     <div>
-      Shiba 
+      <span
+        class="c-wallet-balance-row__token_name"
+      >
+        Shiba
+      </span>
       <br />
       <span
         class="o-text--small"


### PR DESCRIPTION
# Fixes #430

## Description
When the token name is too large, it overlaps with the balance number. This was fixed in this PR

![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/806fa321-6ab2-413d-a03e-99d61bc25a9c)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
