### PR TITLE
quick fixes: ownerLink and new i18n entry

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -477,6 +477,7 @@ export default {
             error_system_token_transfer_config: 'Error getting Wagmi system token transfer config',
             error_token_transfer_config: 'Error getting Wagmi token transfer config',
             error_oreid_no_chain_account: 'The app {appName} does not have a chain account for the chain {networkName}',
+            network_switch_success: 'Network switched successfully',
         },
     },
 };

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -56,7 +56,7 @@ const ownerLink = computed(() => {
         return '';
     }
 
-    return `${explorerUrl}/address/${nft.value.contractAddress}`;
+    return `${explorerUrl}/address/${nft.value.ownerAddress}`;
 });
 
 </script>


### PR DESCRIPTION
# Fixes #510, #514

## Description
Fixed problems:
- clicking the owner link incorrectly goes to the token contract page
- missing localization text for network_switch_success variable

## Test scenarios
- issue 510
  - Go to [this NFT page](https://deploy-preview-513--wallet-staging.netlify.app/evm/collectible-details?contract=0xFebd6214aeE0391590d46EfF558e6f43833D1Dc5&id=7) and click oner's link
  - An new tab should open with the correct address being explored

- issue 514
  - Change network on MetaMask (other than Testnet)
  - try to login with MetaMask
    - you should be prompted to change the network on MetaMask, accept
    - you should be logged and you should get a "Network switched successfully" notification.