### PR TITLE
#491 | Clear stores on login/logout

### DIFF
--- a/src/antelope/stores/account.ts
+++ b/src/antelope/stores/account.ts
@@ -19,7 +19,8 @@ import { API } from '@greymass/eosio';
 import { createInitFunction, createTraceFunction } from 'src/antelope/stores/feedback';
 import { initFuelUserWrapper } from 'src/api/fuel';
 import {
-    useFeedbackStore,
+    useBalancesStore,
+    useFeedbackStore, useHistoryStore, useNftsStore,
 } from 'src/antelope';
 import { getAntelope, useChainStore } from 'src/antelope';
 import { errorToString } from 'src/antelope/config';
@@ -151,6 +152,10 @@ export const useAccountStore = defineStore(store_name, {
 
         async loginEVM({ authenticator, network }: LoginEVMActionData): Promise<boolean> {
             this.trace('loginEVM', network);
+            useHistoryStore().clearEvmTransactions();
+            useBalancesStore().clearBalances();
+            useNftsStore().clearNFTs();
+
             let success = false;
             try {
                 const rawAddress = await authenticator.login(network);
@@ -197,6 +202,10 @@ export const useAccountStore = defineStore(store_name, {
 
         async logout() {
             this.trace('logout');
+            useHistoryStore().clearEvmTransactions();
+            useBalancesStore().clearBalances();
+            useNftsStore().clearNFTs();
+
             try {
                 localStorage.removeItem('network');
                 localStorage.removeItem('account');

--- a/src/antelope/stores/account.ts
+++ b/src/antelope/stores/account.ts
@@ -20,7 +20,9 @@ import { createInitFunction, createTraceFunction } from 'src/antelope/stores/fee
 import { initFuelUserWrapper } from 'src/api/fuel';
 import {
     useBalancesStore,
-    useFeedbackStore, useHistoryStore, useNftsStore,
+    useFeedbackStore,
+    useHistoryStore,
+    useNftsStore,
 } from 'src/antelope';
 import { getAntelope, useChainStore } from 'src/antelope';
 import { errorToString } from 'src/antelope/config';

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -383,6 +383,10 @@ export const useBalancesStore = defineStore(store_name, {
 
             this.__wagmiTokenTransferConfig[label] = config;
         },
+        clearBalances() {
+            this.trace('clearBalances');
+            this.__balances = {};
+        },
     },
 });
 

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -290,6 +290,13 @@ export const useHistoryStore = defineStore(store_name, {
             this.trace('setEvmTransactionsRowCount', count);
             this.__total_evm_transaction_count[label] = count;
         },
+        clearEvmTransactions() {
+            this.trace('clearEvmTransactions');
+            this.setEVMTransactionsFilter({ address: '' });
+            this.setEVMTransactions('current', []);
+            this.setShapedTransactionRows('current', []);
+            this.setEvmTransactionsRowCount('current', 0);
+        },
     },
 });
 

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -271,6 +271,14 @@ export const useNftsStore = defineStore(store_name, {
         setUserFilter(filter: UserNftFilter) {
             this.__user_filter = filter;
         },
+        clearNFTs() {
+            this.__inventory = {};
+            this.setUserFilter({});
+            this.setPaginationFilter({
+                address: '',
+                limit: 10000,
+            });
+        },
     },
 });
 

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -272,6 +272,7 @@ export const useNftsStore = defineStore(store_name, {
             this.__user_filter = filter;
         },
         clearNFTs() {
+            this.trace('clearNFTs');
             this.__inventory = {};
             this.setUserFilter({});
             this.setPaginationFilter({


### PR DESCRIPTION
# Fixes #491

## Description
Currently, if a user logs out and logs in with another account, they are briefly showed the transactions from the previous account. This PR clears stores, including transactions, upon login and logout

## Test scenarios
- setup your metamask to have at least 2 accounts
- log in with an account and go to the transactions tab
- log out
- log in with another account
- go to the transactions tab
    - you should not see stale transactions

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
