### PR TITLE
#440 | Wrap page header

### DIFF
--- a/src/antelope/stores/utils/currency-utils.ts
+++ b/src/antelope/stores/utils/currency-utils.ts
@@ -205,7 +205,11 @@ export function prettyPrintCurrency(
             finalFormattedValue = finalFormattedValue.replace(trailingZeroesRegex, '');
         }
 
-        if (currency) {
+        if (precision === 2 && tokenDecimals === 2 && currency) {
+            // value is a fiat currency with 2 decimals, so add the currency symbol
+            const symbol = getCurrencySymbol(locale, currency);
+            finalFormattedValue = `${symbol}${finalFormattedValue}`;
+        } else if (currency) {
             finalFormattedValue += ` ${currency}`;
         }
 

--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -279,7 +279,6 @@ export default defineComponent({
             </li>
 
             <li
-                v-if="false"
                 class="c-app-nav__menu-item"
                 role="menuitem"
                 :tabindex="menuItemTabIndex"

--- a/src/components/evm/ScrollableInfoCards.vue
+++ b/src/components/evm/ScrollableInfoCards.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import ToolTip from 'components/ToolTip.vue';
+
+const props = defineProps<{
+    cards: {
+        label: string;
+        tooltip?: string;
+        primaryText?: string;
+        secondaryText?: string;
+        lowContrastSecondaryText?: boolean;
+    }[];
+}>();
+</script>
+
+<template>
+<div class="c-scrollable-info-cards">
+    <div v-for="(card, index) in cards" :key="`card-${index}`" class="c-scrollable-info-cards__card">
+        <div class="c-scrollable-info-cards__card-header">
+            <h5 class="u-text--low-contrast">
+                {{ card.label }}
+            </h5>
+
+            <ToolTip
+                v-if="card.tooltip"
+                :text="card.tooltip"
+                class="c-scrollable-info-cards__card-header-tooltip"
+            />
+        </div>
+
+        <h3>{{ card.primaryText }}</h3>
+        <span
+            v-if="card.secondaryText"
+            :class="{
+                'u-text--low-contrast': card.lowContrastSecondaryText
+            }"
+        >
+            {{ card.secondaryText }}
+        </span>
+    </div>
+</div>
+</template>
+
+<style lang="scss">
+.c-scrollable-info-cards {
+    display: flex;
+    gap: 24px;
+    flex-direction: row;
+    max-width: 100%;
+    overflow-x: scroll;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+
+    @include sm-and-up {
+        width: max-content;
+        margin: auto;
+    }
+
+    &__card {
+        background-color: var(--bg-color);
+        padding: 12px;
+        border-radius: 4px;
+        border: 2px solid var(--header-item-outline-color);
+        width: 220px;
+        flex-shrink: 0;
+
+        @include sm-and-up {
+            width: 300px;
+        }
+    }
+
+    &__card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 4px;
+    }
+}
+</style>

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -49,6 +49,7 @@ $saveBtn: #2e1f4f;
     --bg-color-hover: #{$page-header};
 
     --header-bg-color: #{$page-header};
+    --header-item-outline-color: #{rgba($primary, 10%)}; // eztodo replace original of this
 }
 
 // Dark Mode

--- a/src/css/quasar.variables.sass
+++ b/src/css/quasar.variables.sass
@@ -25,7 +25,6 @@ $warning   : #AD6500
 
 $available-color: #172c6c
 $page-header: #F7F5FF
-$header-item-border: darken($page-header, 5%)
 $notify-success: #255B00
 $notify-error: #880000
 $notify-neutral: #4D4D4D

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -153,6 +153,9 @@ export default {
         empty_collection_message: 'Purchase your first collectible',
         empty_collection_link_text: 'here',
     },
+    evm_wrap: {
+        total_of_wrapped_and_unwrapped: 'Total of wrapped {token} and {token}',
+    },
     notification:{
         success_title_trx: 'Success',
         success_title_copied: 'Copied',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -155,6 +155,9 @@ export default {
     },
     evm_wrap: {
         total_of_wrapped_and_unwrapped: 'Total of wrapped {token} and {token}',
+        wrapped_card_label: 'Wrapped {symbol}',
+        wrapped_card_tooltip: '{wrappedSymbol} can be used to buy NFTs and trade on decentralized exchanges, among other things. Wrapping {systemSymbol} is done via a decentralized smart contract.',
+        unwrapped_card_tooltip: 'An equal amount of {systemSymbol} will be received as the amount of {wrappedSymbol} that was unwrapped. Unwrapping {wrappedSymbol} is done via a decentralized smart contract.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/pages/demo/DemoLayout.vue
+++ b/src/pages/demo/DemoLayout.vue
@@ -6,7 +6,7 @@
     <h5>Available demos</h5>
     <ul class="q-mb-xl">
         <li class="c-demo-layout__back">
-            <router-link to="/">Back</router-link>
+            <router-link to="/">Homepage</router-link>
         </li>
         <br >
         <li>
@@ -20,6 +20,9 @@
         </li>
         <li>
             <router-link :to="{ name: 'demos.nfts' }">NFTs / Collectibles</router-link>
+        </li>
+        <li>
+            <router-link :to="{ name: 'demos.scrollable-cards' }">Scrollable Info Cards</router-link>
         </li>
     </ul>
 

--- a/src/pages/demo/InputDemos.vue
+++ b/src/pages/demo/InputDemos.vue
@@ -100,9 +100,12 @@ export default defineComponent({
                 this.randomizeExchangeRates = false;
             }
         },
-        updateCurrencyInputLocale(event: InputEvent): void {
+        updateCurrencyInputLocale(event: Event): void {
             const eventTarget = event.target as HTMLInputElement;
             this.currencyInputLocale = eventTarget.value;
+        },
+        showError() {
+            (this.$refs.currencyTlosUsdInput as typeof CurrencyInput).showEmptyError();
         },
     },
     watch: {
@@ -217,7 +220,7 @@ export default defineComponent({
         <br>
         <br>
 
-        <button @click="$refs.currencyTlosUsdInput.showEmptyError()">
+        <button @click="showError">
             Set empty error
         </button>
         <label>(Required must be true, affects 3rd input only)</label>

--- a/src/pages/demo/NftDemos.vue
+++ b/src/pages/demo/NftDemos.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ShapedNFT } from 'src/antelope/types/NFTs';
+import { ShapedNFT } from 'src/antelope/types';
 import NftTile from 'pages/evm/nfts/NftTile.vue';
 import NftViewer from 'pages/evm/nfts/NftViewer.vue';
 import { ref } from 'vue';

--- a/src/pages/demo/ScrollableInfoCardDemos.vue
+++ b/src/pages/demo/ScrollableInfoCardDemos.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+import ScrollableInfoCards from 'components/evm/ScrollableInfoCards.vue';
+
+
+// data
+const labelText = ref('Label Text');
+const tooltipText = ref('This is an example tooltip');
+const primaryText = ref('$12,345.67');
+const secondaryText = ref('');
+const showSecondaryTextAsGray = ref(true);
+
+
+// computed
+const cards = computed(() =>
+    new Array(2).fill({
+        label: labelText.value,
+        tooltip: tooltipText.value,
+        primaryText: primaryText.value,
+        secondaryText: secondaryText.value,
+        lowContrastSecondaryText: showSecondaryTextAsGray.value,
+    }),
+);
+
+</script>
+
+<template>
+<div class="row q-mb-xl">
+    <div class="col-12">
+        <h3>Scrollable Info Cards</h3>
+        <p>Reduce screen size to see horizontal scrolling behavior</p>
+    </div>
+</div>
+<div class="row q-mb-xl">
+    <div class="col-12">
+        <div class="row">
+            <div class="col-3">
+                <q-input v-model="labelText" label="Label" />
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-3">
+                <q-input v-model="tooltipText" label="Tooltip Text" />
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-3">
+                <q-input v-model="primaryText" label="Primary Text" />
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-3">
+                <q-input v-model="secondaryText" label="Secondary Text" />
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-12">
+                <q-checkbox v-model="showSecondaryTextAsGray" label="Show gray secondary text?" />
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row q-mb-xl">
+    <div class="col-12">
+        <ScrollableInfoCards :cards="cards" />
+    </div>
+</div>
+</template>
+
+<style lang="scss">
+</style>

--- a/src/pages/evm/nfts/NftDetailsCard.vue
+++ b/src/pages/evm/nfts/NftDetailsCard.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
 
 .c-nft-details-card {
     border-radius: 4px;
-    border: 1px solid $header-item-border;
+    border: 1px solid var(--header-item-outline-color);
     background-color: var(--bg-color);
     padding: 16px;
     word-break: break-word;

--- a/src/pages/evm/nfts/NftViewer.vue
+++ b/src/pages/evm/nfts/NftViewer.vue
@@ -276,7 +276,7 @@ function toggleVideoPlay(playOnly?: boolean) {
         max-width: 432px;
         border-radius: 4px;
         background-color: var(--header-bg-color);
-        border: 1px solid darken($page-header, 5%);
+        border: 1px solid var(--header-item-outline-color);
     }
 
     &__video-container {

--- a/src/pages/evm/wrap/WrapPage.vue
+++ b/src/pages/evm/wrap/WrapPage.vue
@@ -1,11 +1,13 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import AppPage from 'components/evm/AppPage.vue';
+import WrapPageHeader from 'pages/evm/wrap/WrapPageHeader.vue';
 
 export default defineComponent({
     name: 'WrapPage',
     components: {
         AppPage,
+        WrapPageHeader,
     },
     data: () => ({
         tabs: ['wrap', 'unwrap'],
@@ -17,7 +19,7 @@ export default defineComponent({
 <template>
 <AppPage :tabs="tabs">
     <template v-slot:header>
-        <p>wrap page header stuff</p>
+        <WrapPageHeader />
     </template>
 
     <template v-slot:wrap>

--- a/src/pages/evm/wrap/WrapPageHeader.vue
+++ b/src/pages/evm/wrap/WrapPageHeader.vue
@@ -77,16 +77,16 @@ const wrappedFiatValueText = computed(() => prettyPrintCurrency(
 ));
 
 const cardData = computed(() => [{
-    label: $t('evm_wrap.wrapped_card_label', { symbol: systemTokenSymbol.value }), // eztodo i18n
+    label: $t('evm_wrap.wrapped_card_label', { symbol: systemTokenSymbol.value }),
     tooltip: $t('evm_wrap.wrapped_card_tooltip', { wrappedSymbol: wrappedTokenSymbol.value, systemSymbol: systemTokenSymbol.value }),
     primaryText: wrappedFiatValueText.value,
-    secondaryText: prettyPrintToken(wrappedTokenBalanceBn.value),
+    secondaryText: prettyPrintToken(wrappedTokenBalanceBn.value, true),
     lowContrastSecondaryText: true,
 }, {
     label: systemTokenSymbol.value,
     tooltip: $t('evm_wrap.unwrapped_card_tooltip', { wrappedSymbol: wrappedTokenSymbol.value, systemSymbol: systemTokenSymbol.value }),
     primaryText: unwrappedFiatValueText.value,
-    secondaryText: prettyPrintToken(systemTokenBalanceBn.value),
+    secondaryText: prettyPrintToken(systemTokenBalanceBn.value, false),
     lowContrastSecondaryText: true,
 }]);
 
@@ -100,13 +100,13 @@ onBeforeMount(() => {
     });
 });
 
-function prettyPrintToken(amount: BigNumber | undefined) {
+function prettyPrintToken(amount: BigNumber | undefined, isWrapped: boolean) {
     return prettyPrintCurrency(
         amount ?? BigNumber.from(0),
-        2,
+        4,
         fiatLocale.value,
         false,
-        systemTokenSymbol.value,
+        isWrapped ? wrappedTokenSymbol.value : systemTokenSymbol.value,
         false,
         WEI_PRECISION,
     );

--- a/src/pages/evm/wrap/WrapPageHeader.vue
+++ b/src/pages/evm/wrap/WrapPageHeader.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useUserStore, useBalancesStore, useChainStore } from 'src/antelope';
+import { getCurrencySymbol } from 'src/antelope/stores/utils/currency-utils';
+import { NativeCurrencyAddress } from 'src/antelope/types';
+import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+import { WEI_PRECISION, formatWei } from 'src/antelope/stores/utils';
+
+const userStore = useUserStore();
+const balancesStore = useBalancesStore();
+const chainStore = useChainStore();
+const chainSettings = (chainStore.loggedChain.settings as EVMChainSettings);
+
+// eztodo loading state
+// computed
+const fiatLocale = computed(() => userStore.fiatLocale);
+const fiatCurrency = computed(() => userStore.fiatCurrency);
+const fiatSymbol = computed(() => getCurrencySymbol(fiatLocale.value, fiatCurrency.value));
+const totalFiatValueText = computed(() => {
+    const systemTokenFiatValueBn = chainSettings.getSystemToken().price.value;
+    const wrappedTokenFiatValueBn = chainSettings.getWrappedSystemToken().price.value;
+    const added = systemTokenFiatValueBn.add(wrappedTokenFiatValueBn);
+    console.log('added', added.toBigInt());
+
+    return `${fiatSymbol.value} ${formatWei(added, WEI_PRECISION)}`;
+});
+
+const allBalances = computed(() => balancesStore.loggedBalances);
+const systemTokenBalanceBn =  computed(() => allBalances.value.find(b => b.token.contract === NativeCurrencyAddress)?.balance);
+const wrappedTokenBalanceBn = computed(() =>
+    allBalances.value.find(b => b.token.contract === chainSettings.getWrappedSystemToken().address)?.balance,
+);
+const totalSystemAndWrappedBalance = computed(() => {
+    if (!systemTokenBalanceBn.value || !wrappedTokenBalanceBn.value) {
+        return '0';
+    }
+    const addedBn = systemTokenBalanceBn.value.add(wrappedTokenBalanceBn.value);
+
+    return formatWei(addedBn, WEI_PRECISION);
+});
+const totalBalanceUnitsText = computed(() => {
+    const systemSymbol = chainSettings.getSystemToken().symbol;
+    const wrappedSymbol = chainSettings.getWrappedSystemToken().symbol;
+
+    return `${systemSymbol} + ${wrappedSymbol}`;
+});
+</script>
+
+<template>
+<div class="c-wrap-header">
+    <h5>Total of Wrapped Telos and Telos</h5>
+    <h1>{{ totalFiatValueText }}</h1>
+    <p class="o-text--small-bold u-text--low-contrast">
+        {{ totalSystemAndWrappedBalance }} {{ totalBalanceUnitsText }}
+    </p>
+</div>
+</template>
+
+<style lang="scss">
+.c-wrap-header {
+    text-align: center;
+}
+</style>

--- a/src/pages/evm/wrap/WrapPageHeader.vue
+++ b/src/pages/evm/wrap/WrapPageHeader.vue
@@ -20,7 +20,6 @@ const totalFiatValueText = computed(() => {
     const systemTokenFiatValueBn = chainSettings.getSystemToken().price.value;
     const wrappedTokenFiatValueBn = chainSettings.getWrappedSystemToken().price.value;
     const added = systemTokenFiatValueBn.add(wrappedTokenFiatValueBn);
-    console.log('added', added.toBigInt());
 
     return `${fiatSymbol.value} ${formatWei(added, WEI_PRECISION)}`;
 });

--- a/src/pages/evm/wrap/WrapPageHeader.vue
+++ b/src/pages/evm/wrap/WrapPageHeader.vue
@@ -1,30 +1,37 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onBeforeMount, ref } from 'vue';
 import { useUserStore, useBalancesStore, useChainStore } from 'src/antelope';
-import { getCurrencySymbol } from 'src/antelope/stores/utils/currency-utils';
+import { prettyPrintCurrency } from 'src/antelope/stores/utils/currency-utils';
 import { NativeCurrencyAddress } from 'src/antelope/types';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 import { WEI_PRECISION, formatWei } from 'src/antelope/stores/utils';
+import { useI18n } from 'vue-i18n';
 
+const { t: $t } = useI18n();
 const userStore = useUserStore();
 const balancesStore = useBalancesStore();
 const chainStore = useChainStore();
 const chainSettings = (chainStore.loggedChain.settings as EVMChainSettings);
 
-// eztodo loading state
+// data
+const systemTokenPrice = ref(0); // always equal to wrapped token price
+const loading = ref(true);
+
 // computed
 const fiatLocale = computed(() => userStore.fiatLocale);
 const fiatCurrency = computed(() => userStore.fiatCurrency);
-const fiatSymbol = computed(() => getCurrencySymbol(fiatLocale.value, fiatCurrency.value));
 const totalFiatValueText = computed(() => {
-    const systemTokenFiatValueBn = chainSettings.getSystemToken().price.value;
-    const wrappedTokenFiatValueBn = chainSettings.getWrappedSystemToken().price.value;
-    const added = systemTokenFiatValueBn.add(wrappedTokenFiatValueBn);
+    if (loading.value) {
+        return '--';
+    }
 
-    // eztodo this is 0.0 when value is 0, should be 0.00
-    return `${fiatSymbol.value} ${formatWei(added, WEI_PRECISION)}`;
+    const totalBalance = +totalSystemAndWrappedBalance.value;
+    const totalFiatValue = totalBalance * systemTokenPrice.value;
+
+    return prettyPrintCurrency(totalFiatValue, 2, fiatLocale.value, false, fiatCurrency.value, false);
 });
 
+const systemTokenName = computed(() => chainSettings.getSystemToken().name);
 const allBalances = computed(() => balancesStore.loggedBalances);
 const systemTokenBalanceBn =  computed(() => allBalances.value.find(b => b.token.contract === NativeCurrencyAddress)?.balance);
 const wrappedTokenBalanceBn = computed(() =>
@@ -44,21 +51,27 @@ const totalBalanceUnitsText = computed(() => {
 
     return `${systemSymbol} + ${wrappedSymbol}`;
 });
+
+
+// methods
+onBeforeMount(() => {
+    chainSettings.getUsdPrice().then((price) => {
+        systemTokenPrice.value = price;
+    }).finally(() => {
+        loading.value = false;
+    });
+});
 </script>
 
 <template>
-<div class="c-wrap-header">
-    <!-- eztodo i18n -->
-    <h5>Total of Wrapped Telos and Telos</h5>
-    <h1>{{ totalFiatValueText }}</h1>
-    <p class="o-text--small-bold u-text--low-contrast">
+<div class="text-center">
+    <h5>{{ $t('evm_wrap.total_of_wrapped_and_unwrapped', { token: systemTokenName }) }}</h5>
+    <h1 class="u-text--high-contrast">{{ totalFiatValueText }}</h1>
+    <p v-if="!loading" class="o-text--small-bold u-text--low-contrast">
         {{ totalSystemAndWrappedBalance }} {{ totalBalanceUnitsText }}
     </p>
 </div>
 </template>
 
 <style lang="scss">
-.c-wrap-header {
-    text-align: center;
-}
 </style>

--- a/src/pages/evm/wrap/WrapPageHeader.vue
+++ b/src/pages/evm/wrap/WrapPageHeader.vue
@@ -21,6 +21,7 @@ const totalFiatValueText = computed(() => {
     const wrappedTokenFiatValueBn = chainSettings.getWrappedSystemToken().price.value;
     const added = systemTokenFiatValueBn.add(wrappedTokenFiatValueBn);
 
+    // eztodo this is 0.0 when value is 0, should be 0.00
     return `${fiatSymbol.value} ${formatWei(added, WEI_PRECISION)}`;
 });
 
@@ -47,6 +48,7 @@ const totalBalanceUnitsText = computed(() => {
 
 <template>
 <div class="c-wrap-header">
+    <!-- eztodo i18n -->
     <h5>Total of Wrapped Telos and Telos</h5>
     <h1>{{ totalFiatValueText }}</h1>
     <p class="o-text--small-bold u-text--low-contrast">

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -111,6 +111,11 @@ const routes = [
                 name: 'demos.nfts',
                 component: () => import('pages/demo/NftDemos.vue'),
             },
+            {
+                path: 'scrollable-cards',
+                name: 'demos.scrollable-cards',
+                component: () => import('pages/demo/ScrollableInfoCardDemos.vue'),
+            },
         ],
     },
 

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -74,11 +74,11 @@ const routes = [
             //     name: 'evm-staking',
             //     component: () => import('pages/evm/staking/StakingPage.vue'),
             // },
-            // {
-            //     path: 'wrap',
-            //     name: 'evm-wrap',
-            //     component: () => import('pages/evm/wrap/WrapPage.vue'),
-            // },
+            {
+                path: 'wrap',
+                name: 'evm-wrap',
+                component: () => import('pages/evm/wrap/WrapPage.vue'),
+            },
         ],
     },
 

--- a/test/jest/__tests__/antelope/stores/utils/currency-utils.spec.ts
+++ b/test/jest/__tests__/antelope/stores/utils/currency-utils.spec.ts
@@ -184,6 +184,10 @@ describe('prettyPrintCurrency', () => {
             prettyPrintCurrency(BigNumber.from(oneThousandFiveHundredEthInWei), 4, 'en-US', true, 'TLOS', undefined, 18),
         ).toBe('1.5K TLOS');
 
+        // ensure that fiat currency expressed as a BigNumber is formatted correctly
+        expect(
+            prettyPrintCurrency(BigNumber.from(100), 2, 'en-US', false, 'USD', false, 2, false),
+        ).toBe('$1.00');
     });
 });
 


### PR DESCRIPTION
# Fixes #440

## Description
This PR adds the header section of the Wrap page. It also fixes an issue with the `prettyPrintCurrency` util

## Test scenarios
- this PR must be tested locally because feature branches do not get netlify builds
- run `git fetch --all && git checkout 440-wrap-page-header && yarn dev`
- go to http://localhost:8081
- log in
- go to Wrap page from navbar
    - the total balances and fiat value should be correct (you can compare to the balances page for this)
    - the amounts in the cards should add up to the total at the top (may be rounded slightly)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
