### PR TITLE
#350 | TX table improvements

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -400,6 +400,11 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const params: AxiosRequestConfig = aux as AxiosRequestConfig;
         const url = `v1/address/${address}/transactions`;
 
+
+        if (1<2) {
+            throw 'asdasdas';
+        }
+
         // The following performs a GET request to the indexer endpoint.
         // Then it pipes the response to the IndexerAccountTransactionsResponse type.
         // Notice that the promise is not awaited, but returned instead immediately.

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -400,11 +400,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const params: AxiosRequestConfig = aux as AxiosRequestConfig;
         const url = `v1/address/${address}/transactions`;
 
-
-        if (1<2) {
-            throw 'asdasdas';
-        }
-
         // The following performs a GET request to the indexer endpoint.
         // Then it pipes the response to the IndexerAccountTransactionsResponse type.
         // Notice that the promise is not awaited, but returned instead immediately.

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -94,7 +94,6 @@ export const useHistoryStore = defineStore(store_name, {
             feedbackStore.setLoading('history.fetchEVMTransactionsForAccount');
 
             try {
-                this.setShapedTransactionRows(label, []);
                 const response = await chain_settings.getEVMTransactions(toRaw(this.__evm_filter));
                 const contracts = response.contracts;
                 const transactions = response.results;
@@ -306,6 +305,8 @@ const historyInitialState: HistoryState = {
     __evm_filter: {
         address: '',
     },
-    __shaped_evm_transaction_rows: {},
+    __shaped_evm_transaction_rows: {
+        current: [],
+    },
     __evm_transactions_pagination_data: {},
 };

--- a/src/boot/errorHandling.js
+++ b/src/boot/errorHandling.js
@@ -134,7 +134,7 @@ const notifyMessage = function(type, icon, title, message, payload) {
         actions.splice(0, actions.length);
     }
 
-    let final_message = message;
+    let final_message = this.$t(message ?? '');
     if (Array.isArray(message)) {
         final_message = message.map(m => ` <${m.tag ?? 'span'} class="${m.class}">${m.text}</${m.tag ?? 'span'}> `).join('');
     }

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -439,7 +439,7 @@ export default {
             error_transaction_canceled: 'You canceled the action',
         },
         history: {
-            error_fetching_transactions: 'Error in fetching transactions',
+            error_fetching_transactions: 'Unexpected error fetching transactions. Please refresh the page to try again.',
         },
         chain: {
             error_update_data: 'Error in updating data',

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -1,19 +1,29 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import { TokenBalance } from 'src/antelope/types';
 import AppPage from 'components/evm/AppPage.vue';
 import WalletPageHeader from 'pages/evm/wallet/WalletPageHeader.vue';
 import WalletBalanceRow from 'pages/evm/wallet/WalletBalanceRow.vue';
-import { useBalancesStore, useFeedbackStore } from 'src/antelope';
+import { useAccountStore, useBalancesStore, useFeedbackStore, useHistoryStore } from 'src/antelope';
 import WalletTransactionsTab from 'pages/evm/wallet/WalletTransactionsTab.vue';
 
+const route = useRoute();
+
+const historyStore = useHistoryStore();
+const accountStore = useAccountStore();
 const feedback = useFeedbackStore();
+
 const tabs = ['balance', 'transactions'];
+
+// data
 const totalFiatAmount = ref(0);
 
+// computed
 const allBalances = computed(() => useBalancesStore().loggedBalances);
 const loading = computed(() => feedback.isLoading('updateBalancesForAccount'));
 
+// watchers
 watch(allBalances, (newBalances: TokenBalance[]) => {
     let newFiatBalance = 0;
     for (let balance of newBalances){
@@ -23,6 +33,19 @@ watch(allBalances, (newBalances: TokenBalance[]) => {
     }
     totalFiatAmount.value = newFiatBalance;
 }, { deep: true, immediate: true });
+
+watch(accountStore, () => {
+    // if user is on the balances screen, prefetch transactions
+    if (accountStore.loggedEvmAccount?.address && route.query.tab === 'balance') {
+        historyStore.setEVMTransactionsFilter({
+            address: accountStore.loggedEvmAccount?.address,
+            offset: 0,
+            limit: 5,
+            includeAbi: true,
+        });
+        historyStore.fetchEVMTransactionsForAccount('current');
+    }
+});
 </script>
 
 <template>

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -45,7 +45,8 @@ watch(accountStore, () => {
         });
         historyStore.fetchEVMTransactionsForAccount('current');
     }
-});
+},
+{ immediate: true });
 </script>
 
 <template>

--- a/src/pages/evm/wallet/WalletPage.vue
+++ b/src/pages/evm/wallet/WalletPage.vue
@@ -36,7 +36,7 @@ watch(allBalances, (newBalances: TokenBalance[]) => {
 
 watch(accountStore, () => {
     // if user is on the balances screen, prefetch transactions
-    if (accountStore.loggedEvmAccount?.address && route.query.tab === 'balance') {
+    if (accountStore.loggedEvmAccount?.address && route.query.tab !== 'transactions') {
         historyStore.setEVMTransactionsFilter({
             address: accountStore.loggedEvmAccount?.address,
             offset: 0,

--- a/src/pages/evm/wallet/WalletTransactionsTab.vue
+++ b/src/pages/evm/wallet/WalletTransactionsTab.vue
@@ -74,7 +74,6 @@ export default defineComponent({
         this.fetchTransactionsInterval = setInterval(() => {
             if (this.address && this.pagination.page === 1) {
                 this.hideLoadingState = true;
-                console.log('getting txs');
 
                 this.getTransactions().finally(() => {
                     this.enableLoadingState();

--- a/src/pages/evm/wallet/WalletTransactionsTab.vue
+++ b/src/pages/evm/wallet/WalletTransactionsTab.vue
@@ -74,6 +74,8 @@ export default defineComponent({
         this.fetchTransactionsInterval = setInterval(() => {
             if (this.address && this.pagination.page === 1) {
                 this.hideLoadingState = true;
+                console.log('getting txs');
+
                 this.getTransactions().finally(() => {
                     this.enableLoadingState();
                 });


### PR DESCRIPTION
# Fixes #350 

## Description
This PR does 2 things:
- prefetch transactions if you are on the wallet balance page
- re-fetch transactions every 13 seconds if you are on the first page (does not refetch if on other pages to prevent data from randomly shifting around for the user)

## Test scenarios
- this PR needs to be tested locally because the testnet indexer isn't caught up yet, thus new transactions do not show
- run `git fetch --all && git checkout 350-tx-table-improvements`
- change `.env` to say `NETWORK="mainnet"`
- run `yarn dev`
- go to http://localhost:8081
- click the Transactions tab
    - the transactions should already be loaded, no loading state
- open http://localhost:8081/evm/send in a new window, place it side by side with the current window
- send yourself some token
    - after a short delay, the new tx should be inserted into the table in the other window

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have tested for mobile functionality and responsiveness
