### PR TITLE
Check for fuel service availability for native transactions

### DIFF
--- a/env.js
+++ b/env.js
@@ -26,7 +26,7 @@ const TESTNET = {
 
 const MAINNET = {
     ...sharedEnv,
-    FUEL_RPC: 'telos.greymass.com',
+    FUEL_RPC: 'https://telos.greymass.com',
     APP_NAME: 'Telos Web Wallet',
     NETWORK_HOST: 'mainnet.telos.net',
     NETWORK_CHAIN_ID:

--- a/src/antelope/stores/account.ts
+++ b/src/antelope/stores/account.ts
@@ -17,7 +17,7 @@ import { Authenticator, User } from 'universal-authenticator-library';
 import { defineStore } from 'pinia';
 import { API } from '@greymass/eosio';
 import { createInitFunction, createTraceFunction } from 'src/antelope/stores/feedback';
-import { FuelUserWrapper } from 'src/api/fuel';
+import { initFuelUserWrapper } from 'src/api/fuel';
 import {
     useFeedbackStore,
     useEVMStore,
@@ -107,7 +107,7 @@ export const useAccountStore = defineStore(store_name, {
                 await authenticator.init();
                 const ualUsers = await authenticator.login();
                 if (ualUsers?.length) {
-                    const ualUser = new FuelUserWrapper(ualUsers[0]);
+                    const ualUser = await initFuelUserWrapper(ualUsers[0]);
                     const permission = (ualUser as unknown as { requestPermission: string })
                         .requestPermission ?? 'active';
                     const account = await ualUser.getAccountName();

--- a/src/api/fuel.js
+++ b/src/api/fuel.js
@@ -54,7 +54,7 @@ class FuelUserWrapper extends User {
           return;
       };
       try {
-          this.available = (await fetch('https://25432542354.com/')).status === 200;
+          this.available = (await fetch(fuelrpc)).status === 200;
       } catch(e) {
           console.error(e);
       }

--- a/src/api/fuel.js
+++ b/src/api/fuel.js
@@ -49,6 +49,7 @@ class FuelUserWrapper extends User {
       this.user = user;
   }
 
+  // called immediately after class instantiation in initFuelUserWrapper()
   async setAvailability() {
       if (!fuelrpc){
           return;

--- a/src/api/fuel.js
+++ b/src/api/fuel.js
@@ -36,14 +36,28 @@ const client = new APIClient({
 });
 
 const fuelrpc = chain.getFuelRPCEndpoint();
-const resourceProviderEndpoint = `https://${fuelrpc}/v1/resource_provider/request_transaction`;
+const resourceProviderEndpoint = `${fuelrpc}/v1/resource_provider/request_transaction`;
 
 // Wrapper for the user to intersect the signTransaction call
-export class FuelUserWrapper extends User {
+// Use initFuelUserWrapper() method to initialize an instance of the class
+class FuelUserWrapper extends User {
   user = null;
+  available = false;
+
   constructor(user/*: User*/) {
       super();
       this.user = user;
+  }
+
+  async setAvailability() {
+      if (!fuelrpc){
+          return;
+      };
+      try {
+          this.available = (await fetch('https://25432542354.com/')).status === 200;
+      } catch(e) {
+          console.error(e);
+      }
   }
 
   async signTransaction(
@@ -52,7 +66,7 @@ export class FuelUserWrapper extends User {
   )/*: Promise<SignTransactionResponse>*/ {
       try {
       // if fuel is not supported, just let the normal implementation to perform
-          if (!fuelrpc) {
+          if (!this.available) {
               return this.user.signTransaction(originalTransaction, originalconfig);
           }
 
@@ -209,6 +223,13 @@ export class FuelUserWrapper extends User {
   getAccountName = async ()/*: Promise<string>*/ => this.user.getAccountName();
   getChainId = async ()/*: Promise<string>*/ => this.user.getChainId();
   getKeys = async ()/*: Promise<string[]>*/ => this.user.getKeys();
+}
+
+// create an instance of FuelUserWrapper class and check fuel service availability
+export async function initFuelUserWrapper(user) {
+    const fuelUserWrapper = new FuelUserWrapper(user);
+    await fuelUserWrapper.setAvailability();
+    return fuelUserWrapper;
 }
 
 // Auxiliar functions to validate with the user the use of the service

--- a/src/store/account/actions.js
+++ b/src/store/account/actions.js
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { FuelUserWrapper } from 'src/api/fuel';
+import { initFuelUserWrapper } from 'src/api/fuel';
 
 export const login = async function(
     { commit, dispatch },
@@ -20,7 +20,7 @@ export const login = async function(
         commit('setJustViewer', justViewer);
         const users = await authenticator.login(account);
         if (users.length) {
-            const account = new FuelUserWrapper(users[0]);
+            const account = await initFuelUserWrapper(users[0]);
             const accountName = await account.getAccountName();
             this.$ualUser = account;
             this.$type = 'ual';


### PR DESCRIPTION
# Fixes #457 

## Description
 For native transactions, if fuel service is unavailable, use default method for signing transactions

## Test scenarios

- checkout branch, set `NETWORK="mainnet"` in .env and login via Ancor
- transaction(s) should succeed using fuel service (verified in Anchor)
- change `fuelrpc` in /src/api/fuel.js to a bad url
- transactions(s) should trigger normal signing behavior using user resources (verified in Anchor)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have tested for mobile functionality and responsiveness
