### PR TITLE
available amount for sending is never negative

### DIFF
--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -146,7 +146,13 @@ export default defineComponent({
             if (!this.selected.balance) {
                 return ethers.constants.Zero;
             }
-            return this.selected.balance.sub(this.selected.isSystem ? this.estimatedGas.system : ethers.constants.Zero);
+            // Let's ensure the returned value is not negative
+            const available = this.selected.balance.sub(this.selected.isSystem ? this.estimatedGas.system : ethers.constants.Zero);
+            if (available.gt(ethers.constants.Zero)) {
+                return available;
+            } else {
+                return ethers.constants.Zero;
+            }
         },
         isAddressValid(): boolean {
             const regex = /^0x[a-fA-F0-9]{40}$/;


### PR DESCRIPTION
# Fixes #345

## Description
This PR fixes the case when the user has a zero balance on TLOS and the send page calculates the available amount by subtracting the fees. Now that value is never negative.

## Test scenarios
- go to [this link](https://deploy-preview-439--wallet-staging.netlify.app/)
- lo gin with a TLOS zero balance account
- goto send page
  - you should see zero as the available amount to send (see screenshot)

 ## Screenshot
![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/1acfa694-b839-424a-a079-2015fb19fc92)


<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
