### PR TITLE
fix: increase limit to fetch all nfts (up to 10k)

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -336,8 +336,8 @@ export default abstract class EVMChainSettings implements ChainSettings {
         return this.getNFTsFromIndexer(`v1/contract/${owner}/nfts`, filter);
     }
 
-    async getNFTsInventory(contract: string, filter: IndexerTransactionsFilter): Promise<NFTClass[]> {
-        return this.getNFTsFromIndexer(`v1/account/${contract}/nfts`, filter);
+    async getNFTsInventory(account: string, filter: IndexerTransactionsFilter): Promise<NFTClass[]> {
+        return this.getNFTsFromIndexer(`v1/account/${account}/nfts`, filter);
     }
 
     constructTokenId(token: TokenSourceInfo): string {

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -277,6 +277,7 @@ export const useNftsStore = defineStore(store_name, {
 const nftsInitialState: NftsState = {
     __indexer_filter: {
         address: '',
+        limit: 10000, // override api limit default value of 50
     },
     __user_filter: {
         collection: '',


### PR DESCRIPTION
## Fixes #467 

## Description
Overrides indexer query limit default value to fetch all NFTs (up to 10k).

## Test scenarios
- tested with contract account that has 3400 NFTs '0x54Bd4f7C2d606797f375272587c36DA2d249Ea6D'

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have tested for mobile functionality and responsiveness
