### PR TITLE
transaction history fetches data in parallel much faster

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,11 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "octref.vetur"
+    "vue.volar",
+    "streetsidesoftware.code-spell-checker",
+    "abdelaziz18003.quasar-snippets",
+    "syler.sass-indented",
+    "mrmlnc.vscode-scss",
   ],
   "unwantedRecommendations": [
     "hookyqr.beautify",

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -30,6 +30,11 @@ import { getAntelope } from 'src/antelope';
 
 
 export default abstract class EVMChainSettings implements ChainSettings {
+    // to avoid init() being called twice
+    protected ready = false;
+
+    protected initPromise: Promise<void>;
+
     // Short Name of the network
     protected network: string;
 
@@ -94,13 +99,41 @@ export default abstract class EVMChainSettings implements ChainSettings {
         this.indexer.interceptors.response.use(responseHandler, erorrHandler);
 
         // Check indexer health state periodically
-        this.updateIndexerHealthState();
+        this.initPromise = new Promise((resolve) => {
+            this.updateIndexerHealthState().then(() => {
+                // we resolve the promise that will be returned by init()
+                resolve();
+            });
+        });
+    }
+
+    async init(): Promise<void> {
+        // this is called only when this chain is needed to avoid initialization of all chains
+        if (this.ready) {
+            return this.initPromise;
+        }
+        this.ready = true;
+
         // this setTimeout is a work arround because we can't call getAntelope() function before it initializes
         setTimeout(() => {
             setInterval(() => {
                 this.updateIndexerHealthState();
             }, getAntelope().config.indexerHealthCheckInterval);
         }, 1000);
+
+        // Update system token price
+        this.getUsdPrice().then((value:number) => {
+            const sys_token = this.getSystemToken();
+            const price = value.toString();
+            const marketInfo = { price } as MarketSourceInfo;
+            const marketData = new TokenMarketData(marketInfo);
+            sys_token.market = marketData;
+
+            const wsys_token = this.getWrappedSystemToken();
+            wsys_token.market = marketData;
+        });
+
+        return this.initPromise;
     }
 
     get deathHealthResponse() {
@@ -183,7 +216,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
     abstract getExplorerUrl(): string;
     abstract getEcosystemUrl(): string;
     abstract getTrustedContractsBucket(): string;
-    abstract getImportantTokensIdList(): string[];
+    abstract getSystemTokens(): TokenClass[];
     abstract getIndexerApiEndpoint(): string;
     abstract hasIndexerSupport(): boolean;
 

--- a/src/antelope/chains/NativeChainSettings.ts
+++ b/src/antelope/chains/NativeChainSettings.ts
@@ -49,6 +49,8 @@ export const DEFAULT_ICON = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjciIGhla
 const abortController = new AbortController();
 
 export default abstract class NativeChainSettings implements ChainSettings {
+    // to avoid init() being called twice
+    protected ready = false;
 
     // Short Name of the network
     protected network: string;
@@ -103,6 +105,14 @@ export default abstract class NativeChainSettings implements ChainSettings {
 
     }
 
+    async init(): Promise<void> {
+        // this is called only when this chain is needed to avoid initialization of all chains at once
+        if (this.ready) {
+            return;
+        }
+        this.ready = true;
+    }
+
     isNative() {
         return true;
     }
@@ -140,7 +150,7 @@ export default abstract class NativeChainSettings implements ChainSettings {
      * @returns An array of strings representing the IDs of the important tokens.
      * Each ID follows the format: <symbol>-<contract>-<chainId>.
      */
-    abstract getImportantTokensIdList(): string[];
+    abstract getSystemTokens(): TokenClass[];
 
     async getNFTsInventory(owner: string, filter: IndexerTransactionsFilter): Promise<NFTClass[]> {
         throw new Error('Method not implemented yet getNFTsInventory() ' + + JSON.stringify({ ...filter, owner }));

--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -28,6 +28,7 @@ const S_TOKEN = new TokenClass({
     network: NETWORK,
     decimals: 18,
     address: '0xa9991E4daA44922D00a78B6D986cDf628d46C4DD',
+    logo: 'https://raw.githubusercontent.com/telosnetwork/teloscan/master/public/stlos-logo.png',
     isNative: false,
     isSystem: false,
 } as TokenSourceInfo);
@@ -38,6 +39,7 @@ const W_TOKEN = new TokenClass({
     network: NETWORK,
     decimals: 18,
     address: '0xaE85Bf723A9e74d6c663dd226996AC1b8d075AA9',
+    logo: 'https://raw.githubusercontent.com/telosnetwork/images/master/logos_2021/Symbol%202.svg',
     isNative: false,
     isSystem: false,
 } as TokenSourceInfo);
@@ -97,7 +99,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         if (this.hasIndexerSupport()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
-            const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
+            const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer, this);
 
             if (fiatPrice !== 0) {
                 return fiatPrice;
@@ -135,8 +137,8 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         return 'https://www.telos.net/#buy-tlos-simplex';
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id, S_TOKEN.id, W_TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN, S_TOKEN, W_TOKEN];
     }
 
     getIndexerApiEndpoint(): string {

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -28,6 +28,7 @@ const S_TOKEN = new TokenClass({
     network: NETWORK,
     decimals: 18,
     address: '0xB4B01216a5Bc8F1C8A33CD990A1239030E60C905',
+    logo: 'https://raw.githubusercontent.com/telosnetwork/teloscan/master/public/stlos-logo.png',
     isNative: false,
     isSystem: false,
 } as TokenSourceInfo);
@@ -38,6 +39,7 @@ const W_TOKEN = new TokenClass({
     network: NETWORK,
     decimals: 18,
     address: '0xD102cE6A4dB07D247fcc28F366A623Df0938CA9E',
+    logo: 'https://raw.githubusercontent.com/telosnetwork/images/master/logos_2021/Symbol%202.svg',
     isNative: false,
     isSystem: false,
 } as TokenSourceInfo);
@@ -97,7 +99,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         if (this.hasIndexerSupport()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
-            const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer);
+            const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer, this);
 
             if (fiatPrice !== 0) {
                 return fiatPrice;
@@ -135,8 +137,8 @@ export default class TelosEVMTestnet extends EVMChainSettings {
         return 'https://www.telos.net/#buy-tlos-simplex';
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id, S_TOKEN.id, W_TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN, S_TOKEN, W_TOKEN];
     }
 
     getIndexerApiEndpoint(): string {

--- a/src/antelope/chains/native/eos/index.ts
+++ b/src/antelope/chains/native/eos/index.ts
@@ -99,7 +99,7 @@ export default class EOS extends NativeChainSettings {
         return true;
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN];
     }
 }

--- a/src/antelope/chains/native/jungle/index.ts
+++ b/src/antelope/chains/native/jungle/index.ts
@@ -94,7 +94,7 @@ export default class TelosTestnet extends NativeChainSettings {
         return true;
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN];
     }
 }

--- a/src/antelope/chains/native/telos-testnet/index.ts
+++ b/src/antelope/chains/native/telos-testnet/index.ts
@@ -113,7 +113,7 @@ export default class TelosTestnet extends NativeChainSettings {
         return true;
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN];
     }
 }

--- a/src/antelope/chains/native/telos/index.ts
+++ b/src/antelope/chains/native/telos/index.ts
@@ -120,7 +120,7 @@ export default class Telos extends NativeChainSettings {
         return true;
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN];
     }
 }

--- a/src/antelope/chains/native/ux/index.ts
+++ b/src/antelope/chains/native/ux/index.ts
@@ -94,7 +94,7 @@ export default class UX extends NativeChainSettings {
         return true;
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN];
     }
 }

--- a/src/antelope/chains/native/wax/index.ts
+++ b/src/antelope/chains/native/wax/index.ts
@@ -94,7 +94,7 @@ export default class EOS extends NativeChainSettings {
         return true;
     }
 
-    getImportantTokensIdList(): string[] {
-        return [TOKEN.id];
+    getSystemTokens(): TokenClass[] {
+        return [TOKEN];
     }
 }

--- a/src/antelope/index.ts
+++ b/src/antelope/index.ts
@@ -37,6 +37,7 @@ const events = {
     onLoggedOut: new Subject<void>(),
     onNetworkChanged: new Subject<{label:string, chain:ChainModel}>(),
     onAccountChanged: new Subject<{label:string, account:AccountModel|null}>(),
+    onChainIndexer: new Subject<{label:string, isHealthy:boolean}>(),
     onErrorMessage: new Subject<{name: string, message:string}>(),
 };
 export const getEvents = () => events;

--- a/src/antelope/stores/account.ts
+++ b/src/antelope/stores/account.ts
@@ -93,6 +93,7 @@ export const useAccountStore = defineStore(store_name, {
         currentIsLogged: state =>
             state.__accounts['logged']?.account === state.__accounts['current']?.account &&
             state.__accounts['logged']?.network === state.__accounts['current']?.network,
+        getAccount: state => (label: Label) => ({ ...state.__accounts[label] }),
     },
     actions: {
         trace: createTraceFunction(store_name),

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -17,8 +17,6 @@ import {
     AntelopeError,
     EvmTransactionResponse,
     Label,
-    TokenMarketData,
-    MarketSourceInfo,
     NativeTransactionResponse,
     TokenBalance,
     TokenClass,
@@ -72,16 +70,29 @@ export const useBalancesStore = defineStore(store_name, {
         trace: createTraceFunction(store_name),
         init: () => {
             useFeedbackStore().setDebug(store_name, isTracingAll());
+            const self = useBalancesStore();
             getAntelope().events.onAccountChanged.subscribe({
                 next: async ({ label, account }) => {
-                    await useBalancesStore().updateBalancesForAccount(label, toRaw(account));
+                    await self.updateBalancesForAccount(label, toRaw(account));
+                },
+            });
+
+            getAntelope().events.onChainIndexer.subscribe({
+                next: async ({ label, isHealthy }) => {
+                    if (isHealthy) {
+                        self.trace('init', 'onChainIndexer:', label, isHealthy);
+                        const account = useAccountStore().getAccount(label);
+                        if (account?.account) {
+                            await self.updateBalancesForAccount(label, account);
+                        }
+                    }
                 },
             });
 
             // update logged balances every 10 seconds only if the user is logged
             setInterval(async () => {
                 if (useAccountStore().loggedAccount) {
-                    await useBalancesStore().updateBalancesForAccount('logged', useAccountStore().loggedAccount);
+                    await self.updateBalancesForAccount('logged', useAccountStore().loggedAccount);
                 }
             }, 10000);
 
@@ -101,52 +112,35 @@ export const useBalancesStore = defineStore(store_name, {
                 } else {
                     const chain_settings = chain.settings as EVMChainSettings;
                     if (account?.account) {
+                        this.__balances[label] = this.__balances[label] ?? [];
                         if (chain_settings.isIndexerHealthy()) {
                             this.trace('updateBalancesForAccount', 'Indexer OK!');
                             if (account?.account) {
-                                this.__balances[label] = await chain_settings.getBalances(account.account);
+                                const balances = await chain_settings.getBalances(account.account);
                                 // if new account with no index records display default zero TLOS balance
-                                if (this.__balances[label].length === 0){
-                                    await this.updateSystemBalanceForAccount(label, account.account);
+                                if (balances.length > 0){
+                                    this.__balances[label] = balances;
                                 }
+                                await this.updateSystemBalancesForAccount(label, account.account);
                                 this.sortBalances(label);
                                 useFeedbackStore().unsetLoading('updateBalancesForAccount');
                             }
                         } else {
                             this.trace('updateBalancesForAccount', 'Indexer is NOT healthy!', chain_settings.getNetwork(), toRaw(chain_settings.indexerHealthState));
                             // In case the chain does not support index, we need to fetch the balances using Web3
-                            this.__balances[label] = this.__balances[label] ?? [];
+
+                            // first, we add the system token
+                            await this.updateSystemBalanceForAccount(label, account.account, chain_settings.getSystemToken());
+
+                            // then we iterate over the tokens, fetch the balance for each and add them to the list
                             const tokens = await chain_settings.getTokenList();
-                            await this.updateSystemBalanceForAccount(label, account.account);
-                            this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
-                            const evm = useEVMStore();
-                            let promises: Promise<void>[] = [];
-
-                            if (localStorage.getItem('wagmi.connected')) {
-
-                                promises = tokens.map(async (token) => {
-                                    fetchBalance({
-                                        address: getAccount().address as addressString,
-                                        chainId: +chain_settings.getChainId(),
-                                        token: token.address as addressString,
-                                    }).then((balanceBn: FetchBalanceResult) => {
-                                        this.processBalanceForToken(label, token, balanceBn.value);
-                                    });
-                                });
-
-                            } else {
-                                promises = tokens
-                                    .map(token => evm.getERC20TokenBalance(account.account, token.address)
-                                        .then((balanceBn: BigNumber) => {
-                                            this.processBalanceForToken(label, token, balanceBn);
-                                        }),
-                                    );
-
-                            }
+                            const promises = tokens.map(
+                                async token => this.updateERC20BalanceForAccount(label, account.account, token),
+                            );
 
                             Promise.allSettled(promises).then(() => {
                                 useFeedbackStore().unsetLoading('updateBalancesForAccount');
-                                this.trace('updateBalancesForAccount', 'balances:', toRaw(this.__balances[label]));
+                                this.trace('updateBalancesForAccount', 'balances:', toRaw(this.__balances[label]).map(t => t.toString()));
                             });
                         }
                     }
@@ -156,16 +150,20 @@ export const useBalancesStore = defineStore(store_name, {
                 console.error('Error: ', errorToString(error));
             }
         },
-
-        async updateSystemBalanceForAccount(label: string, address: string): Promise<void> {
+        async updateSystemBalancesForAccount(label: string, address: string): Promise<void> {
+            const chain_settings = useChainStore().getChain(label).settings;
+            chain_settings.getSystemTokens().forEach(async (token) => {
+                if (token.isSystem) {
+                    this.updateSystemBalanceForAccount(label, address, token);
+                } else {
+                    this.updateERC20BalanceForAccount(label, address, token);
+                }
+            });
+        },
+        async updateSystemBalanceForAccount(label: string, address: string, token: TokenClass): Promise<void> {
             const evm = useEVMStore();
             const provider = toRaw(evm.rpcProvider);
-            const chain_settings = useChainStore().getChain(label).settings as EVMChainSettings;
-            const token = chain_settings.getSystemToken();
-            const price = (await chain_settings.getUsdPrice()).toString();
-            const marketInfo = { price } as MarketSourceInfo;
-            const marketData = new TokenMarketData(marketInfo);
-            token.market = marketData;
+            const chain_settings = useChainStore().getChain(label).settings;
 
             if (provider) {
                 const balanceBn = await provider.getBalance(address);
@@ -180,8 +178,27 @@ export const useBalancesStore = defineStore(store_name, {
                 throw new AntelopeError('antelope.evm.error_no_provider');
             }
         },
+        async updateERC20BalanceForAccount(label: string, address: string, token: TokenClass): Promise<void> {
+            const chain_settings = useChainStore().getChain(label).settings;
+            const evm = useEVMStore();
+            if (localStorage.getItem('wagmi.connected')) {
+                console.assert(getAccount().address === address, `${getAccount().address} is different from ${address}`);
+                fetchBalance({
+                    address: address as addressString,
+                    chainId: +chain_settings.getChainId(),
+                    token: token.address as addressString,
+                }).then((balanceBn: FetchBalanceResult) => {
+                    this.processBalanceForToken(label, token, balanceBn.value);
+                });
+            } else {
+                return evm.getERC20TokenBalance(address, token.address)
+                    .then((balanceBn: BigNumber) => {
+                        this.processBalanceForToken(label, token, balanceBn);
+                    });
+            }
+        },
         shouldAddTokenBalance(label: string, balanceBn: BigNumber, token: TokenClass): boolean {
-            const importantTokens = useChainStore().getChain(label).settings.getImportantTokensIdList();
+            const importantTokens = useChainStore().getChain(label).settings.getSystemTokens().map(t => t.id);
             let result = false;
             if (importantTokens.includes(token.id)) {
                 // if the token is important, we always add it. Even with 0 balance.

--- a/src/antelope/stores/chain.ts
+++ b/src/antelope/stores/chain.ts
@@ -125,6 +125,7 @@ export const useChainStore = defineStore(store_name, {
             useFeedbackStore().setLoading('updateChainData');
             try {
                 await Promise.all([
+                    this.updateSettings(label),
                     this.updateApy(label),
                     this.updateGasPrice(label),
                 ]);
@@ -134,6 +135,14 @@ export const useChainStore = defineStore(store_name, {
             } finally {
                 useFeedbackStore().unsetLoading('updateChainData');
             }
+        },
+        async updateSettings(label: string) {
+            this.getChain(label).settings.init().then(() => {
+                getAntelope().events.onChainIndexer.next({ label, isHealthy: true });
+            }).catch((error) => {
+                console.error(error);
+                throw new Error('antelope.chain.error_settings');
+            });
         },
         async updateApy(label: string) {
             useFeedbackStore().setLoading('updateApy');

--- a/src/antelope/stores/contract.ts
+++ b/src/antelope/stores/contract.ts
@@ -28,7 +28,7 @@ import { ethers } from 'ethers';
 export interface ContractStoreState {
     __factory: EvmContractFactory;
     __cachedContracts: Record<string, EvmContract>
-    __processing: string[];
+    __processing: Record<string, Promise<EvmContract | null>>
 }
 
 const store_name = 'contract';
@@ -46,33 +46,37 @@ export const useContractStore = defineStore(store_name, {
         async getContract(address: string): Promise<EvmContract | null> {
             const addressLower = address.toLowerCase();
 
+            // if we have it in cache, return it
             if (typeof this.__cachedContracts[addressLower] !== 'undefined') {
                 return this.__cachedContracts[addressLower];
             }
 
-            if (this.__processing.includes(addressLower)) {
-                await new Promise(resolve => setTimeout(resolve, 300));
-                return this.getContract(address);
+            // maybe we already starting processing it, return the promise
+            if (typeof this.__processing[addressLower] !== 'undefined') {
+                return this.__processing[addressLower];
             }
-            this.__processing.push(addressLower);
 
-            const index = this.__processing.indexOf(addressLower);
-            let contract = { address: address };
-            try {
-                const indexer = (useChainStore().loggedChain.settings as EVMChainSettings).getIndexer();
-                const response = await indexer.get(`/contract/${address}?full=true&includeAbi=true`);
+            // ok, we need to fetch it
+            this.__processing[addressLower] = new Promise(async (resolve) => {
 
-                if (response.data?.success && response.data.results.length > 0){
-                    contract = response.data.results[0];
+                let contract = { address: address };
+                try {
+                    const indexer = (useChainStore().loggedChain.settings as EVMChainSettings).getIndexer();
+                    const response = await indexer.get(`/contract/${address}?full=true&includeAbi=true`);
+                    if (response.data?.success && response.data.results.length > 0){
+                        contract = response.data.results[0];
+                    }
+                } catch (e) {
+                    console.warn(`Could not retrieve contract ${address}: ${e}`);
+                    resolve(null);
                 }
-            } catch (e) {
-                console.warn(`Could not retrieve contract ${address}: ${e}`);
-                this.__processing.splice(index, 1);
-                return null;
-            }
-            this.addContractToCache(address, contract);
-            this.__processing.splice(index, 1);
-            return this.$state.__factory.buildContract(contract);
+                this.addContractToCache(address, contract);
+
+                resolve(this.$state.__factory.buildContract(contract));
+            });
+
+            // return the promise
+            return this.__processing[addressLower];
         },
 
         async getTransfersFromTransaction(transaction: EvmTransaction): Promise<Erc20Transfer[]> {
@@ -153,6 +157,6 @@ export const useContractStore = defineStore(store_name, {
 
 const contractInitialState: ContractStoreState = {
     __cachedContracts: {},
-    __processing: [],
+    __processing: {},
     __factory: new EvmContractFactory(),
 };

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -15,13 +15,10 @@
 
 import { defineStore } from 'pinia';
 import {
-    getAntelope,
+    createTraceFunction,
+    isTracingAll,
     useFeedbackStore,
-    useChainStore,
-    useContractStore,
-    useUserStore,
-} from 'src/antelope';
-import { createTraceFunction, isTracingAll } from 'src/antelope/stores/feedback';
+} from 'src/antelope/stores/feedback';
 import {
     Label,
     EvmTransaction,
@@ -32,8 +29,10 @@ import {
     EVMTransactionsPaginationData, TransactionValueData, EvmSwapFunctionNames,
 } from 'src/antelope/types';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+import { useChainStore } from 'src/antelope/stores/chain';
 import { toRaw } from 'vue';
 import { BigNumber } from 'ethers';
+import { getAntelope, useContractStore, useUserStore } from '..';
 import { formatUnits } from 'ethers/lib/utils';
 import { getGasInTlos, WEI_PRECISION } from 'src/antelope/stores/utils';
 import { convertCurrency } from 'src/antelope/stores/utils/currency-utils';
@@ -47,16 +46,16 @@ export interface HistoryState {
         [label: Label]: {
             transactions: EvmTransaction[],
         },
-    };
+    }
     __total_evm_transaction_count: {
         [label: Label]: number,
-    };
+    },
     __shaped_evm_transaction_rows: {
         [label: Label]: ShapedTransactionRow[],
     };
     __evm_transactions_pagination_data: {
         [label: Label]: EVMTransactionsPaginationData,
-    };
+    },
 }
 
 const store_name = 'history';
@@ -86,17 +85,16 @@ export const useHistoryStore = defineStore(store_name, {
 
         // actions ---
         async fetchEVMTransactionsForAccount(label: Label = 'current') {
+            this.trace('fetchEVMTransactionsForAccount', label);
             const feedbackStore = useFeedbackStore();
-            const userStore = useUserStore();
             const chain = useChainStore().getChain(label);
             const chain_settings = chain.settings as EVMChainSettings;
-            const indexer = chain_settings.getIndexer();
             const contractStore = useContractStore();
-            const chainSettings = (chain.settings as EVMChainSettings);
 
             feedbackStore.setLoading('history.fetchEVMTransactionsForAccount');
 
             try {
+                this.setShapedTransactionRows(label, []);
                 const response = await chain_settings.getEVMTransactions(toRaw(this.__evm_filter));
                 const contracts = response.contracts;
                 const transactions = response.results;
@@ -117,138 +115,162 @@ export const useHistoryStore = defineStore(store_name, {
                     contractStore.addContractToCache(address, parsedContracts[address]);
                 });
 
-                const tlosInUsd = await chainSettings.getUsdPrice();
                 this.setEVMTransactions(label, transactions);
+                // we do the shaping of transactions in background to speed up the UI
 
-                const shapedTransactionRows: ShapedTransactionRow[] = [];
+                await this.shapeTransactions(label, transactions);
 
-                for (const tx of transactions) {
-                    const transfers = await contractStore.getTransfersFromTransaction(tx);
-                    const userAddressLower = this.__evm_filter.address.toLowerCase();
-
-                    const gasUsedInTlosBn = BigNumber.from(tx.gasPrice).mul(tx.gasused);
-                    const gasUsedInTlos = getGasInTlos(tx.gasused, tx.gasPrice);
-                    const gasInUsdBn = convertCurrency(gasUsedInTlosBn, WEI_PRECISION, 2, tlosInUsd);
-                    const gasInUsd = +(formatUnits(gasInUsdBn, 2));
-
-                    // all contracts in transactions are cached, no need to use getContract
-                    const toPrettyName = contractStore.__cachedContracts[tx.to?.toLowerCase()]?.name ?? '';
-                    const fromPrettyName = contractStore.__cachedContracts[tx.from?.toLowerCase()]?.name ?? '';
-
-                    const valuesIn: TransactionValueData[] = [];
-                    const valuesOut: TransactionValueData[] = [];
-
-                    const isFailed = tx.status !== '0x1';
-                    const isContractCreation = !tx.to && !!tx.contractAddress;
-                    let functionName = '';
-
-                    if (!isContractCreation && tx.to && tx.to.toLowerCase() !== userAddressLower) {
-                        // if the user interacted with a contract, the 'to' field is that contract's address
-                        const contract = await contractStore.getContract(tx.to);
-
-                        if (contract && contract.abi) {
-                            functionName = await contractStore.getFunctionNameFromTransaction(tx, contract);
-                        }
-
-                    }
-
-                    let actionName = '';
-
-                    if (!isFailed) {
-                        if (+tx.value) {
-                            const valueInFiatBn = convertCurrency(BigNumber.from(tx.value), WEI_PRECISION, 2, tlosInUsd);
-                            const valueInFiat = +formatUnits(valueInFiatBn, 2);
-
-                            if (tx.from?.toLowerCase() === userAddressLower) {
-                                valuesOut.push({
-                                    amount: +formatUnits(tx.value, WEI_PRECISION),
-                                    symbol: chainSettings.getSystemToken().symbol,
-                                    fiatValue: valueInFiat,
-                                });
-                            }
-                            if (tx.to?.toLowerCase() === userAddressLower) {
-                                valuesIn.push({
-                                    amount: +formatUnits(tx.value, WEI_PRECISION),
-                                    symbol: chainSettings.getSystemToken().symbol,
-                                    fiatValue: valueInFiat,
-                                });
-                            }
-                        }
-
-                        for (const tokenXfer of transfers) {
-                            if (tokenXfer.symbol && tokenXfer.decimals) {
-                                let transferAmountInFiat: number | undefined;
-
-                                if (tokenXfer.symbol) {
-                                    const tokenFiatPrice = await getFiatPriceFromIndexer(
-                                        tokenXfer.symbol,
-                                        tokenXfer.address,
-                                        userStore.fiatCurrency,
-                                        indexer,
-                                        chain_settings,
-                                    );
-
-                                    transferAmountInFiat = tokenFiatPrice ?
-                                        tokenFiatPrice * +formatUnits(tokenXfer.value, tokenXfer.decimals) :
-                                        undefined;
-                                }
-
-                                if (tokenXfer.from?.toLowerCase() === userAddressLower) {
-                                    // sent from user
-                                    valuesOut.push({
-                                        amount: +formatUnits(tokenXfer.value, tokenXfer.decimals),
-                                        symbol: tokenXfer.symbol,
-                                        fiatValue: transferAmountInFiat,
-                                    });
-                                } else if (tokenXfer.to?.toLowerCase() === userAddressLower) {
-                                    // sent to user
-                                    valuesIn.push({
-                                        amount: +formatUnits(tokenXfer.value, tokenXfer.decimals),
-                                        symbol: tokenXfer.symbol,
-                                        fiatValue: transferAmountInFiat,
-                                    });
-                                }
-                            }
-                        }
-
-                        if (isContractCreation) {
-                            actionName = 'contractCreation';
-                        } else if (+tx.value && transfers.length === 0 && !functionName) {
-                            if (tx.from?.toLowerCase() === userAddressLower) {
-                                actionName = 'send';
-                            } else if (tx.to?.toLowerCase() === userAddressLower) {
-                                actionName = 'receive';
-                            }
-                        } else if (EvmSwapFunctionNames.includes(functionName)) {
-                            actionName = 'swap';
-                        } else if (functionName) {
-                            actionName = functionName;
-                        }
-                    }
-
-
-                    shapedTransactionRows.push({
-                        id: tx.hash,
-                        epoch: tx.timestamp / 1000,
-                        actionName,
-                        from: tx.from,
-                        fromPrettyName,
-                        to: tx.to,
-                        toPrettyName,
-                        valuesIn,
-                        valuesOut,
-                        gasUsed: +gasUsedInTlos,
-                        gasFiatValue: gasInUsd,
-                        failed: isFailed,
-                    });
-                }
-
-                this.setShapedTransactionRows(label, shapedTransactionRows);
-                feedbackStore.unsetLoading('history.fetchEVMTransactionsForAccount');
+                // there's an instant between this point and the appearance of the first transaction to show
+                // so we add a small delay to avoid flickering
+                setTimeout(() => {
+                    feedbackStore.unsetLoading('history.fetchEVMTransactionsForAccount');
+                }, 500);
             } catch (error) {
                 feedbackStore.unsetLoading('history.fetchEVMTransactionsForAccount');
                 throw new AntelopeError('antelope.history.error_fetching_transactions');
             }
+        },
+
+        async shapeTransactions(label: Label = 'current', transactions: EvmTransaction[]) {
+            this.trace('shapeTransactions', label);
+            const feedbackStore = useFeedbackStore();
+            const userStore = useUserStore();
+            const chain = useChainStore().getChain(label);
+            const chain_settings = chain.settings as EVMChainSettings;
+            const indexer = chain_settings.getIndexer();
+            const contractStore = useContractStore();
+            const chainSettings = (chain.settings as EVMChainSettings);
+            const tlosInUsd = await chainSettings.getUsdPrice();
+
+            transactions.forEach(async (tx) => {
+                const index = transactions.findIndex(t => t.hash === tx.hash);
+
+                // Each of these calls is a separate context, so we can do them in parallel
+                const loadingFlag = `history.shapeTransactions-${index}`;
+                feedbackStore.setLoading(loadingFlag);
+
+                const transfers = await contractStore.getTransfersFromTransaction(tx);
+                const userAddressLower = this.__evm_filter.address.toLowerCase();
+
+                const gasUsedInTlosBn = BigNumber.from(tx.gasPrice).mul(tx.gasused);
+                const gasUsedInTlos = getGasInTlos(tx.gasused, tx.gasPrice);
+                const gasInUsdBn = convertCurrency(gasUsedInTlosBn, WEI_PRECISION, 2, tlosInUsd);
+                const gasInUsd = +(formatUnits(gasInUsdBn, 2));
+
+                // all contracts in transactions are cached, no need to use getContract
+                const toPrettyName = contractStore.__cachedContracts[tx.to?.toLowerCase()]?.name ?? '';
+                const fromPrettyName = contractStore.__cachedContracts[tx.from?.toLowerCase()]?.name ?? '';
+
+                const valuesIn: TransactionValueData[] = [];
+                const valuesOut: TransactionValueData[] = [];
+
+                const isFailed = tx.status !== '0x1';
+                const isContractCreation = !tx.to && !!tx.contractAddress;
+                let functionName = '';
+
+                if (!isContractCreation && tx.to && tx.to.toLowerCase() !== userAddressLower) {
+                    // if the user interacted with a contract, the 'to' field is that contract's address
+                    const contract = await contractStore.getContract(tx.to);
+                    if (contract && contract.abi) {
+                        functionName = await contractStore.getFunctionNameFromTransaction(tx, contract);
+                    }
+                }
+
+                let actionName = '';
+
+                if (!isFailed) {
+                    if (+tx.value) {
+                        const valueInFiatBn = convertCurrency(BigNumber.from(tx.value), WEI_PRECISION, 2, tlosInUsd);
+                        const valueInFiat = +formatUnits(valueInFiatBn, 2);
+
+                        if (tx.from?.toLowerCase() === userAddressLower) {
+                            valuesOut.push({
+                                amount: +formatUnits(tx.value, WEI_PRECISION),
+                                symbol: chainSettings.getSystemToken().symbol,
+                                fiatValue: valueInFiat,
+                            });
+                        }
+                        if (tx.to?.toLowerCase() === userAddressLower) {
+                            valuesIn.push({
+                                amount: +formatUnits(tx.value, WEI_PRECISION),
+                                symbol: chainSettings.getSystemToken().symbol,
+                                fiatValue: valueInFiat,
+                            });
+                        }
+                    }
+
+                    for (const tokenXfer of transfers) {
+                        if (tokenXfer.symbol && tokenXfer.decimals) {
+                            let transferAmountInFiat: number | undefined;
+
+                            if (tokenXfer.symbol) {
+                                const tokenFiatPrice = await getFiatPriceFromIndexer(
+                                    tokenXfer.symbol,
+                                    tokenXfer.address,
+                                    userStore.fiatCurrency,
+                                    indexer,
+                                    chain_settings,
+                                );
+
+                                transferAmountInFiat = tokenFiatPrice ?
+                                    tokenFiatPrice * +formatUnits(tokenXfer.value, tokenXfer.decimals) :
+                                    undefined;
+
+                            }
+
+                            if (tokenXfer.from?.toLowerCase() === userAddressLower) {
+                                // sent from user
+                                valuesOut.push({
+                                    amount: +formatUnits(tokenXfer.value, tokenXfer.decimals),
+                                    symbol: tokenXfer.symbol,
+                                    fiatValue: transferAmountInFiat,
+                                });
+                            } else if (tokenXfer.to?.toLowerCase() === userAddressLower) {
+                                // sent to user
+                                valuesIn.push({
+                                    amount: +formatUnits(tokenXfer.value, tokenXfer.decimals),
+                                    symbol: tokenXfer.symbol,
+                                    fiatValue: transferAmountInFiat,
+                                });
+                            }
+                        }
+                    }
+
+                    if (isContractCreation) {
+                        actionName = 'contractCreation';
+                    } else if (+tx.value && transfers.length === 0 && !functionName) {
+                        if (tx.from?.toLowerCase() === userAddressLower) {
+                            actionName = 'send';
+                        } else if (tx.to?.toLowerCase() === userAddressLower) {
+                            actionName = 'receive';
+                        }
+                    } else if (EvmSwapFunctionNames.includes(functionName)) {
+                        actionName = 'swap';
+                    } else if (functionName) {
+                        actionName = functionName;
+                    }
+                }
+
+                const shapedTx = {
+                    id: tx.hash,
+                    epoch: tx.timestamp / 1000,
+                    actionName,
+                    from: tx.from,
+                    fromPrettyName,
+                    to: tx.to,
+                    toPrettyName,
+                    valuesIn,
+                    valuesOut,
+                    gasUsed: +gasUsedInTlos,
+                    gasFiatValue: gasInUsd,
+                    failed: isFailed,
+                } as ShapedTransactionRow;
+
+                // The shapedTxs may not be in the same order as the transactions
+                this.__shaped_evm_transaction_rows[label][index] = shapedTx;
+
+                feedbackStore.unsetLoading(loadingFlag);
+            });
         },
 
 

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -185,6 +185,7 @@ export const useHistoryStore = defineStore(store_name, {
                                         tokenXfer.address,
                                         userStore.fiatCurrency,
                                         indexer,
+                                        chain_settings,
                                     );
 
                                     transferAmountInFiat = tokenFiatPrice ?

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -54,7 +54,6 @@ export const useNftsStore = defineStore(store_name, {
                         list: [],
                         loading: true,
                     };
-                    await self.updateNFTsForAccount(label, toRaw(account));
                 },
             });
         },

--- a/src/antelope/stores/user.ts
+++ b/src/antelope/stores/user.ts
@@ -99,7 +99,7 @@ export const useUserStore = defineStore(store_name, {
             } catch (error) {
                 console.error('Error: ', errorToString(error));
             } finally {
-                useFeedbackStore().unsetLoading('account.loadUsers');
+                useFeedbackStore().unsetLoading('user.loadUsers');
             }
 
             this.loadCurrencyPreferences();

--- a/src/antelope/stores/utils/text-utils.ts
+++ b/src/antelope/stores/utils/text-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Given some text, ellipsizes the text if it exceeds a specific length
+ *
+ * @param text
+ * @param maxLength
+ */
+export function truncateText(text: string, maxLength = 10) {
+    if (text.length <= maxLength) {
+        return text;
+    }
+
+    return `${text.slice(0, maxLength)}...`;
+}

--- a/src/antelope/types/ChainSettings.ts
+++ b/src/antelope/types/ChainSettings.ts
@@ -2,6 +2,7 @@ import { RpcEndpoint } from 'universal-authenticator-library';
 import { IndexerTransactionsFilter, NFTClass, PriceChartData, TokenClass } from 'src/antelope/types';
 
 export interface ChainSettings {
+    init(): Promise<void>;
     isNative(): boolean;
     getNetwork(): string;
     getSystemToken(): TokenClass;
@@ -13,7 +14,7 @@ export interface ChainSettings {
     getRPCEndpoint(): RpcEndpoint;
     getPriceData(): Promise<PriceChartData>;
     getUsdPrice(): Promise<number>;
-    getImportantTokensIdList(): string[];
+    getSystemTokens(): TokenClass[];
     getNFTsInventory(address: string, filter: IndexerTransactionsFilter): Promise<NFTClass[]>;
     getNFTsCollection(contract: string, filter: IndexerTransactionsFilter): Promise<NFTClass[]>
 }

--- a/src/antelope/types/TokenClass.ts
+++ b/src/antelope/types/TokenClass.ts
@@ -250,6 +250,9 @@ export class TokenClass implements TokenSourceInfo {
         };
     }
 
+    toString(): string {
+        return this.symbol;
+    }
 }
 
 // A class to represent the balance of a token
@@ -328,5 +331,7 @@ export class TokenBalance {
         return this.token.isNative;
     }
 
-
+    toString(): string {
+        return this._balanceStr;
+    }
 }

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -5,7 +5,6 @@ import {
     PriceHistory,
     PriceStats,
 } from 'src/antelope/types';
-import { useChainStore } from 'src/antelope';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 
 interface CachedPrice {
@@ -53,8 +52,9 @@ export async function getFiatPriceFromIndexer(
     tokenAddress: string,
     fiatCode: string,
     indexerAxios: AxiosInstance,
+    chain_settings: EVMChainSettings,
 ): Promise<number> {
-    const wrappedSystemAddress = (useChainStore().loggedChain.settings as EVMChainSettings).getWrappedSystemToken().address;
+    const wrappedSystemAddress = chain_settings.getWrappedSystemToken().address;
     const actualTokenAddress = tokenAddress === NativeCurrencyAddress ? wrappedSystemAddress : tokenAddress;
     const response = (await indexerAxios.get(`/v1/tokens/marketdata?tokens=${tokenSymbol}&vs=${fiatCode}`)).data;
 

--- a/src/components/ExternalLink.vue
+++ b/src/components/ExternalLink.vue
@@ -36,7 +36,8 @@ const formattedText = computed(() => {
 <style lang="scss">
 .c-external-link {
     &__link {
-        line-height: 24px;
+        @include text--paragraph;
+
         text-decoration: none;
         color: var(--link-color);
         display: inline-flex;

--- a/src/components/evm/TableControls.vue
+++ b/src/components/evm/TableControls.vue
@@ -15,10 +15,13 @@ const props = defineProps({
         }>,
         required: true,
     },
+    rowsPerPageOptions: {
+        type: Array as PropType<number[]>,
+        default: () => [5, 10, 20, 50, 100],
+    },
 });
 const emit = defineEmits(['pagination-updated']);
 
-const rowsPerPageOptions = [5, 10, 20, 50, 100];
 const showRowsPerPageDropdown = ref(false);
 const rowsPerPagePopup = ref<QPopupProxy>();
 
@@ -90,7 +93,7 @@ function changePageNumber(direction: 'next' | 'prev' | 'first' | 'last') {
         <q-btn
             outline
             size="sm"
-            color="primary"
+            :color="pagination.page === 1 ? 'gray-4' : 'primary'"
             icon="first_page"
             class="q-mr-xs"
             :disable="pagination.page === 1"
@@ -99,7 +102,7 @@ function changePageNumber(direction: 'next' | 'prev' | 'first' | 'last') {
         <q-btn
             outline
             size="sm"
-            color="primary"
+            :color="pagination.page === 1 ? 'gray-4' : 'primary'"
             icon="chevron_left"
             class="q-mr-sm"
             :disable="pagination.page === 1"
@@ -111,7 +114,7 @@ function changePageNumber(direction: 'next' | 'prev' | 'first' | 'last') {
         <q-btn
             outline
             size="sm"
-            color="primary"
+            :color="pagination.page === totalPages ? 'gray-4' : 'primary'"
             icon="chevron_right"
             class="q-ml-sm"
             :disable="pagination.page === totalPages"
@@ -120,7 +123,7 @@ function changePageNumber(direction: 'next' | 'prev' | 'first' | 'last') {
         <q-btn
             outline
             size="sm"
-            color="primary"
+            :color="pagination.page === totalPages ? 'gray-4' : 'primary'"
             icon="last_page"
             class="q-ml-xs"
             :disable="pagination.page === totalPages"

--- a/src/css/global/_typography.scss
+++ b/src/css/global/_typography.scss
@@ -27,64 +27,64 @@
 /* Typography mixins */
 @mixin text--header-1 {
     @include bold;
-    font-size: 2.5rem;
+    font-size: 2.5rem !important;
     line-height: 100%;
 
     @include tiny-only {
-        font-size: 2rem;
+        font-size: 2rem !important;
     }
 }
 
 @mixin text--header-2 {
     @include bold;
-    font-size: 1.5rem;
+    font-size: 1.5rem !important;
     line-height: 130%;
 }
 
 @mixin text--header-3 {
     @include regular;
-    font-size: 1.5rem;
+    font-size: 1.5rem !important;
     line-height: 130%;
 }
 
 @mixin text--header-4 {
     @include bold;
-    font-size: 1.125rem;
+    font-size: 1.125rem !important;
     line-height: 130%;
 
     @media only screen and (min-width: $breakpoint-sm-min) {
-        font-size: 1.25rem;
+        font-size: 1.25rem !important;
     }
 }
 
 @mixin text--header-5 {
     @include bold;
-    font-size: 0.9rem;
+    font-size: 0.9rem !important;
     line-height: 150%;
     text-transform: uppercase;
 }
 
 @mixin text--paragraph {
     @include regular;
-    font-size: 1rem;
+    font-size: 1rem !important;
     line-height: 150%;
 }
 
 @mixin text--paragraph-bold {
     @include bold;
-    font-size: 1rem;
+    font-size: 1rem !important;
     line-height: 150%;
 }
 
 @mixin text--small {
     @include regular;
-    font-size: 0.8rem;
+    font-size: 0.8rem !important;
     line-height: 150%;
 }
 
 @mixin text--small-bold {
     @include bold;
-    font-size: 0.8rem;
+    font-size: 0.8rem !important;
     line-height: 150%;
 }
 

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -101,7 +101,7 @@ export default {
         add_to_metamask: 'Add to MetaMask',
         rejected_metamask_prompt: 'The MetaMask prompt was rejected',
         error_adding_token_to_metamask: 'Error adding token to MetaMask',
-        inventory: 'Inventory',
+        inventory: 'Collectibles',
     },
     global: {
         native: 'Native',
@@ -121,8 +121,12 @@ export default {
         amount: 'Amount',
         id: 'ID',
         attributes: 'Attributes',
+        name: 'Name',
+        collection: 'Collection',
+        search: 'Search',
     },
     nft : {
+        collectible: 'Collectible',
         link_to_nft_details: 'Go to NFT details page for {name}',
         img_alt: 'NFT - {nftInfo}',
         img_alt_video_nft: 'Video NFT cover - {nftInfo}',
@@ -141,6 +145,10 @@ export default {
         // 'part 2' is 'global.id'
         collectible_not_found_nft_id_part_3: 'correct? An incorrect ID may result in inaccurate information being displayed.',
         empty_collection_title: 'You don\'t have any digital collectibles yet',
+        show_as_tiles_label: 'Show collectibles as tiles',
+        show_as_list_label: 'Show collectibles in a list',
+        go_to_detail_page_label: 'Go to collectible detail page',
+        name_missing: '(No name)',
         empty_collection_message: 'Purchase your first collectible',
         empty_collection_link_text: 'here',
     },
@@ -223,6 +231,7 @@ export default {
         },
     },
     forms: {
+        clear_search_label: 'Clear search terms',
         errors: {
             accountFormat:
           'The account can contain lowercase characters only, numbers from 1 to 5 or a dot (.)',

--- a/src/pages/evm/nfts/NftDetailsCard.vue
+++ b/src/pages/evm/nfts/NftDetailsCard.vue
@@ -20,5 +20,6 @@ const props = defineProps<{
     border: 1px solid $header-item-border;
     background-color: var(--bg-color);
     padding: 16px;
+    word-break: break-word;
 }
 </style>

--- a/src/pages/evm/nfts/NftTile.vue
+++ b/src/pages/evm/nfts/NftTile.vue
@@ -31,6 +31,9 @@ const nftDetailsRoute = {
 // computed
 const creatorLinkText = computed(() => props.nft.contractPrettyName || props.nft.contractAddress);
 const creatorLinkUrl = computed(() => `${chainSettings.getExplorerUrl()}/address/${props.nft.contractAddress}`);
+// hide ID text if the NFT name includes the ID, which is common
+const showId = computed(() => !props.nft.name.includes(props.nft.id));
+
 </script>
 
 <template>
@@ -48,9 +51,11 @@ const creatorLinkUrl = computed(() => `${chainSettings.getExplorerUrl()}/address
         />
     </router-link>
     <div class="c-nft-tile__text-container">
-        <h4>
-            <span class="u-text--high-contrast q-pr-sm">{{nft.name}}</span>
-            <span class="u-text--default-contrast">{{nft.id}}</span>
+        <h4 class="c-nft-tile__text">
+            <span v-if="nft.name" class="u-text--high-contrast q-pr-sm">
+                {{nft.name}}
+            </span>
+            <span v-if="showId" class="u-text--default-contrast">{{nft.id}}</span>
         </h4>
         <ExternalLink :text="creatorLinkText" :url="creatorLinkUrl" />
     </div>
@@ -72,6 +77,11 @@ const creatorLinkUrl = computed(() => `${chainSettings.getExplorerUrl()}/address
 
     @include tiny-only {
         width: 288px;
+    }
+
+    &__text {
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     &__link {

--- a/src/pages/evm/nfts/NftViewer.vue
+++ b/src/pages/evm/nfts/NftViewer.vue
@@ -70,6 +70,10 @@ const iconOverlayName = computed(() => {
     }
 
     if (nftType.value === nftTypes.video) {
+        if (props.previewMode) {
+            return 'o_movie';
+        }
+
         if (videoIsAtEnd.value) {
             return 'o_replay';
         } else {

--- a/src/pages/evm/wallet/WalletTransactionsTab.vue
+++ b/src/pages/evm/wallet/WalletTransactionsTab.vue
@@ -32,7 +32,7 @@ export default defineComponent({
             return feedbackStore.getLoadings;
         },
         loading() {
-            return this.shapedTransactions.length === 0;
+            return feedbackStore.isLoading('history.fetchEVMTransactionsForAccount');
         },
         address() {
             return accountStore.loggedEvmAccount?.address ?? '';
@@ -109,10 +109,6 @@ export default defineComponent({
         <h2>{{ $t('global.transactions') }}</h2>
         <span v-if="totalRowsText">{{ totalRowsText }}</span>
     </div>
-    <!--
-    <div><pre>{{ loadings }}</pre></div>
-    <div><pre>{{ hashes }}</pre></div>
-    -->
     <template v-if="loading">
         <q-skeleton
             v-for="i of pagination.rowsCurrentPage"

--- a/test/jest/__tests__/antelope/stores/balances.spec.ts
+++ b/test/jest/__tests__/antelope/stores/balances.spec.ts
@@ -75,10 +75,10 @@ const ChainStore = jest.fn().mockImplementation(() => ({
             getTokenList: jest.fn().mockImplementation(() => tokenList),
             getSystemToken: jest.fn().mockImplementation(() => tokenSys),
             getUsdPrice: jest.fn().mockImplementation(() => 1),
-            getImportantTokensIdList: jest.fn().mockImplementation(() => []),
             hasIndexerSupport: jest.fn().mockImplementation(() => false),
             isIndexerHealthy: jest.fn().mockImplementation(() => false),
             getNetwork: jest.fn().mockImplementation(() => TEST_NETWORK),
+            getSystemTokens: jest.fn().mockImplementation(() => [tokenSys]),
         },
     })),
     loggedChain: {
@@ -95,7 +95,28 @@ jest.mock('src/antelope/stores/evm', () => ({
 }));
 
 jest.mock('src/antelope/stores/chain', () => ({
-    useChainStore: ChainStore,
+    useChainStore: jest.fn().mockImplementation(() => ({
+        getChain: jest.fn().mockImplementation(() => ({
+            settings: {
+                isNative: jest.fn(),
+                getTokens: jest.fn(),
+                getTokenList: jest.fn().mockImplementation(() => tokenList),
+                getSystemToken: jest.fn().mockImplementation(() => tokenSys),
+                getUsdPrice: jest.fn().mockImplementation(() => 1),
+                getSystemTokens: jest.fn().mockImplementation(() => [tokenSys]),
+                hasIndexerSupport: jest.fn().mockImplementation(() => false),
+                isIndexerHealthy: jest.fn().mockImplementation(() => false),
+                getNetwork: jest.fn().mockImplementation(() => TEST_NETWORK),
+            },
+        })),
+        loggedChain: {
+            settings: {
+                isNative: jest.fn(),
+                getTokens: jest.fn(),
+                getTokenList: jest.fn().mockImplementation(() => tokenList),
+            },
+        },
+    })),
 }));
 
 jest.mock('src/antelope/stores/account', () => ({
@@ -154,7 +175,7 @@ describe('Antelope Balance Store', () => {
         const tokenBalance = new TokenBalance(tokenList[0], TOKEN_BALANCE);
 
         const expected = {
-            label: [sysBalance, tokenBalance],
+            label: [tokenBalance, sysBalance],
         };
         expect(JSON.stringify(store.__balances)).toBe(JSON.stringify(expected));
     });


### PR DESCRIPTION
# Fixes #445

## Description
This PR splits the process of fetching transaction history data and let them run in parallel. This result in a much faster loading time.

## Test scenarios
- go to [this link](https://deploy-preview-447--wallet-staging.netlify.app/)
- login on EVM with an account with some history
- goto history tab
   - you should see the history page loading gradually and not all at once

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x]  Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
