### PR TITLE
#518 | Clear localstorage on app version update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,9 +2,37 @@
 import { useChainStore } from 'src/antelope';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 import { TELOS_CHAIN_IDS } from 'src/antelope/chains/chain-constants';
+import packageInfo from '../package.json';
 
 export default {
     name: 'App',
+    created() {
+        const appVersionJustUpdated = 'UPDATED_NOTIFY_USER';
+        const currentVersion = packageInfo.version;
+        const clientVersion = localStorage.getItem('appVersion');
+
+        console.info('Wallet version: ', packageInfo.version);
+
+        if (clientVersion && clientVersion !== appVersionJustUpdated) {
+            console.info('Client version: ', clientVersion);
+        }
+
+        if (clientVersion === appVersionJustUpdated) {
+            console.info('App version mismatch, local storage cleared');
+            // App version was updated, localStorage was cleared, and the page reloaded
+            // Now inform the user that the app was updated & have them login again, and set the client app version
+            localStorage.setItem('appVersion', currentVersion);
+            (this as any).$notifySuccessMessage(
+                (this as any).$t('global.new_app_version'),
+            );
+        } else if (clientVersion && clientVersion !== currentVersion) {
+            localStorage.clear();
+            localStorage.setItem('appVersion', appVersionJustUpdated);
+            window.location.reload();
+        } else if (!clientVersion) {
+            localStorage.setItem('appVersion', currentVersion);
+        }
+    },
     mounted() {
         const chainSettings = useChainStore().currentChain.settings as EVMChainSettings;
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,10 @@ export default {
             console.info('Client version: ', clientVersion);
         }
 
+        // when localstorage is cleared, we need to reload the page for it to take effect.
+        // however if we immediately reload the page here we cannot show a notification to the user.
+        // so the const appVersionUpdated lets us know after the reload that we just cleared the old localStorage
+        // and need to notify the user that they need to log in again
         if (clientVersion === appVersionJustUpdated) {
             console.info('App version mismatch, local storage cleared');
             // App version was updated, localStorage was cleared, and the page reloaded
@@ -25,12 +29,10 @@ export default {
             (this as any).$notifySuccessMessage(
                 (this as any).$t('global.new_app_version'),
             );
-        } else if (clientVersion && clientVersion !== currentVersion) {
+        } else if (clientVersion !== currentVersion) {
             localStorage.clear();
             localStorage.setItem('appVersion', appVersionJustUpdated);
             window.location.reload();
-        } else if (!clientVersion) {
-            localStorage.setItem('appVersion', currentVersion);
         }
     },
     mounted() {

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -138,6 +138,7 @@ export default {
         collection: 'Collection',
         search: 'Search',
         no_results: 'No results found',
+        new_app_version: 'Telos Wallet has been updated 🚀 Please login again',
     },
     nft : {
         collectible: 'Collectible',


### PR DESCRIPTION
# Fixes #518

## Description
This PR ensures that there is no stale localstorage info on the client when there is an app update, based on the app version in `package.json`

## Test scenarios
- go to https://deploy-preview-519--wallet-staging.netlify.app/
- open dev tools
- go to Application tab
- click on Local Storage -> `https://deploy-preview-519....`
    - you should see `AppVersion` === `2.1.0`
- modify `AppVersion` to be something else, like `2.0.0`
- reload the page (to simulate loading the application with an old version)
    - you should be redirected to the home page and logged out
    - you should see a notification saying the app was updated & to login again
    - `AppVersion` should be updated to `2.1.0`
- log in
    - login should work fine
- reload the page
    - you should see no notification and should not be logged out again 

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
