### PR TITLE
#441 | Wrap/unwrap pages

### DIFF
--- a/src/antelope/stores/account.ts
+++ b/src/antelope/stores/account.ts
@@ -34,8 +34,9 @@ import {
     addressString,
 } from 'src/antelope/types';
 import { EVMAuthenticator } from 'src/antelope/wallets';
-import { getChecksumAddress, truncateAddress } from 'src/antelope/stores/utils/text-utils';
+import { truncateAddress } from 'src/antelope/stores/utils/text-utils';
 import { toRaw } from 'vue';
+import { getAddress } from 'ethers/lib/utils';
 
 export interface LoginNativeActionData {
     authenticator: Authenticator,
@@ -164,7 +165,7 @@ export const useAccountStore = defineStore(store_name, {
                 this.trace('loginEVM', 'authenticator finished with address', rawAddress);
 
                 if (rawAddress) {
-                    const address = getChecksumAddress(rawAddress);
+                    const address = getAddress(rawAddress) as addressString;
 
                     const displayAddress = truncateAddress(address);
 

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -254,6 +254,50 @@ export const useBalancesStore = defineStore(store_name, {
                 await useBalancesStore().updateBalancesForAccount(label, toRaw(useAccountStore().loggedAccount));
             }
         },
+        async wrapSystemTokens(amount: BigNumber): Promise<TransactionResponse> {
+            this.trace('wrapSystemTokens', amount.toString());
+            const label = 'logged';
+            try {
+                useFeedbackStore().setLoading('wrapSystemTokens');
+                const chain = useChainStore().loggedChain;
+                if (chain.settings.isNative()) {
+                    console.error('ERROR: wrap not supported on native');
+                    throw new AntelopeError('antelope.evm.error_wrap_not_supported_on_native');
+                } else {
+                    const account = useAccountStore().loggedAccount as EvmAccountModel;
+                    const authenticator = useAccountStore().getEVMAuthenticator(label);
+                    return await authenticator.wrapSystemToken(amount)
+                        .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
+                }
+            } catch (error) {
+                console.error(error);
+                throw getAntelope().config.wrapError('antelope.evm.error_wrap_failed', error);
+            } finally {
+                useFeedbackStore().unsetLoading('wrapSystemTokens');
+            }
+        },
+        async unwrapSystemTokens(amount: BigNumber): Promise<TransactionResponse> {
+            this.trace('unwrapSystemTokens', amount.toString());
+            const label = 'logged';
+            try {
+                useFeedbackStore().setLoading('unwrapSystemTokens');
+                const chain = useChainStore().loggedChain;
+                if (chain.settings.isNative()) {
+                    console.error('ERROR: unwrap not supported on native');
+                    throw new AntelopeError('antelope.evm.error_unwrap_not_supported_on_native');
+                } else {
+                    const account = useAccountStore().loggedAccount as EvmAccountModel;
+                    const authenticator = useAccountStore().getEVMAuthenticator(label);
+                    return await authenticator.unwrapSystemToken(amount)
+                        .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
+                }
+            } catch (error) {
+                console.error(error);
+                throw getAntelope().config.wrapError('antelope.evm.error_unwrap_failed', error);
+            } finally {
+                useFeedbackStore().unsetLoading('unwrapSystemTokens');
+            }
+        },
         async transferNativeTokens(
             settings: NativeChainSettings,
             account: AccountModel,

--- a/src/antelope/stores/utils/abi/index.ts
+++ b/src/antelope/stores/utils/abi/index.ts
@@ -3,6 +3,7 @@ export * from 'src/antelope/stores/utils/abi/erc721Metadata';
 export * from 'src/antelope/stores/utils/abi/erc1155';
 export * from 'src/antelope/stores/utils/abi/erc20';
 export * from 'src/antelope/stores/utils/abi/supportsInterface';
+export * from 'src/antelope/stores/utils/abi/wrapTlos';
 export * from 'src/antelope/stores/utils/abi/signature/transfer_signatures';
 
 export type StateMutabilityType = 'pure' | 'view' | 'nonpayable' | 'payable';

--- a/src/antelope/stores/utils/abi/wrapTlos.ts
+++ b/src/antelope/stores/utils/abi/wrapTlos.ts
@@ -1,0 +1,32 @@
+import { EvmABI } from '.';
+
+export const wtlosAbiDeposit: EvmABI = [
+    {
+        constant: false,
+        inputs: [],
+        name: 'deposit',
+        outputs: [],
+        payable: true,
+        stateMutability: 'payable',
+        type: 'function',
+    },
+];
+
+export const wtlosAbiWithdraw: EvmABI = [
+    {
+        constant: false,
+        inputs: [
+            {
+                indexed: false,
+                internalType: 'uint256',
+                name: 'wad',
+                type: 'uint256',
+            },
+        ],
+        name: 'withdraw',
+        outputs: [],
+        payable: false,
+        stateMutability: 'nonpayable',
+        type: 'function',
+    },
+];

--- a/src/antelope/stores/utils/contracts/EvmContract.ts
+++ b/src/antelope/stores/utils/contracts/EvmContract.ts
@@ -1,5 +1,5 @@
 import { ContractInterface, ethers } from 'ethers';
-import { markRaw } from 'vue';
+import { markRaw, toRaw } from 'vue';
 import {
     AntelopeError, EvmContractCalldata,
     EvmABI,
@@ -26,7 +26,6 @@ export default class EvmContract {
     private readonly _manager?: EvmContractManagerI;
     private readonly _token?: TokenSourceInfo | null;
 
-    private _contract?: ethers.Contract | null;
     private _verified?: boolean;
 
     constructor({
@@ -140,10 +139,7 @@ export default class EvmContract {
         }
         const signer = await this._manager?.getSigner();
 
-        if (!this._contract || signer) {
-            this._contract = new ethers.Contract(this.address, this.abi, signer);
-        }
-        return this._contract;
+        return new ethers.Contract(this.address, this.abi, signer);
     }
 
     async parseTransaction(data:string) {

--- a/src/antelope/stores/utils/contracts/EvmContract.ts
+++ b/src/antelope/stores/utils/contracts/EvmContract.ts
@@ -1,5 +1,5 @@
 import { ContractInterface, ethers } from 'ethers';
-import { markRaw, toRaw } from 'vue';
+import { markRaw } from 'vue';
 import {
     AntelopeError, EvmContractCalldata,
     EvmABI,

--- a/src/antelope/stores/utils/index.ts
+++ b/src/antelope/stores/utils/index.ts
@@ -1,11 +1,7 @@
 export * from 'src/antelope/stores/utils/abi/signature';
 import { BigNumber, ethers } from 'ethers';
 import { formatUnits } from '@ethersproject/units';
-import { keccak256 } from '@ethersproject/keccak256';
-import { toUtf8Bytes } from '@ethersproject/strings';
-import {
-    EvmABIEntry,
-} from 'src/antelope/types';
+import { EvmABIEntry } from 'src/antelope/types';
 import { fromUnixTime, format } from 'date-fns';
 import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
 import { prettyPrintCurrency } from 'src/antelope/stores/utils/currency-utils';
@@ -70,30 +66,6 @@ export function isValidAddressFormat(ethAddressString: string): boolean {
 
 export function getTopicHash(topic: string): string {
     return `0x${topic.substring(topic.length - 40)}`;
-}
-
-export function toChecksumAddress(address: string): string {
-    if (!address) {
-        return address;
-    }
-
-    let addy = address.toLowerCase().replace('0x', '');
-    if (addy.length !== 40) {
-        addy = addy.padStart(40, '0');
-    }
-
-    const hash = keccak256(toUtf8Bytes(addy));
-    let ret = '0x';
-
-    for (let i = 0; i < addy.length; i++) {
-        if (parseInt(hash[i], 16) >= 8) {
-            ret += addy[i].toUpperCase();
-        } else {
-            ret += addy[i];
-        }
-    }
-
-    return ret;
 }
 
 export function parseErrorMessage(output: string): string {

--- a/src/antelope/stores/utils/text-utils.ts
+++ b/src/antelope/stores/utils/text-utils.ts
@@ -1,5 +1,3 @@
-import { arrayify, isHexString, keccak256 } from 'ethers/lib/utils';
-import { addressString } from 'src/antelope/stores/utils/abi';
 
 /**
  * Given some text, ellipsizes the text if it exceeds a specific length
@@ -24,37 +22,3 @@ export function truncateText(text: string, maxLength = 10) {
 export function truncateAddress(address: string) {
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
-
-/**
- * convertes a address to a checksum address
- *
- * @param address
- */
-export function getChecksumAddress(address: string): addressString {
-    if (!isHexString(address, 20)) {
-        throw new Error(`Invalid address: ${address}`);
-    }
-
-    const addressLower = address.toLowerCase();
-
-    const chars = addressLower.substring(2).split('');
-
-    const expanded = new Uint8Array(40);
-    for (let i = 0; i < 40; i++) {
-        expanded[i] = chars[i].charCodeAt(0);
-    }
-
-    const hashed = arrayify(keccak256(expanded));
-
-    for (let i = 0; i < 40; i += 2) {
-        if ((hashed[i >> 1] >> 4) >= 8) {
-            chars[i] = chars[i].toUpperCase();
-        }
-        if ((hashed[i >> 1] & 0x0f) >= 8) {
-            chars[i + 1] = chars[i + 1].toUpperCase();
-        }
-    }
-
-    return '0x' + chars.join('') as addressString;
-}
-

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -25,6 +25,7 @@ export abstract class EVMAuthenticator {
     abstract getERC20TokenBalance(address: addressString | string, tokenAddress: addressString | string): Promise<BigNumber>;
     abstract transferTokens(token: TokenClass, amount: BigNumber, to: addressString | string): Promise<EvmTransactionResponse | SendTransactionResult | WriteContractResult>;
     abstract prepareTokenForTransfer(token: TokenClass | null, amount: BigNumber, to: string): Promise<void>;
+    abstract wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse | WriteContractResult>;
     abstract isConnectedTo(chainId: string): Promise<boolean>;
     abstract externalProvider(): Promise<ethers.providers.ExternalProvider>;
     abstract web3Provider(): Promise<ethers.providers.Web3Provider>;

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -26,6 +26,7 @@ export abstract class EVMAuthenticator {
     abstract transferTokens(token: TokenClass, amount: BigNumber, to: addressString | string): Promise<EvmTransactionResponse | SendTransactionResult | WriteContractResult>;
     abstract prepareTokenForTransfer(token: TokenClass | null, amount: BigNumber, to: string): Promise<void>;
     abstract wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse | WriteContractResult>;
+    abstract unwrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse | WriteContractResult>;
     abstract isConnectedTo(chainId: string): Promise<boolean>;
     abstract externalProvider(): Promise<ethers.providers.ExternalProvider>;
     abstract web3Provider(): Promise<ethers.providers.Web3Provider>;

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -29,6 +29,7 @@ export abstract class EVMAuthenticator {
     abstract isConnectedTo(chainId: string): Promise<boolean>;
     abstract externalProvider(): Promise<ethers.providers.ExternalProvider>;
     abstract web3Provider(): Promise<ethers.providers.Web3Provider>;
+    abstract getSigner(): Promise<ethers.Signer>;
 
     // to easily clone the authenticator
     abstract newInstance(label: string): EVMAuthenticator;

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -1,6 +1,6 @@
 
 
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { BehaviorSubject, filter, map } from 'rxjs';
 import { useChainStore, useEVMStore, useFeedbackStore } from 'src/antelope';
 import { AntelopeError, ERC20_TYPE, EthereumProvider, EvmTransactionResponse, TokenClass, addressString } from 'src/antelope/types';
@@ -61,6 +61,20 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             }
         });
     }
+
+    async wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse> {
+        const wrappedSystemTokenContractAddress = (useChainStore().currentChain.settings as EVMChainSettings).getWrappedSystemToken().address;
+        const wrappedSystemTokenContractInstance = await (await useEVMStore().getContract(this, wrappedSystemTokenContractAddress, 'logged', ERC20_TYPE))?.getContractInstance();
+        if (wrappedSystemTokenContractInstance) {
+            const test = wrappedSystemTokenContractInstance.functions;
+            debugger;
+            const transaction = (await wrappedSystemTokenContractInstance.functions.deposit()) as EvmTransactionResponse;
+            return transaction;
+        } else {
+            throw 'eztodo this error';
+        }
+    }
+
 
     // EVMAuthenticator API ----------------------------------------------------------
 

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -64,7 +64,8 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
 
     async wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse> {
         useFeedbackStore().setLoading('wrapSystemToken');
-        const wrappedSystemTokenContractAddress = (useChainStore().currentChain.settings as EVMChainSettings).getWrappedSystemToken().address;
+        const chainSettings = (useChainStore().currentChain.settings as EVMChainSettings);
+        const wrappedSystemTokenContractAddress = chainSettings.getWrappedSystemToken().address;
         let wrappedSystemTokenContractInstance: ethers.Contract | undefined;
         try {
             const wrappedSystemTokenContract = await useEVMStore().getContract(this, wrappedSystemTokenContractAddress, 'logged', ERC20_TYPE);

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -1,5 +1,5 @@
 import { AuthProvider, ChainNetwork, OreId, OreIdOptions, JSONObject, UserChainAccount } from 'oreid-js';
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { WebPopup } from 'oreid-webpopup';
 import { erc20Abi } from 'src/antelope/types';
 import { EVMAuthenticator } from 'src/antelope/wallets';
@@ -254,6 +254,10 @@ export class OreIdAuth extends EVMAuthenticator {
 
     async prepareTokenForTransfer(token: TokenClass | null, amount: ethers.BigNumber, to: string): Promise<void> {
         this.trace('prepareTokenForTransfer', [token], amount, to);
+    }
+
+    async wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse> {
+        throw 'eztodo this';
     }
 
     async isConnectedTo(chainId: string): Promise<boolean> {

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -281,4 +281,10 @@ export class OreIdAuth extends EVMAuthenticator {
         });
     }
 
+    async getSigner(): Promise<ethers.Signer> {
+        this.trace('getSigner');
+        const provider = await this.web3Provider();
+        return provider.getSigner();
+    }
+
 }

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -277,45 +277,46 @@ export class WalletConnectAuth extends EVMAuthenticator {
     }
 
     async wrapSystemToken(amount: BigNumber): Promise<WriteContractResult> {
-        useFeedbackStore().setLoading('wrapSystemToken');
-        const chainSettings = (useChainStore().currentChain.settings as EVMChainSettings);
-        const wrappedSystemTokenContractAddress = chainSettings.getWrappedSystemToken().address as addressString;
-        let abi: EvmABI | null | undefined;
-        try {
-            const wrappedSystemTokenContract = await useEVMStore().getContract(this, wrappedSystemTokenContractAddress, 'logged', ERC20_TYPE);
-            abi = wrappedSystemTokenContract?.abi;
+        throw 'eztodo';
+        // useFeedbackStore().setLoading('wrapSystemToken');
+        // const chainSettings = (useChainStore().currentChain.settings as EVMChainSettings);
+        // const wrappedSystemTokenContractAddress = chainSettings.getWrappedSystemToken().address as addressString;
+        // let abi: EvmABI | null | undefined;
+        // try {
+        //     const wrappedSystemTokenContract = await useEVMStore().getContract(this, wrappedSystemTokenContractAddress, 'logged', ERC20_TYPE);
+        //     abi = wrappedSystemTokenContract?.abi;
 
-            if (!abi) {
-                throw 'Unable to get wrapped system contract ABI';
-            }
-        } catch (error) {
-            useFeedbackStore().unsetLoading('wrapSystemToken');
-            throw new AntelopeError('antelope.wrap.error_getting_wrapped_contract', { error });
-        }
+        //     if (!abi) {
+        //         throw 'Unable to get wrapped system contract ABI';
+        //     }
+        // } catch (error) {
+        //     useFeedbackStore().unsetLoading('wrapSystemToken');
+        //     throw new AntelopeError('antelope.wrap.error_getting_wrapped_contract', { error });
+        // }
 
-        let request;
-        try {
-            const prepareWriteContractResult = await prepareWriteContract({
-                address: wrappedSystemTokenContractAddress,
-                abi,
-                functionName: 'deposit',
-                args: [amount],
-            });
+        // let request;
+        // try {
+        //     const prepareWriteContractResult = await prepareWriteContract({
+        //         address: wrappedSystemTokenContractAddress,
+        //         abi,
+        //         functionName: 'deposit',
+        //         args: [amount],
+        //     });
 
-            request = prepareWriteContractResult.request;
-        } catch(e) {
-            console.error(e);
-            useFeedbackStore().unsetLoading('wrapSystemToken');
-            // eztodo throw antelope error
-        }
+        //     request = prepareWriteContractResult.request;
+        // } catch(e) {
+        //     console.error(e);
+        //     useFeedbackStore().unsetLoading('wrapSystemToken');
+        //     // eztodo throw antelope error
+        // }
 
-        try {
-            useFeedbackStore().unsetLoading('wrapSystemToken');
-            return await writeContract(request as unknown as WriteContractPreparedArgs<readonly unknown[], string>);
-        } catch {
-            useFeedbackStore().unsetLoading('wrapSystemToken');
-            throw new AntelopeError('antelope.wrap.error_wrap');
-        }
+        // try {
+        //     useFeedbackStore().unsetLoading('wrapSystemToken');
+        //     return await writeContract(request as unknown as WriteContractPreparedArgs<readonly unknown[], string>);
+        // } catch {
+        //     useFeedbackStore().unsetLoading('wrapSystemToken');
+        //     throw new AntelopeError('antelope.wrap.error_wrap');
+        // }
     }
 
     async isConnectedTo(chainId: string): Promise<boolean> {

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -275,6 +275,10 @@ export class WalletConnectAuth extends EVMAuthenticator {
         await this._debouncedPrepareTokenConfig(token, amount, to);
     }
 
+    async wrapSystemToken(amount: BigNumber): Promise<WriteContractResult> {
+        throw 'eztodo this';
+    }
+
     async isConnectedTo(chainId: string): Promise<boolean> {
         this.trace('isConnectedTo', chainId);
 

--- a/src/assets/icon--arrow-down.svg
+++ b/src/assets/icon--arrow-down.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="18" viewBox="0 0 20 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 8L10 18L0 8H6V0H14V8H20ZM10 15L15 10H12V2H8V10H5L10 15Z" fill="#4D4D4D"/>
+</svg>

--- a/src/components/ConversionRateBadge.vue
+++ b/src/components/ConversionRateBadge.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { BigNumber } from 'ethers';
+import { useUserStore } from 'src/antelope';
+import { prettyPrintCurrency } from 'src/antelope/stores/utils/currency-utils';
+import { computed } from 'vue';
+
+const userStore = useUserStore();
+
+const props = defineProps<{
+    tokenOneSymbol: string;
+    tokenTwoSymbol: string;
+    tokenTwoAmount: BigNumber; // the amount of token two in a single token one
+    tokenTwoDecimals: number; // the number of decimals in token two, e.g. 18 for ETH
+}>();
+
+// computed
+const fiatLocale = computed(() => userStore.fiatLocale);
+
+const label = computed(() => {
+    const prettyTokenTwoAmount = prettyPrintCurrency(
+        props.tokenTwoAmount,
+        4,
+        fiatLocale.value,
+        true,
+        props.tokenTwoSymbol,
+        false,
+        props.tokenTwoDecimals,
+        false,
+    );
+
+    return `1 ${props.tokenOneSymbol} = ${prettyTokenTwoAmount}`;
+});
+</script>
+
+<template>
+<div class="c-conversion-rate-badge">
+    <q-badge outline :label="label" />
+</div>
+</template>
+
+<style lang="scss">
+.c-conversion-rate-badge {
+    // quasar overrides
+    .q-badge {
+        padding: 4px 6px;
+        border-color: var(--accent-color-3);
+        color: var(--text-default-contrast)
+    }
+}
+</style>

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { PropType, defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'AppPage',
@@ -122,9 +122,12 @@ export default defineComponent({
     }
 
     &__tabs {
-        margin-top: 48px;
         flex-grow: 1;
         color: var(--header-text-color);
+
+        @include sm-and-up {
+            margin-top: 36px;
+        }
 
         // quasar override
         .q-tab__indicator {

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { PropType, defineComponent } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'AppPage',

--- a/src/components/evm/inputs/CurrencyInput.vue
+++ b/src/components/evm/inputs/CurrencyInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 
-import { BigNumber } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { formatUnits, parseUnits } from 'ethers/lib/utils';
 import { usePlatformStore } from 'src/antelope';
 import InlineSvg from 'vue-inline-svg';
@@ -45,6 +45,13 @@ export default defineComponent({
             // the number of decimals used for the token. Use 2 for fiat values
             type: Number,
             required: true,
+            validator: (value: number) => value >= 0 && Number.isInteger(value),
+        },
+        decimalsToDisplay: {
+            // the number of decimals to display in the input.
+            type: Number,
+            required: false,
+            default: 4,
             validator: (value: number) => value >= 0 && Number.isInteger(value),
         },
         secondaryCurrencyConversionFactor: {
@@ -764,7 +771,7 @@ export default defineComponent({
                 if (this.currenciesAreSwapped) {
                     maxDecimals = this.secondaryCurrencyDecimals;
                 } else {
-                    maxDecimals = this.decimals;
+                    maxDecimals = this.decimalsToDisplay;
                 }
 
                 const keypressIsDigit = numKeys.includes(event.key);
@@ -861,7 +868,8 @@ export default defineComponent({
                     this.secondaryCurrencyDecimals,
                     this.secondaryCurrencyConversionFactor,
                 );
-                const maxValueDecimals = formatUnits(maxValueInSecondaryCurrency, this.secondaryCurrencyDecimals).split('.')[1].length;
+                const currentDecimals = formatUnits(maxValueInSecondaryCurrency, this.secondaryCurrencyDecimals).split('.')[1].length;
+                const maxValueDecimals = Math.min(currentDecimals, this.decimalsToDisplay);
 
                 formattedMaxValue = prettyPrintCurrency(
                     maxValueInSecondaryCurrency,
@@ -874,7 +882,8 @@ export default defineComponent({
                     true,
                 );
             } else {
-                const maxValueDecimals = formatUnits(this.maxValue, this.decimals).split('.')[1].length;
+                const currentDecimals = formatUnits(this.maxValue, this.decimals).split('.')[1].length;
+                const maxValueDecimals = Math.min(currentDecimals, this.decimalsToDisplay);
 
                 formattedMaxValue = prettyPrintCurrency(
                     this.maxValue,
@@ -1107,7 +1116,7 @@ export default defineComponent({
         top: 25px;
         left: var(--symbol-left);
         color: var(--text-low-contrast);
-
+        pointer-events: none;
     }
 
     &__amount-available {

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -21,6 +21,7 @@ $saveBtn: #2e1f4f;
 .body--light {
     $accent-1: #571AFF;
     $accent-2: #505DCD;
+    $accent-4: #A5A6F6;
     $page-header: #F7F5FF;
     $site-gradient: linear-gradient(0.4turn, #071033, #6039A4);
     $high-contrast-text-color: #282828;
@@ -39,6 +40,7 @@ $saveBtn: #2e1f4f;
 
     --accent-color: #{$accent-1};
     --accent-color-2: #{$accent-2};
+    --accent-color-4: #{$accent-4};
     --negative-color: #{$negative};
     --positive-color: #{$positive};
     --warning-color-ui: #{$warning};

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -19,6 +19,8 @@ $saveBtn: #2e1f4f;
 
 // Light Mode
 .body--light {
+    $accent-1: #571AFF;
+    $accent-2: #505DCD;
     $page-header: #F7F5FF;
     $site-gradient: linear-gradient(0.4turn, #071033, #6039A4);
     $high-contrast-text-color: #282828;
@@ -26,17 +28,17 @@ $saveBtn: #2e1f4f;
     $low-contrast-text-color: #939393;
     $native-contrast-text-color: #F7F5FF;
     $menu-text: #fff;
-    $link-color: #646FD3;
     $canvas: #fff;
 
     --text-high-contrast: #{$high-contrast-text-color};
     --text-default-contrast: #{$default-contrast-text-color};
     --text-low-contrast: #{$low-contrast-text-color};
     --native-contrast-text-color: #{$native-contrast-text-color};
-    --link-color: #{$link-color};
+    --link-color: #{$accent-2};
     --menu-text: #{$menu-text};
 
-    --accent-color: #{$primary};
+    --accent-color: #{$accent-1};
+    --accent-color-2: #{$accent-2};
     --negative-color: #{$negative};
     --positive-color: #{$positive};
     --warning-color-ui: #{$warning};
@@ -49,7 +51,6 @@ $saveBtn: #2e1f4f;
     --bg-color-hover: #{$page-header};
 
     --header-bg-color: #{$page-header};
-    --header-item-outline-color: #{rgba($primary, 10%)};
 }
 
 // Dark Mode

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -49,7 +49,7 @@ $saveBtn: #2e1f4f;
     --bg-color-hover: #{$page-header};
 
     --header-bg-color: #{$page-header};
-    --header-item-outline-color: #{rgba($primary, 10%)}; // eztodo replace original of this
+    --header-item-outline-color: #{rgba($primary, 10%)};
 }
 
 // Dark Mode

--- a/src/css/global/_colors.scss
+++ b/src/css/global/_colors.scss
@@ -21,6 +21,7 @@ $saveBtn: #2e1f4f;
 .body--light {
     $accent-1: #571AFF;
     $accent-2: #505DCD;
+    $accent-3: #DDD1FF;
     $accent-4: #A5A6F6;
     $page-header: #F7F5FF;
     $site-gradient: linear-gradient(0.4turn, #071033, #6039A4);
@@ -40,6 +41,7 @@ $saveBtn: #2e1f4f;
 
     --accent-color: #{$accent-1};
     --accent-color-2: #{$accent-2};
+    --accent-color-3: #{$accent-3};
     --accent-color-4: #{$accent-4};
     --negative-color: #{$negative};
     --positive-color: #{$positive};

--- a/src/css/global/_media-queries.scss
+++ b/src/css/global/_media-queries.scss
@@ -27,6 +27,12 @@
     }
 }
 
+@mixin lg-and-up {
+    @media only screen and (min-width: $breakpoint-lg-min) {
+        @content;
+    }
+}
+
 @mixin mobile-landscape {
     @media only screen and (max-width: $breakpoint-sm-max) and (orientation: landscape) {
         @content;

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -170,7 +170,9 @@ export default {
     },
     evm_wrap: {
         wrap: 'Wrap',
+        unwrap: 'Unwrap',
         wrap_button_label: 'Wrap {systemSymbol} to {wrappedSymbol}',
+        unwrap_button_label: 'Unwrap {wrappedSymbol} to {systemSymbol}',
         total_of_wrapped_and_unwrapped: 'Total of wrapped {token} and {token}',
         wrapped_card_label: 'Wrapped {symbol}',
         wrapped_card_tooltip: '{wrappedSymbol} can be used to buy NFTs and trade on decentralized exchanges, among other things. Wrapping {systemSymbol} is done via a decentralized smart contract.',
@@ -182,6 +184,7 @@ export default {
         unwrap_sidebar_title: 'Unwrapping {symbol}',
         unwrap_sidebar: 'Unwrap your {wrappedSymbol} to get your {systemSymbol} back instantly.',
         wrap_input_label: 'Wrapping Amount',
+        unwrap_input_label: 'Unwrapping Amount',
     },
     notification:{
         success_title_trx: 'Success',
@@ -201,6 +204,7 @@ export default {
         neutral_message_unstaking: 'Unstaking <b>{quantity}</b>',
         neutral_message_revoking: 'Revoking  <b>{symbol}</b> allowance for <b>{address}</b>',
         neutral_message_wrapping: 'Wrapping <b>{quantity} {symbol}</b>',
+        neutral_message_unwrapping: 'Unwrapping <b>{quantity} {symbol}</b>',
     },
     resources: {
         title: 'Network Resources',
@@ -468,6 +472,10 @@ export default {
             error_unpredictable_gas_limit: 'The gas limit for this transaction couldn\'t be estimated',
             error_user_rejected: 'You rejected the transaction',
             error_transaction_canceled: 'You canceled the action',
+            error_wrap_not_supported_on_native: 'Wrap is not supported on native chain',
+            error_unwrap_not_supported_on_native: 'Unwrap is not supported on native chain',
+            error_wrap_failed: 'An unknown error occurred when wrapping tokens',
+            error_unwrap_failed: 'An unknown error occurred when unwrapping tokens',
         },
         history: {
             error_fetching_transactions: 'Unexpected error fetching transactions. Please refresh the page to try again.',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -171,6 +171,10 @@ export default {
         wrapped_card_label: 'Wrapped {symbol}',
         wrapped_card_tooltip: '{wrappedSymbol} can be used to buy NFTs and trade on decentralized exchanges, among other things. Wrapping {systemSymbol} is done via a decentralized smart contract.',
         unwrapped_card_tooltip: 'An equal amount of {systemSymbol} will be received as the amount of {wrappedSymbol} that was unwrapped. Unwrapping {wrappedSymbol} is done via a decentralized smart contract.',
+        wrap_sidebar_title: 'Why wrap {symbol}?',
+        wrap_sidebar_content_fragment_1: 'Wrap your {systemSymbol} to {wrappedSymbol} for ',
+        wrap_sidebar_content_fragment_bold: 'seamless integration with DeFi platforms',
+        wrap_sidebar_content_fragment_3: ', improved compatibility with ERC-20 tokens, and cross-chain interoperability. Unlock new opportunities and financial services by converting your native {systemSymbol} into the versatile {wrappedSymbol} token.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -138,6 +138,7 @@ export default {
         collection: 'Collection',
         search: 'Search',
         no_results: 'No results found',
+        toggle: 'Toggle "{text}"',
     },
     nft : {
         collectible: 'Collectible',
@@ -175,6 +176,8 @@ export default {
         wrap_sidebar_content_fragment_1: 'Wrap your {systemSymbol} to {wrappedSymbol} for ',
         wrap_sidebar_content_fragment_bold: 'seamless integration with DeFi platforms',
         wrap_sidebar_content_fragment_3: ', improved compatibility with ERC-20 tokens, and cross-chain interoperability. Unlock new opportunities and financial services by converting your native {systemSymbol} into the versatile {wrappedSymbol} token.',
+        unwrap_sidebar_title: 'Unwrapping {symbol}',
+        unwrap_sidebar: 'Unwrap your {wrappedSymbol} to get your {systemSymbol} back instantly.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -139,6 +139,7 @@ export default {
         search: 'Search',
         no_results: 'No results found',
         toggle: 'Toggle "{text}"',
+        arrow_icon_alt: 'Arrow icon',
     },
     nft : {
         collectible: 'Collectible',
@@ -168,6 +169,8 @@ export default {
         empty_collection_link_text: 'here',
     },
     evm_wrap: {
+        wrap: 'Wrap',
+        wrap_button_label: 'Wrap {systemSymbol} to {wrappedSymbol}',
         total_of_wrapped_and_unwrapped: 'Total of wrapped {token} and {token}',
         wrapped_card_label: 'Wrapped {symbol}',
         wrapped_card_tooltip: '{wrappedSymbol} can be used to buy NFTs and trade on decentralized exchanges, among other things. Wrapping {systemSymbol} is done via a decentralized smart contract.',
@@ -178,6 +181,7 @@ export default {
         wrap_sidebar_content_fragment_3: ', improved compatibility with ERC-20 tokens, and cross-chain interoperability. Unlock new opportunities and financial services by converting your native {systemSymbol} into the versatile {wrappedSymbol} token.',
         unwrap_sidebar_title: 'Unwrapping {symbol}',
         unwrap_sidebar: 'Unwrap your {wrappedSymbol} to get your {systemSymbol} back instantly.',
+        wrap_input_label: 'Wrapping Amount',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -200,6 +200,7 @@ export default {
         neutral_message_staking: 'Staking <b>{quantity}</b>',
         neutral_message_unstaking: 'Unstaking <b>{quantity}</b>',
         neutral_message_revoking: 'Revoking  <b>{symbol}</b> allowance for <b>{address}</b>',
+        neutral_message_wrapping: 'Wrapping <b>{quantity} {symbol}</b>',
     },
     resources: {
         title: 'Network Resources',
@@ -494,6 +495,10 @@ export default {
             error_system_token_transfer_config: 'Error getting Wagmi system token transfer config',
             error_token_transfer_config: 'Error getting Wagmi token transfer config',
             error_oreid_no_chain_account: 'The app {appName} does not have a chain account for the chain {networkName}',
+        },
+        wrap: {
+            error_getting_wrapped_contract: 'An error occurred while getting the wrapped system token contract',
+            error_wrap: 'An unknown error occurred while wrapping system token',
         },
     },
 };

--- a/src/layouts/EVMSidebarPage.vue
+++ b/src/layouts/EVMSidebarPage.vue
@@ -32,7 +32,7 @@ function handleExpansionItemUpdate() {
 </script>
 
 <template>
-<div class="c-sidebar-page">
+<div class="c-sidebar-page q-mb-xl">
     <aside class="c-sidebar-page__sidebar-container">
         <q-expansion-item
             :model-value="expansionItemModel || isLarge"
@@ -92,6 +92,7 @@ function handleExpansionItemUpdate() {
         grid-area: b;
         word-break: break-all;
         max-width: 1000px;
+        width: 100%;
         margin: auto;
 
         @include lg-and-up {

--- a/src/layouts/EVMSidebarPage.vue
+++ b/src/layouts/EVMSidebarPage.vue
@@ -18,12 +18,12 @@ const props = defineProps<{
 const expansionItemModel = ref(false);
 
 // computed
-const isMobile = computed(() => $q.screen.lt.md);
+const isStacked = computed(() => $q.screen.lt.lg);
 const isLarge = computed(() => $q.screen.gt.md);
 
 // methods
 function handleExpansionItemUpdate() {
-    if (!isMobile.value) {
+    if (!isStacked.value) {
         expansionItemModel.value = true;
     } else {
         expansionItemModel.value = !expansionItemModel.value;
@@ -33,11 +33,12 @@ function handleExpansionItemUpdate() {
 
 <template>
 <div class="c-sidebar-page">
-    <div class="c-sidebar-page__sidebar-container">
+    <aside class="c-sidebar-page__sidebar-container">
         <q-expansion-item
             :model-value="expansionItemModel || isLarge"
             :label="sidebarContent.header"
-            :expand-icon="isMobile ? 'expand_more' : 'none'"
+            :toggle-aria-label="$t('global.toggle', { text: sidebarContent.header })"
+            :expand-icon="isStacked ? 'expand_more' : 'none'"
             class="c-sidebar-page__expansion-item"
             @update:model-value="handleExpansionItemUpdate"
         >
@@ -53,7 +54,7 @@ function handleExpansionItemUpdate() {
                 </q-card-section>
             </q-card>
         </q-expansion-item>
-    </div>
+    </aside>
     <div class="c-sidebar-page__body-container">
         <slot></slot>
     </div>
@@ -63,6 +64,7 @@ function handleExpansionItemUpdate() {
 <style lang="scss">
 .c-sidebar-page {
     display: grid;
+    gap: 24px;
 
     grid-template: 'a'
                    'b';
@@ -81,17 +83,27 @@ function handleExpansionItemUpdate() {
 
         @include lg-and-up {
             margin: unset;
+            display: flex;
+            justify-content: center;
         }
     }
 
     &__body-container {
         grid-area: b;
+        word-break: break-all;
+        max-width: 1000px;
+        margin: auto;
+
+        @include lg-and-up {
+            margin: unset;
+        }
     }
 
     &__expansion-item {
         border-radius: 4px;
         border: 2px solid var(--header-bg-color);
         margin-bottom: 8px;
+        height: fit-content;
 
         @include sm-and-up {
             width: 350px;
@@ -119,7 +131,7 @@ function handleExpansionItemUpdate() {
                 left: 0;
                 width: calc(100% - 30px);
                 height: 1px;
-                background-color: var(--accent-color-2);
+                background-color: var(--accent-color-4);
             }
         }
     }

--- a/src/layouts/EVMSidebarPage.vue
+++ b/src/layouts/EVMSidebarPage.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { is, useQuasar } from 'quasar';
+
+
+interface SidebarProps {
+    header: string;
+    content: { text: string; bold: boolean; }[];
+}
+
+const $q = useQuasar();
+
+const props = defineProps<{
+    sidebarContent: SidebarProps;
+}>();
+
+//data
+const expansionItemModel = ref(true);
+
+// computed
+const isMobile = computed(() => $q.screen.lt.sm);
+
+// methods
+function handleExpansionItemUpdate() {
+    if (!isMobile.value) {
+        expansionItemModel.value = true;
+    } else {
+        expansionItemModel.value = !expansionItemModel.value;
+    }
+}
+</script>
+
+<template>
+<div class="c-sidebar-page">
+    <div class="c-sidebar-page__sidebar-container">
+        <q-expansion-item
+            :model-value="expansionItemModel"
+            :label="sidebarContent.header"
+            :expand-icon="isMobile ? 'expand_more' : 'none'"
+            class="c-sidebar-page__expansion-item"
+            @update:model-value="handleExpansionItemUpdate"
+        >
+            <q-card>
+                <q-card-section>
+                    <span
+                        v-for="(text, index) in sidebarContent.content"
+                        :key="`text-fragment-${index}`"
+                        :class="{ 'o-text--paragraph-bold': text.bold }"
+                    >
+                        {{ text.text }}&nbsp;
+                    </span>
+                </q-card-section>
+            </q-card>
+        </q-expansion-item>
+    </div>
+    <div class="c-sidebar-page__body-container">
+        <slot></slot>
+    </div>
+</div>
+</template>
+
+<style lang="scss">
+.c-sidebar-page {
+    display: grid;
+
+    grid-template: 'a'
+                   'b';
+
+    @include sm-and-up {
+        grid-template: 'a b .';
+    }
+
+    &__sidebar-container {
+        grid-area: a;
+    }
+
+    &__body-container {
+        grid-area: b;
+    }
+
+    &__expansion-item {
+        border-radius: 4px;
+        border: 1px solid var(--header-item-outline-color);
+        margin-bottom: 8px;
+
+        // quasiar overrides
+        .q-item__label {
+            @include text--header-4;
+        }
+
+        .q-item.q-item-type {
+            position: relative;
+
+            &::after {
+                content: ' ';
+                margin: auto;
+                position: absolute;
+                right: 0;
+                bottom: 8px;
+                left: 0;
+                width: calc(100% - 30px);
+                height: 1px;
+                background-color: var(--link-color);
+            }
+        }
+    }
+}
+</style>

--- a/src/layouts/EVMSidebarPage.vue
+++ b/src/layouts/EVMSidebarPage.vue
@@ -14,14 +14,12 @@ const props = defineProps<{
     sidebarContent: SidebarProps;
 }>();
 
-//data
+// data
 const expansionItemModel = ref(false);
 
 // computed
 const isMobile = computed(() => $q.screen.lt.md);
 const isLarge = computed(() => $q.screen.gt.md);
-
-// eztodo get color updates from 1155 branch
 
 // methods
 function handleExpansionItemUpdate() {

--- a/src/layouts/EVMSidebarPage.vue
+++ b/src/layouts/EVMSidebarPage.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { is, useQuasar } from 'quasar';
+import { useQuasar } from 'quasar';
 
 
 interface SidebarProps {
     header: string;
-    content: { text: string; bold: boolean; }[];
+    content: { text: string; bold?: boolean; }[];
 }
 
 const $q = useQuasar();
@@ -15,10 +15,13 @@ const props = defineProps<{
 }>();
 
 //data
-const expansionItemModel = ref(true);
+const expansionItemModel = ref(false);
 
 // computed
-const isMobile = computed(() => $q.screen.lt.sm);
+const isMobile = computed(() => $q.screen.lt.md);
+const isLarge = computed(() => $q.screen.gt.md);
+
+// eztodo get color updates from 1155 branch
 
 // methods
 function handleExpansionItemUpdate() {
@@ -34,7 +37,7 @@ function handleExpansionItemUpdate() {
 <div class="c-sidebar-page">
     <div class="c-sidebar-page__sidebar-container">
         <q-expansion-item
-            :model-value="expansionItemModel"
+            :model-value="expansionItemModel || isLarge"
             :label="sidebarContent.header"
             :expand-icon="isMobile ? 'expand_more' : 'none'"
             class="c-sidebar-page__expansion-item"
@@ -43,11 +46,11 @@ function handleExpansionItemUpdate() {
             <q-card>
                 <q-card-section>
                     <span
-                        v-for="(text, index) in sidebarContent.content"
+                        v-for="(content, index) in sidebarContent.content"
                         :key="`text-fragment-${index}`"
-                        :class="{ 'o-text--paragraph-bold': text.bold }"
+                        :class="{ 'o-text--paragraph-bold': content.bold }"
                     >
-                        {{ text.text }}&nbsp;
+                        {{ content.text }}
                     </span>
                 </q-card-section>
             </q-card>
@@ -66,12 +69,21 @@ function handleExpansionItemUpdate() {
     grid-template: 'a'
                    'b';
 
-    @include sm-and-up {
+    @include lg-and-up {
         grid-template: 'a b .';
+        grid-template-columns: 1fr 1fr 1fr;
     }
 
     &__sidebar-container {
         grid-area: a;
+
+        @include sm-and-up {
+            margin: auto;
+        }
+
+        @include lg-and-up {
+            margin: unset;
+        }
     }
 
     &__body-container {
@@ -80,8 +92,13 @@ function handleExpansionItemUpdate() {
 
     &__expansion-item {
         border-radius: 4px;
-        border: 1px solid var(--header-item-outline-color);
+        border: 2px solid var(--header-bg-color);
         margin-bottom: 8px;
+
+        @include sm-and-up {
+            width: 350px;
+            max-width: 100%;
+        }
 
         // quasiar overrides
         .q-item__label {
@@ -90,6 +107,10 @@ function handleExpansionItemUpdate() {
 
         .q-item.q-item-type {
             position: relative;
+
+            @include lg-and-up {
+                pointer-events: none;
+            }
 
             &::after {
                 content: ' ';
@@ -100,7 +121,7 @@ function handleExpansionItemUpdate() {
                 left: 0;
                 width: calc(100% - 30px);
                 height: 1px;
-                background-color: var(--link-color);
+                background-color: var(--accent-color-2);
             }
         }
     }

--- a/src/pages/evm/wallet/WalletBalanceRow.vue
+++ b/src/pages/evm/wallet/WalletBalanceRow.vue
@@ -137,10 +137,11 @@ export default defineComponent({
             const chainSettings = chainStore.currentChain.settings as EVMChainSettings;
             const getExplorerUrl = (address: string) => `${chainSettings.getExplorerUrl()}/address/${address}`;
 
-            const tokenIsTlos  = this.token.address === NativeCurrencyAddress;
+            const tokenIsSystemToken  = this.token.address === NativeCurrencyAddress;
+            const tokenIsWrappedSystemToken = this.token.address === chainSettings.getWrappedSystemToken().address;
             const buyMoreLink  = chainSettings.getBuyMoreOfTokenLink();
 
-            if (tokenIsTlos) {
+            if (tokenIsSystemToken) {
                 items.push({
                     label: this.$t('evm_wallet.buy'),
                     icon: require('src/assets/icon--plus.svg'),
@@ -148,7 +149,7 @@ export default defineComponent({
                 });
             }
 
-            if (!tokenIsTlos) {
+            if (!tokenIsSystemToken) {
                 items.push({
                     label: this.$t('global.contract'),
                     icon: require('src/assets/icon--code.svg'),
@@ -164,6 +165,22 @@ export default defineComponent({
                     query: { ...(this.token.address !== NativeCurrencyAddress ? { token: this.token.address ?? '' } : {}) },
                 },
             });
+
+            if (tokenIsSystemToken) {
+                items.push({
+                    label: this.$t('evm_wallet.wrap'),
+                    icon: require('src/assets/icon--wrap-tlos.svg'),
+                    url: { name: 'evm-wrap' },
+                });
+            }
+
+            if (tokenIsWrappedSystemToken) {
+                items.push({
+                    label: this.$t('evm_wallet.unwrap'),
+                    icon: require('src/assets/icon--wrap-tlos.svg'),
+                    url: { name: 'evm-wrap', query: { tab: 'unwrap' } },
+                });
+            }
 
             if (this.token.address !== NativeCurrencyAddress) {
                 items.push({

--- a/src/pages/evm/wrap/UnwrapTab.vue
+++ b/src/pages/evm/wrap/UnwrapTab.vue
@@ -15,19 +15,11 @@ const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 
 // computed
 const sidebarContent = computed(() => {
-    const header = $t('evm_wrap.wrap_sidebar_title', { symbol: systemTokenSymbol });
+    const header = $t('evm_wrap.unwrap_sidebar_title', { symbol: systemTokenSymbol });
     const content = [{
         text: $t(
-            'evm_wrap.wrap_sidebar_content_fragment_1',
-            { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
-        ),
-    }, {
-        text: $t('evm_wrap.wrap_sidebar_content_fragment_bold'),
-        bold: true,
-    }, {
-        text: $t(
-            'evm_wrap.wrap_sidebar_content_fragment_3',
-            { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
+            'evm_wrap.unwrap_sidebar',
+            { wrappedSymbol: wrappedTokenSymbol, systemSymbol: systemTokenSymbol },
         ),
     }];
 

--- a/src/pages/evm/wrap/UnwrapTab.vue
+++ b/src/pages/evm/wrap/UnwrapTab.vue
@@ -22,6 +22,7 @@ const accountStore = useAccountStore();
 const systemToken = chainSettings.getSystemToken();
 const systemTokenSymbol = systemToken.symbol;
 const systemTokenDecimals = systemToken.decimals;
+const uiDecimals = 2;
 const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 
 // data
@@ -154,6 +155,7 @@ async function handleUnwrapClick() {
                 v-model="inputModelValue"
                 :symbol="wrappedTokenSymbol"
                 :decimals="systemTokenDecimals"
+                :decimals-to-display="uiDecimals"
                 :secondary-currency-code="fiatCurrency"
                 :secondary-currency-decimals="2"
                 :secondary-currency-conversion-factor="systemTokenFiatPrice"

--- a/src/pages/evm/wrap/UnwrapTab.vue
+++ b/src/pages/evm/wrap/UnwrapTab.vue
@@ -1,18 +1,42 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onBeforeMount, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { useChainStore } from 'src/antelope';
+import { getAntelope, useAccountStore, useBalancesStore, useChainStore, useEVMStore, useUserStore } from 'src/antelope';
 
+import ConversionRateBadge from 'src/components/ConversionRateBadge.vue';
+import CurrencyInput from 'src/components/evm/inputs/CurrencyInput.vue';
 import EVMSidebarPage from 'src/layouts/EVMSidebarPage.vue';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+import { ethers } from 'ethers';
+import { WEI_PRECISION, formatWei } from 'src/antelope/stores/utils';
+import { AntelopeError } from 'src/antelope/types';
 
 const { t: $t } = useI18n();
+const ant = getAntelope();
 const chainSettings = useChainStore().currentChain.settings as EVMChainSettings;
-const systemTokenSymbol = chainSettings.getSystemToken().symbol;
+const userStore = useUserStore();
+const balanceStore = useBalancesStore();
+const accountStore = useAccountStore();
+
+const systemToken = chainSettings.getSystemToken();
+const systemTokenSymbol = systemToken.symbol;
+const systemTokenDecimals = systemToken.decimals;
 const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 
+// data
+const oneEth = ethers.BigNumber.from('1'.concat('0'.repeat(systemTokenDecimals)));
+const inputModelValue = ref(ethers.constants.Zero);
+const estimatedGas = ref(ethers.constants.Zero);
 
+// computed
+const fiatLocale = computed(() => userStore.fiatLocale);
+const fiatCurrency = computed(() => userStore.fiatCurrency);
+const systemTokenBalanceInfo = computed(() => balanceStore.currentBalances.filter(
+    balance => balance.token.contract === systemToken.address)[0],
+);
+const systemTokenFiatPrice = computed(() => systemTokenBalanceInfo.value?.token.price.getAmountInFiatStr(1) ?? '1');
+const systemTokenBalance = computed(() => systemTokenBalanceInfo.value?.amount ?? ethers.constants.Zero);
 // computed
 const sidebarContent = computed(() => {
     const header = $t('evm_wrap.unwrap_sidebar_title', { symbol: systemTokenSymbol });
@@ -28,15 +52,181 @@ const sidebarContent = computed(() => {
         content,
     };
 });
+const availableToWrap = computed(() => {
+    const available = systemTokenBalance.value.sub(estimatedGas.value);
+
+    if (available.lt(0)) {
+        return ethers.constants.Zero;
+    }
+    return available;
+});
+const formIsValid = computed(() =>
+    !inputModelValue.value.isZero() &&
+    inputModelValue.value.lt(availableToWrap.value),
+);
+const ctaIsLoading = computed(() => ant.stores.feedback.isLoading('unwrapSystemTokens'));
+
+
+// methods
+onBeforeMount(() => {
+    // https://github.com/telosnetwork/telos-wallet/issues/274
+    const GAS_FOR_WRAPPING_TOKEN = 55500;
+    chainSettings.getEstimatedGas(GAS_FOR_WRAPPING_TOKEN).then((gas) => {
+        estimatedGas.value = gas.system;
+    });
+});
+// -----------------------------------------------
+// New computed properties and data
+const wrappedTokenBalanceInfo = computed(() => balanceStore.currentBalances.filter(
+    balance => balance.token.contract === chainSettings.getWrappedSystemToken().address,
+)[0]);
+const wrappedTokenBalance = computed(() => wrappedTokenBalanceInfo.value?.amount ?? ethers.constants.Zero);
+const availableToUnwrap = computed(() => wrappedTokenBalance.value);
+
+// New methods
+async function handleUnwrapClick() {
+    const label = 'logged';
+    if (!await accountStore.isConnectedToCorrectNetwork(label)) {
+        const networkName = useChainStore().loggedChain.settings.getDisplay();
+        const errorMessage = ant.config.localizationHandler('evm_wallet.incorrect_network', { networkName });
+
+        ant.config.notifyFailureWithAction(errorMessage, {
+            label: ant.config.localizationHandler('evm_wallet.switch'),
+        });
+
+        return;
+    }
+
+    if (formIsValid.value) {
+        try {
+            const tx = await useBalancesStore().unwrapSystemTokens(inputModelValue.value);
+            const formattedAmount = formatWei(inputModelValue.value, systemTokenDecimals, WEI_PRECISION);
+
+            const dismiss = ant.config.notifyNeutralMessageHandler(
+                $t('notification.neutral_message_unwrapping', { quantity: formattedAmount, symbol: wrappedTokenSymbol }),
+            );
+
+            tx.wait().then(() => {
+                ant.config.notifySuccessfulTrxHandler(
+                    `${chainSettings.getExplorerUrl()}/tx/${tx.hash}`,
+                );
+            }).catch((err: any) => {
+                console.error(err);
+            }).finally(() => {
+                dismiss();
+            });
+        } catch (err) {
+            console.error(err);
+            if (err instanceof AntelopeError) {
+                const evmErr = err as AntelopeError;
+                ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
+            } else {
+                ant.config.notifyFailureMessage($t('evm_wallet.general_error'));
+            }
+        }
+    }
+}
+
 
 </script>
 
 <template>
 <EVMSidebarPage :sidebar-content="sidebarContent">
-    {{ 'test '.repeat(300) }}
-    {{ 'test'.repeat(300) }}
+
+    <!-- convert ratio 1:1 -->
+    <div class="row q-mb-xl">
+        <div class="col-12">
+            <div class="c-unwrap-tab__badge-container">
+                <ConversionRateBadge
+                    :token-one-symbol="wrappedTokenSymbol"
+                    :token-two-symbol="systemTokenSymbol"
+                    :token-two-decimals="systemTokenDecimals"
+                    :token-two-amount="oneEth"
+                />
+            </div>
+        </div>
+    </div>
+
+    <!-- WTLOS input -->
+    <div class="row q-mb-lg">
+        <div class="col-12">
+            <CurrencyInput
+                v-model="inputModelValue"
+                :symbol="wrappedTokenSymbol"
+                :decimals="systemTokenDecimals"
+                :secondary-currency-code="fiatCurrency"
+                :secondary-currency-decimals="2"
+                :secondary-currency-conversion-factor="systemTokenFiatPrice"
+                :locale="fiatLocale"
+                :label="$t('evm_wrap.unwrap_input_label')"
+                :max-value="availableToUnwrap"
+                class="c-unwrap-tab__input"
+            />
+        </div>
+    </div>
+
+    <!-- arrow -->
+    <div class="row q-mb-sm">
+        <div class="col-12 text-center">
+            <img
+                src="~assets/icon--arrow-down.svg"
+                :alt="$t('global.arrow_icon_alt')"
+                height="20"
+                width="18"
+            >
+        </div>
+    </div>
+
+    <!-- output field (readonly) -->
+    <div class="row q-mb-lg">
+        <div class="col-12">
+            <CurrencyInput
+                v-model="inputModelValue"
+                :symbol="systemTokenSymbol"
+                :decimals="systemTokenDecimals"
+                :locale="fiatLocale"
+                :label="$t('evm_wrap.unwrap_input_label')"
+                class="c-unwrap-tab__input"
+                readonly="readonly"
+            />
+        </div>
+    </div>
+
+    <!-- Unwrap button -->
+    <div class="row">
+        <div class="col-12">
+            <div class="c-unwrap-tab__cta-container">
+                <q-btn
+                    color="primary"
+                    :disable="availableToUnwrap.isZero()"
+                    :loading="ctaIsLoading"
+                    :label="$t('evm_wrap.unwrap')"
+                    :aria-label="$t(
+                        'evm_wrap.unwrap_button_label',
+                        { wrappedSymbol: wrappedTokenSymbol, systemSymbol: systemTokenSymbol },
+                    )"
+                    @click="handleUnwrapClick"
+                />
+            </div>
+        </div>
+    </div>
 </EVMSidebarPage>
 </template>
 
 <style lang="scss">
+.c-unwrap-tab {
+    &__badge-container,
+    &__cta-container,
+    &__input {
+        max-width: 320px;
+        margin: auto;
+    }
+
+    &__badge-container,
+    &__cta-container {
+        display: flex;
+        justify-content: flex-end;
+    }
+}
 </style>
+

--- a/src/pages/evm/wrap/WrapPage.vue
+++ b/src/pages/evm/wrap/WrapPage.vue
@@ -2,6 +2,7 @@
 import AppPage from 'components/evm/AppPage.vue';
 import WrapPageHeader from 'pages/evm/wrap/WrapPageHeader.vue';
 import WrapTab from 'pages/evm/wrap/WrapTab.vue';
+import UnwrapTab from 'pages/evm/wrap/UnwrapTab.vue';
 
 const tabs = ['wrap', 'unwrap'];
 </script>
@@ -17,7 +18,7 @@ const tabs = ['wrap', 'unwrap'];
     </template>
 
     <template v-slot:unwrap>
-        <p>unwrap tab</p>
+        <UnwrapTab />
     </template>
 </AppPage>
 </template>

--- a/src/pages/evm/wrap/WrapPage.vue
+++ b/src/pages/evm/wrap/WrapPage.vue
@@ -1,19 +1,9 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
 import AppPage from 'components/evm/AppPage.vue';
 import WrapPageHeader from 'pages/evm/wrap/WrapPageHeader.vue';
+import WrapTab from 'pages/evm/wrap/WrapTab.vue';
 
-export default defineComponent({
-    name: 'WrapPage',
-    components: {
-        AppPage,
-        WrapPageHeader,
-    },
-    data: () => ({
-        tabs: ['wrap', 'unwrap'],
-    }),
-
-});
+const tabs = ['wrap', 'unwrap'];
 </script>
 
 <template>
@@ -23,7 +13,7 @@ export default defineComponent({
     </template>
 
     <template v-slot:wrap>
-        <p>wrap tab</p>
+        <WrapTab />
     </template>
 
     <template v-slot:unwrap>

--- a/src/pages/evm/wrap/WrapPageHeader.vue
+++ b/src/pages/evm/wrap/WrapPageHeader.vue
@@ -40,7 +40,7 @@ const totalFiatValueText = computed(() => {
 const systemTokenName = computed(() => chainSettings.getSystemToken().name);
 const systemTokenSymbol = computed(() => chainSettings.getSystemToken().symbol);
 const wrappedTokenSymbol = computed(() => chainSettings.getWrappedSystemToken().symbol);
-const allBalances = computed(() => balancesStore.loggedBalances);
+const allBalances = computed(() => balancesStore.currentBalances);
 const systemTokenBalanceBn =  computed(() => allBalances.value.find(b => b.token.contract === NativeCurrencyAddress)?.balance);
 const wrappedTokenBalanceBn = computed(() =>
     allBalances.value.find(b => b.token.contract === chainSettings.getWrappedSystemToken().address)?.balance,

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -57,6 +57,7 @@ const sidebarContent = computed(() => {
         content,
     };
 });
+const disableCta = computed(() => true);
 
 
 // methods
@@ -123,16 +124,19 @@ function handleCtaClick() {
     </div>
 
     <div class="row">
-        <div class="col-12 text-right">
-            <q-btn
-                color="primary"
-                :label="$t('evm_wrap.wrap')"
-                :aria-label="$t(
-                    'evm_wrap.wrap_button_label',
-                    { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
-                )"
-                @click="handleCtaClick"
-            />
+        <div class="col-12">
+            <div class="c-wrap-tab__cta-container">
+                <q-btn
+                    color="primary"
+                    :disable="disableCta"
+                    :label="$t('evm_wrap.wrap')"
+                    :aria-label="$t(
+                        'evm_wrap.wrap_button_label',
+                        { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
+                    )"
+                    @click="handleCtaClick"
+                />
+            </div>
         </div>
     </div>
 </EVMSidebarPage>
@@ -140,16 +144,17 @@ function handleCtaClick() {
 
 <style lang="scss">
 .c-wrap-tab {
-    &__badge-container {
-        display: flex;
-        justify-content: flex-end;
+    &__badge-container,
+    &__cta-container,
+    &__input {
         max-width: 320px;
         margin: auto;
     }
 
-    &__input {
-        max-width: 320px;
-        margin: 0 auto;
+    &__badge-container,
+    &__cta-container {
+        display: flex;
+        justify-content: flex-end;
     }
 }
 </style>

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -29,6 +29,7 @@ const accountStore = useAccountStore();
 const systemToken = chainSettings.getSystemToken();
 const systemTokenSymbol = systemToken.symbol;
 const systemTokenDecimals = systemToken.decimals;
+const uiDecimals = 2;
 const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 
 // data
@@ -158,6 +159,7 @@ async function handleCtaClick() {
                 v-model="inputModelValue"
                 :symbol="systemTokenSymbol"
                 :decimals="systemTokenDecimals"
+                :decimals-to-display="uiDecimals"
                 :secondary-currency-code="fiatCurrency"
                 :secondary-currency-decimals="2"
                 :secondary-currency-conversion-factor="systemTokenFiatPrice"

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -1,12 +1,41 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useChainStore } from 'src/antelope';
 
 import EVMSidebarPage from 'src/layouts/EVMSidebarPage.vue';
+import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+
+const { t: $t } = useI18n();
+const chainSettings = useChainStore().currentChain.settings as EVMChainSettings;
+const systemTokenSymbol = chainSettings.getSystemToken().symbol;
+const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 
 
+// computed
 const sidebarContent = computed(() => {
-    const header = 'Why wrap TLOS?'; // eztodo make chain independent, i18n
-    const content = [{ text: 'test text here', bold: false }, { text: 'bold text here', bold: true }, { text: 'more non bold text here', bold: false }];
+    /*
+    Wrap your TLOS to wTELOS for seamless integration with DeFi platforms,
+    improved compatibility with ERC-20 tokens, and cross-chain interoperability.
+    Unlock new opportunities and financial services by converting your native
+    TLOS into the versatile wTELOS token.
+    */
+    const header = $t('evm_wrap.wrap_sidebar_title', { symbol: systemTokenSymbol });
+    const content = [{
+        text: $t(
+            'evm_wrap.wrap_sidebar_content_fragment_1',
+            { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
+        ),
+    }, {
+        text: $t('evm_wrap.wrap_sidebar_content_fragment_bold'),
+        bold: true,
+    }, {
+        text: $t(
+            'evm_wrap.wrap_sidebar_content_fragment_3',
+            { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
+        ),
+    }];
 
     return {
         header,

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -1,19 +1,40 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { useChainStore } from 'src/antelope';
+import { useBalancesStore, useChainStore, useUserStore } from 'src/antelope';
+
+import { BigNumber } from 'ethers';
 
 import EVMSidebarPage from 'src/layouts/EVMSidebarPage.vue';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+import ConversionRateBadge from 'src/components/ConversionRateBadge.vue';
+import CurrencyInput from 'src/components/evm/inputs/CurrencyInput.vue';
 
 const { t: $t } = useI18n();
 const chainSettings = useChainStore().currentChain.settings as EVMChainSettings;
-const systemTokenSymbol = chainSettings.getSystemToken().symbol;
+const userStore = useUserStore();
+const balanceStore = useBalancesStore();
+
+const systemToken = chainSettings.getSystemToken();
+const systemTokenSymbol = systemToken.symbol;
+const systemTokenDecimals = systemToken.decimals;
 const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 
+// data
+const oneEth = BigNumber.from('1'.concat('0'.repeat(systemTokenDecimals)));
+const inputModelValue = ref(BigNumber.from(0));
+
+// eztodo available doe snot match currency input available
 
 // computed
+const fiatLocale = computed(() => userStore.fiatLocale);
+const fiatCurrency = computed(() => userStore.fiatCurrency);
+const systemTokenBalanceInfo = computed(() => balanceStore.currentBalances.filter(
+    balance => balance.token.address === systemToken.address)[0],
+);
+const systemTokenBalance = computed(() => systemTokenBalanceInfo.value?.amount ?? BigNumber.from(0));
+const systemTokenFiatPrice = computed(() => systemTokenBalanceInfo.value?.token.price.getAmountInFiatStr(1));
 const sidebarContent = computed(() => {
     const header = $t('evm_wrap.wrap_sidebar_title', { symbol: systemTokenSymbol });
     const content = [{
@@ -37,14 +58,98 @@ const sidebarContent = computed(() => {
     };
 });
 
+
+// methods
+function handleCtaClick() {
+    console.log('wrap');
+}
 </script>
 
 <template>
 <EVMSidebarPage :sidebar-content="sidebarContent">
-    {{ 'test '.repeat(300) }}
-    {{ 'test'.repeat(300) }}
+    <div class="row q-mb-xl">
+        <div class="col-12">
+            <div class="c-wrap-tab__badge-container">
+                <ConversionRateBadge
+                    :token-one-symbol="wrappedTokenSymbol"
+                    :token-two-symbol="systemTokenSymbol"
+                    :token-two-decimals="systemTokenDecimals"
+                    :token-two-amount="oneEth"
+                />
+            </div>
+        </div>
+    </div>
+
+    <div class="row q-mb-lg">
+        <div class="col-12">
+            <CurrencyInput
+                v-model="inputModelValue"
+                :symbol="systemTokenSymbol"
+                :decimals="systemTokenDecimals"
+                :secondary-currency-code="fiatCurrency"
+                :secondary-currency-decimals="2"
+                :secondary-currency-conversion-factor="systemTokenFiatPrice"
+                :locale="fiatLocale"
+                :label="$t('evm_wrap.wrap_input_label')"
+                :max-value="systemTokenBalance"
+                class="c-wrap-tab__input"
+            />
+        </div>
+    </div>
+
+    <div class="row q-mb-sm">
+        <div class="col-12 text-center">
+            <img
+                src="~assets/icon--arrow-down.svg"
+                :alt="$t('global.arrow_icon_alt')"
+                height="20"
+                width="18"
+            >
+        </div>
+    </div>
+
+    <div class="row q-mb-lg">
+        <div class="col-12">
+            <CurrencyInput
+                v-model="inputModelValue"
+                :symbol="wrappedTokenSymbol"
+                :decimals="systemTokenDecimals"
+                :locale="fiatLocale"
+                :label="$t('evm_wrap.wrap_input_label')"
+                class="c-wrap-tab__input"
+                readonly="readonly"
+            />
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12 text-right">
+            <q-btn
+                color="primary"
+                :label="$t('evm_wrap.wrap')"
+                :aria-label="$t(
+                    'evm_wrap.wrap_button_label',
+                    { systemSymbol: systemTokenSymbol, wrappedSymbol: wrappedTokenSymbol },
+                )"
+                @click="handleCtaClick"
+            />
+        </div>
+    </div>
 </EVMSidebarPage>
 </template>
 
 <style lang="scss">
+.c-wrap-tab {
+    &__badge-container {
+        display: flex;
+        justify-content: flex-end;
+        max-width: 320px;
+        margin: auto;
+    }
+
+    &__input {
+        max-width: 320px;
+        margin: 0 auto;
+    }
+}
 </style>

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -61,6 +61,9 @@ const disableCta = computed(() => false); //eztodo
 
 // methods
 async function handleCtaClick() {
+    const evmStore = useEVMStore();
+    const authenticator = evmStore.injectedProvider(evmStore.injectedProviderNames[0]);
+    authenticator.wrapSystemToken(inputModelValue.value);
     console.log('wrap');
 }
 </script>

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import EVMSidebarPage from 'src/layouts/EVMSidebarPage.vue';
+
+
+const sidebarContent = computed(() => {
+    const header = 'Why wrap TLOS?'; // eztodo make chain independent, i18n
+    const content = [{ text: 'test text here', bold: false }, { text: 'bold text here', bold: true }, { text: 'more non bold text here', bold: false }];
+
+    return {
+        header,
+        content,
+    };
+});
+
+</script>
+
+<template>
+<EVMSidebarPage :sidebar-content="sidebarContent">
+    test
+</EVMSidebarPage>
+</template>
+
+<style lang="scss">
+</style>

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { useBalancesStore, useChainStore, useUserStore } from 'src/antelope';
+import { useAccountStore, useBalancesStore, useChainStore, useEVMStore, useUserStore } from 'src/antelope';
 
 import { BigNumber } from 'ethers';
 
@@ -10,6 +10,7 @@ import EVMSidebarPage from 'src/layouts/EVMSidebarPage.vue';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 import ConversionRateBadge from 'src/components/ConversionRateBadge.vue';
 import CurrencyInput from 'src/components/evm/inputs/CurrencyInput.vue';
+import { EVMAuthenticator, InjectedProviderAuth } from 'src/antelope/wallets';
 
 const { t: $t } = useI18n();
 const chainSettings = useChainStore().currentChain.settings as EVMChainSettings;
@@ -24,8 +25,6 @@ const wrappedTokenSymbol = chainSettings.getWrappedSystemToken().symbol;
 // data
 const oneEth = BigNumber.from('1'.concat('0'.repeat(systemTokenDecimals)));
 const inputModelValue = ref(BigNumber.from(0));
-
-// eztodo available doe snot match currency input available
 
 // computed
 const fiatLocale = computed(() => userStore.fiatLocale);
@@ -57,11 +56,11 @@ const sidebarContent = computed(() => {
         content,
     };
 });
-const disableCta = computed(() => true);
+const disableCta = computed(() => false); //eztodo
 
 
 // methods
-function handleCtaClick() {
+async function handleCtaClick() {
     console.log('wrap');
 }
 </script>

--- a/src/pages/home/ConnectWalletOptions.vue
+++ b/src/pages/home/ConnectWalletOptions.vue
@@ -237,7 +237,8 @@ export default defineComponent({
 .wallet-options-container{
     background: $dark;
     width: 300px;
-    height: 240px;
+    height: fit-content;
+    padding-bottom: 2rem;
     margin:auto;
     color: $white;
 

--- a/test/jest/__tests__/pages/evm/wallet/__snapshots__/WalletBalanceRow.spec.ts.snap
+++ b/test/jest/__tests__/pages/evm/wallet/__snapshots__/WalletBalanceRow.spec.ts.snap
@@ -576,6 +576,29 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
               evm_wallet.send
             </span>
           </li>
+          <li
+            aria-labelledby="overflow-text-2"
+            class="c-wallet-balance-row__overflow-li"
+            tabindex="0"
+          >
+            <div
+              class="c-wallet-balance-row__overflow-icon-wrapper"
+            >
+              <inline-svg-stub
+                aria-hidden="true"
+                class="c-wallet-balance-row__overflow-icon"
+                keepduringloading="true"
+                src=""
+                transformsource="[Function]"
+              />
+            </div>
+            <span
+              class="c-wallet-balance-row__overflow-text"
+              id="overflow-text-2"
+            >
+              evm_wallet.wrap
+            </span>
+          </li>
           
         </ul>
         
@@ -717,7 +740,7 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
             >
               <inline-svg-stub
                 aria-hidden="true"
-                class="c-wallet-balance-row__overflow-icon c-wallet-balance-row__overflow-icon--stroke"
+                class="c-wallet-balance-row__overflow-icon"
                 keepduringloading="true"
                 src=""
                 transformsource="[Function]"
@@ -726,6 +749,29 @@ exports[`WalletBalanceRow.vue should render the right overflow items when the to
             <span
               class="c-wallet-balance-row__overflow-text"
               id="overflow-text-2"
+            >
+              evm_wallet.unwrap
+            </span>
+          </li>
+          <li
+            aria-labelledby="overflow-text-3"
+            class="c-wallet-balance-row__overflow-li"
+            tabindex="0"
+          >
+            <div
+              class="c-wallet-balance-row__overflow-icon-wrapper"
+            >
+              <inline-svg-stub
+                aria-hidden="true"
+                class="c-wallet-balance-row__overflow-icon c-wallet-balance-row__overflow-icon--stroke"
+                keepduringloading="true"
+                src=""
+                transformsource="[Function]"
+              />
+            </div>
+            <span
+              class="c-wallet-balance-row__overflow-text"
+              id="overflow-text-3"
             >
               evm_wallet.add_to_metamask
             </span>


### PR DESCRIPTION
# Fixes #441 

## Description
This PR adds a new layout for displaying sidebar text (such as on the wrap/unwrap/staking/unstaking pages), and adds it onto the wrap/unwrap pages

## Test scenarios
- this PR must be tested locally because its base branch is not `develop`
- from the project root, run `git fetch --all && git checkout 441-wrap-page-sidebar && yarn install && yarn dev`
- go to http://localhost:8081
- log in
- click the wrap link on the nav
  - the tabs should match the [designs](https://www.figma.com/file/eIpbnt6vqwqptEbZWtwO8Y/v0.3?type=design&node-id=703-5046&mode=design&t=wmsRDyLz8pkfEVYG-0)
- go to the Wrap tab and wrap any amount of TLOS
  - You should be receiving a neutral notification of the transaction sent and later a success notification with the tx hash.
  - The balances for TLOS and WTLOS should be updated automatically, that includes:
    - the headers balances
    - the max available for wrap
- go to the Unwrap tab and unwrap any amount of WTLOS
  - You should be receiving a neutral notification of the transaction sent and later a success notification with the tx hash.
  - The balances for TLOS and WTLOS should be updated automatically, that includes:
    - the headers balances
    - the max available for unwrap
- Repeat the previous process with all different login methods (OreId, SafePal, MetaMask, WalletConnect)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
