### PR TITLE
Disabling the send button until is ready for transfer

### DIFF
--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -32,6 +32,11 @@ export abstract class EVMAuthenticator {
     // to easily clone the authenticator
     abstract newInstance(label: string): EVMAuthenticator;
 
+    // indicates the authenticator is ready to transfer tokens
+    readyForTransfer(): boolean {
+        return true;
+    }
+
     async login(network: string): Promise<addressString | null> {
         this.trace('login', network);
         const chain = useChainStore();

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -220,6 +220,10 @@ export class WalletConnectAuth extends EVMAuthenticator {
         }
     }
 
+    readyForTransfer(): boolean {
+        return !!this.sendConfig;
+    }
+
     sendConfig: PrepareSendTransactionResult | PrepareWriteContractResult<EvmABI, string, number> | null = null;
     private _debouncedPrepareTokenConfig(token: TokenClass | null, amount: BigNumber, to: string) {
         // If there is already a pending call, clear it
@@ -272,6 +276,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
         }
     }
     async prepareTokenForTransfer(token: TokenClass | null, amount: BigNumber, to: string): Promise<void> {
+        this.sendConfig = null;
         await this._debouncedPrepareTokenConfig(token, amount, to);
     }
 

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -163,6 +163,9 @@ export default defineComponent({
         isLoading(): boolean {
             return ant.stores.feedback.isLoading('transferEVMTokens');
         },
+        authIsReadyForTransfer(): boolean {
+            return accountStore.getEVMAuthenticator('logged')?.readyForTransfer() ?? false;
+        },
         configIsLoading() {
             let config;
             if (this.token?.isSystem) {
@@ -399,7 +402,7 @@ export default defineComponent({
                             class="wallet-btn"
                             :label="$t('evm_wallet.send')"
                             :loading="isLoading"
-                            :disable="!isFormValid || isLoading"
+                            :disable="!isFormValid || isLoading || !authIsReadyForTransfer"
                             @click="startTransfer"
                         />
                     </div>


### PR DESCRIPTION
# Fixes #526

## Description
Our wallet consists of several ways to authenticate the user and therefore different ways to carry out a transaction. The method that WalletConnect uses is the only one that requires two steps to perform a transaction: the creation of the sendConfig object and the actual execution of the transfer.

However, it happens that if the user tries to execute the transfer before the configuration object is ready, the error described in #526 occurs.

To avoid that, we disable the submit button until we're sure the config object is ready to be used.

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
