### PR TITLE
#511 | Fix currency input max value on mobile

### DIFF
--- a/src/components/evm/inputs/CurrencyInput.vue
+++ b/src/components/evm/inputs/CurrencyInput.vue
@@ -938,7 +938,7 @@ export default defineComponent({
         class="c-currency-input__amount-available"
         @click="fillMaxValue"
     >
-        <ToolTip v-if="!isDisabled && !isReadonly" :text="$t('evm_wallet.click_to_fill_max')" :hide-icon="true">
+        <ToolTip v-if="!isDisabled && !isReadonly && !$q.screen.lt.md" :text="$t('evm_wallet.click_to_fill_max')" :hide-icon="true">
             {{ prettyMaxValue }}
         </ToolTip>
         <template v-else>


### PR DESCRIPTION
# Fixes #511

## Description

Currently users can't fill the max value on the currency input because tapping it just shows a tooltip. This PR removes the tooltip on mobile.

## Test scenarios
- go to

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
