### PR TITLE
#532 | Fix logic for 'new app version' notification

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ export default {
     name: 'App',
     created() {
         const appVersionJustUpdated = 'UPDATED_NOTIFY_USER';
+        const userIsNew = !localStorage.getItem('account');
         const currentVersion = packageInfo.version;
         const clientVersion = localStorage.getItem('appVersion');
 
@@ -29,6 +30,9 @@ export default {
             (this as any).$notifySuccessMessage(
                 (this as any).$t('global.new_app_version'),
             );
+        } else if (userIsNew) {
+            localStorage.clear();
+            localStorage.setItem('appVersion', currentVersion);
         } else if (clientVersion !== currentVersion) {
             localStorage.clear();
             localStorage.setItem('appVersion', appVersionJustUpdated);


### PR DESCRIPTION
# Fixes #532 

## Description
Currently, new users see the 'new app version, please login again' notification when the site loads. Instead this notification should only be shown if the user has already been to the site and logged in before

## Test scenarios
- go to
    - you should not see a notification
- open dev tools > application tab
- log in
- change 'appVersion' localstorage field to something else, like `abc123`
- reload the page
    - you should be redirected to the home page & logged out
    - you should see a 'new app version' notification
- in localstorage, delete the 'appVersion' field but leave your 'account' field (to simulate a user who logged in before this flow was introduced)
- reload the page
    - you should see localstorage was cleared & a notification

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
