### PR TITLE
Anchoring TLOS on top of the balance table

### DIFF
--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -325,8 +325,12 @@ export const useBalancesStore = defineStore(store_name, {
         sortBalances(label: string): void {
             this.trace('sortBalances', label);
             const allTokens = this.__balances[label] as TokenBalance[];
-            const [tokensWithFiatValue, tokensWithoutFiatValue] = this.splitTokensBasedOnHasFiatValue(allTokens);
+            const systemTokenBalance = allTokens.filter(b => b.token.isSystem);
+            const erc20TokenBalances = allTokens.filter(b => !b.token.isSystem);
+
+            const [tokensWithFiatValue, tokensWithoutFiatValue] = this.splitTokensBasedOnHasFiatValue(erc20TokenBalances);
             this.__balances[label] = [
+                ...systemTokenBalance,
                 ...tokensWithFiatValue,
                 ...tokensWithoutFiatValue,
             ];


### PR DESCRIPTION
# Fixes #503

## Description
This small PR makes the TLOS token balance to be anchored to the top of the balance table

## Test scenarios
- Log in with an account with few or zero TLOS balance and others ERC20 tokens with token price un usd
- You should find TLOS balance always on top


![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/86fd7b37-aca5-473d-889e-423d87eb65a5)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
