### PR TITLE
#517 | Fix duplicate login events

### DIFF
--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -35,6 +35,8 @@ export class WalletConnectAuth extends EVMAuthenticator {
     // thus, we need to implement out own debounce so that we can await the async function (in this case, _prepareTokenForTransfer)
     private _debounceTimer: number | NodeJS.Timer | null;
     private _debouncedPrepareTokenConfigResolver: ((value: unknown) => void) | null;
+    private web3Modal: Web3Modal;
+    private unsubscribeWeb3Modal: null | (() => void) = null;
 
     options: Web3ModalConfig;
     wagmiClient: EthereumClient;
@@ -45,6 +47,8 @@ export class WalletConnectAuth extends EVMAuthenticator {
         this.wagmiClient = wagmiClient;
         this._debounceTimer = null;
         this._debouncedPrepareTokenConfigResolver = null;
+
+        this.web3Modal = new Web3Modal(this.options, this.wagmiClient);
     }
 
     // EVMAuthenticator API ----------------------------------------------------------
@@ -136,8 +140,8 @@ export class WalletConnectAuth extends EVMAuthenticator {
         } else {
             return new Promise(async (resolve) => {
                 this.trace('login', 'web3Modal.openModal()');
-                const web3Modal = new Web3Modal(this.options, this.wagmiClient);
-                web3Modal.subscribeModal(async (newState) => {
+
+                this.unsubscribeWeb3Modal = this.web3Modal.subscribeModal(async (newState) => {
                     this.trace('login', 'web3Modal.subscribeModal ', newState, wagmiConnected);
 
                     if (newState.open === true) {
@@ -166,12 +170,20 @@ export class WalletConnectAuth extends EVMAuthenticator {
                                 { id: TELOS_ANALYTICS_EVENT_IDS.loginFailedWalletConnect },
                             );
                         }
+
+                        // this prevents multiple subscribers from being attached to the web3Modal
+                        // without this, every time the user logs out and back in again, this subscribeModal handler
+                        // runs one more time than the last time
+                        if (this.unsubscribeWeb3Modal) {
+                            this.unsubscribeWeb3Modal();
+                        }
                     }
+
                     if (wagmiConnected()) {
                         resolve(this.walletConnectLogin(network));
                     }
                 });
-                web3Modal.openModal();
+                this.web3Modal.openModal();
             });
         }
     }


### PR DESCRIPTION
# Fixes #517

## Description
The numbers don't add up for the number of login events fired. This is because the code which handles the web3modal (wallet connect popup) would create duplicate listeners, which were not unsubscribed after completion. As such, with each login and log out without reloading the page, the walletconnect login code would run 1 more time than before. this PR ensures that subscribers are cleaned up after they run.

after this PR is merged I suggest wiping all event data from Fathom dashboard (copy event code, delete event, make new event with same code I think)

## Test scenarios

- go to https://deploy-preview-523--wallet-staging.netlify.app?trace=true
- open dev tools
- filter the console text by 'login' to prevent log spam
- log in with walletconnect
    - you should see 3 trackAnalyticsEvent events fire, successful login (generic), successful login (wallet connect), and login started
- log out
- clear console
- log in again
    - you should see the exact same events fire, rather than 2 of each 

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
