### PR TITLE
Re design EVM login buttons

### DIFF
--- a/src/pages/home/EVMLoginButtons.vue
+++ b/src/pages/home/EVMLoginButtons.vue
@@ -239,6 +239,12 @@ export default defineComponent({
         }
 
         &:not(:hover) #{$self}__icon {
+            &--oreid {
+                opacity: 1;
+            }
+            &--metamask, &--safepal, &--wallet-connect {
+                opacity: 0.3;
+            }
             &--metamask {
                 .st3, .st8, .st9 {
                     fill: $blackDark;

--- a/src/pages/home/EVMLoginButtons.vue
+++ b/src/pages/home/EVMLoginButtons.vue
@@ -117,7 +117,7 @@ export default defineComponent({
 <div class="c-evm-login-buttons">
 
     <!-- Google OAuth Provider -->
-    <div class="c-evm-login-buttons__option c-evm-login-buttons__option--oreid" @click="setOreIdAuthenticator('google')">
+    <!--div class="c-evm-login-buttons__option c-evm-login-buttons__option--oreid" @click="setOreIdAuthenticator('google')">
         <template v-if="isLoadingOreId('google')">
             <div class="c-evm-login-buttons__loading"><QSpinnerFacebook /></div>
         </template>
@@ -129,7 +129,7 @@ export default defineComponent({
             >
             {{ $t('home.login_with_social_media') }}
         </template>
-    </div>
+    </div-->
 
     <!-- Metamask Authenticator button -->
     <div
@@ -216,7 +216,7 @@ export default defineComponent({
     &__option{
         width: 224px;
         height: 54px;
-        color: $gray;
+        color: $white;
         border: solid $white;
         border-width: 1px;
         border-radius: 4px;
@@ -233,44 +233,43 @@ export default defineComponent({
             margin-right: 8px;
         }
 
-        &:hover {
-            color: $white;
-            border-color: $white;
-        }
+        // &:hover {
+        //     color: $white;
+        //     border-color: $white;
+        // }
 
-        &:not(:hover) #{$self}__icon {
-            &--oreid {
-                opacity: 1;
-            }
-            &--metamask, &--safepal, &--wallet-connect {
-                opacity: 0.3;
-            }
-            &--metamask {
-                .st3, .st8, .st9 {
-                    fill: $blackDark;
-                    stroke: $blackDark;
-                }
-                .st0, .st1, .st2, .st4, .st5, .st6, .st7 {
-                    fill: $white;
-                    stroke: $blackDark;
-                }
-            }
-            &--safepal {
-                path {
-                    fill: $white;
-                }
-            }
-            &--wallet-connect {
-                circle {
-                    fill: $white;
-                    stroke: $blackDark;
-                }
-                path {
-                    fill: $blackDark;
-                }
-            }
-        }
-
+        // &:not(:hover) #{$self}__icon {
+        //     &--oreid {
+        //         opacity: 1;
+        //     }
+        //     &--metamask, &--safepal, &--wallet-connect {
+        //         opacity: 0.3;
+        //     }
+        //     &--metamask {
+        //         .st3, .st8, .st9 {
+        //             fill: $blackDark;
+        //             stroke: $blackDark;
+        //         }
+        //         .st0, .st1, .st2, .st4, .st5, .st6, .st7 {
+        //             fill: $white;
+        //             stroke: $blackDark;
+        //         }
+        //     }
+        //     &--safepal {
+        //         path {
+        //             fill: $white;
+        //         }
+        //     }
+        //     &--wallet-connect {
+        //         circle {
+        //             fill: $white;
+        //             stroke: $blackDark;
+        //         }
+        //         path {
+        //             fill: $blackDark;
+        //         }
+        //     }
+        // }
     }
 }
 </style>

--- a/src/pages/home/EVMLoginButtons.vue
+++ b/src/pages/home/EVMLoginButtons.vue
@@ -3,11 +3,13 @@ import { getAntelope, useAccountStore, useChainStore, useEVMStore, useFeedbackSt
 import { ComponentInternalInstance, computed, defineComponent, getCurrentInstance, ref, watch } from 'vue';
 import { QSpinnerFacebook } from 'quasar';
 import { OreIdAuth } from 'src/antelope/wallets';
+import InlineSvg from 'vue-inline-svg';
 
 export default defineComponent({
     name: 'EVMLoginButtons',
     components: {
         QSpinnerFacebook,
+        InlineSvg,
     },
     setup(props, { emit }) {
         const ant = getAntelope();
@@ -115,18 +117,17 @@ export default defineComponent({
 <div class="c-evm-login-buttons">
 
     <!-- Google OAuth Provider -->
-    <div class="c-evm-login-buttons__option" @click="setOreIdAuthenticator('google')">
+    <div class="c-evm-login-buttons__option c-evm-login-buttons__option--oreid" @click="setOreIdAuthenticator('google')">
         <template v-if="isLoadingOreId('google')">
             <div class="c-evm-login-buttons__loading"><QSpinnerFacebook /></div>
         </template>
         <template v-else>
             <img
                 width="24"
-                class="flex q-ml-auto q-mt-auto wallet-logo"
-                alt="Google"
-                src="~assets/evm/icon-oauth-google.svg"
+                class="c-evm-login-buttons__icon"
+                src="~assets/logo--tlos.svg"
             >
-            {{ $t('home.oauth_google') }}
+            {{ $t('home.login_with_social_media') }}
         </template>
     </div>
 
@@ -140,12 +141,13 @@ export default defineComponent({
             <div class="c-evm-login-buttons__loading"><QSpinnerFacebook /></div>
         </template>
         <template v-else>
-            <img
+            <InlineSvg
+                :src="require('src/assets/evm/metamask_fox.svg')"
+                class="c-evm-login-buttons__icon c-evm-login-buttons__icon--metamask"
+                height="24"
                 width="24"
-                class="flex q-ml-auto q-mt-auto wallet-logo"
-                alt="Metamask"
-                src="~assets/evm/metamask_fox.svg"
-            >
+                aria-hidden="true"
+            />
             {{ supportsMetamask ? $t('home.metamask') : $t('home.install_metamask') }}
         </template>
     </div>
@@ -160,12 +162,13 @@ export default defineComponent({
             <div class="c-evm-login-buttons__loading"><QSpinnerFacebook /></div>
         </template>
         <template v-else>
-            <img
+            <InlineSvg
+                :src="require('src/assets/evm/safepal.svg')"
+                class="c-evm-login-buttons__icon c-evm-login-buttons__icon--safepal"
+                height="24"
                 width="24"
-                class="flex q-ml-auto q-mt-auto wallet-logo"
-                alt="SafePal"
-                src="~assets/evm/safepal.svg"
-            >
+                aria-hidden="true"
+            />
             {{ supportsSafePal ? $t('home.safepal') : $t('home.install_safepal') }}
         </template>
     </div>
@@ -176,12 +179,13 @@ export default defineComponent({
             <div class="c-evm-login-buttons__loading"><QSpinnerFacebook /></div>
         </template>
         <template v-else>
-            <img
+            <InlineSvg
+                :src="require('src/assets/evm/wallet_connect.svg')"
+                class="c-evm-login-buttons__icon c-evm-login-buttons__icon--wallet-connect"
+                height="24"
                 width="24"
-                class="flex q-ml-auto q-mt-auto wallet-logo"
-                alt="WalletConnect"
-                src="~assets/evm/wallet_connect.svg"
-            >
+                aria-hidden="true"
+            />
             {{ $t('home.walletconnect') }}
         </template>
     </div>
@@ -191,6 +195,7 @@ export default defineComponent({
 
 <style lang="scss">
 .c-evm-login-buttons {
+    $self: &;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -211,7 +216,7 @@ export default defineComponent({
     &__option{
         width: 224px;
         height: 54px;
-        color: $white;
+        color: $gray;
         border: solid $white;
         border-width: 1px;
         border-radius: 4px;
@@ -222,11 +227,44 @@ export default defineComponent({
         padding-right: 14px;
         cursor: pointer;
 
-        img {
+        #{$self}__icon, img {
             display: inline-block;
             vertical-align:top;
             margin-right: 8px;
         }
+
+        &:hover {
+            color: $white;
+            border-color: $white;
+        }
+
+        &:not(:hover) #{$self}__icon {
+            &--metamask {
+                .st3, .st8, .st9 {
+                    fill: $blackDark;
+                    stroke: $blackDark;
+                }
+                .st0, .st1, .st2, .st4, .st5, .st6, .st7 {
+                    fill: $white;
+                    stroke: $blackDark;
+                }
+            }
+            &--safepal {
+                path {
+                    fill: $white;
+                }
+            }
+            &--wallet-connect {
+                circle {
+                    fill: $white;
+                    stroke: $blackDark;
+                }
+                path {
+                    fill: $blackDark;
+                }
+            }
+        }
+
     }
 }
 </style>


### PR DESCRIPTION
# Fixes #498

## Description
We want to save one click to the user when login in. Instead of having two set menu buttons, we decided to have all options in the first menu.

## Screenshots
![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/8152df3a-b02d-4b42-acd9-ae8372387892)


## Test scenarios

--- Desktop
- go to [this link](https://deploy-preview-507--wallet-staging.netlify.app/)
  - you should see the new design
  - all buttons should work as before
- if you have both wallets, enable and desable the overwhite of injected provider. You will find the switch button on the bottom of the SafePal wallet. Refresh the page each time you switched.
  - you should see that it changes from "install MetaMask" to only "Metamask" and back while the SafePal button does the opposite.
![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/9a091045-88bd-41bd-aba1-2e394e63ce91)
![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/2f8814f0-0e38-41dd-a11f-dd9793635a79)


--- Mobile - Chrome
- go to [this link](https://deploy-preview-507--wallet-staging.netlify.app/)
  - you should see the new design but...
  - you should not see the MetaMask and Safepal buttons

--- Mobile - SafePal or Metamask internal browser
- Inside Wallet's browser go to [this link](https://deploy-preview-507--wallet-staging.netlify.app/)
  - you should see the new design but...
  - only the corresponding button (SafePal or Metamask) should appear

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
