### PR TITLE
fixing WC-QR login removing injected provider dependancy

### DIFF
--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -50,7 +50,6 @@ import {
 import { AccountModel, EvmAccountModel } from 'src/antelope/stores/account';
 import { EVMAuthenticator } from 'src/antelope/wallets';
 import { filter } from 'rxjs';
-import { convertCurrency } from 'src/antelope/stores/utils/currency-utils';
 
 export interface BalancesState {
     __balances:  { [label: Label]: TokenBalance[] };
@@ -169,38 +168,12 @@ export const useBalancesStore = defineStore(store_name, {
                 const chain_settings = useChainStore().getChain(label).settings as EVMChainSettings;
                 const sysToken = chain_settings.getSystemToken();
                 const wrpToken = chain_settings.getWrappedSystemToken();
-                const stkToken = chain_settings.getStakedSystemToken();
 
                 // get the price for both system and wrapped tokens
                 const price = (await chain_settings.getUsdPrice()).toString();
                 const marketInfo = { price } as MarketSourceInfo;
                 sysToken.market = new TokenMarketData(marketInfo);
                 wrpToken.market = new TokenMarketData(marketInfo);
-
-                // first we need the contract instance to be able to execute queries
-                const evm = useEVMStore();
-                const authenticator = useAccountStore().getEVMAuthenticator(label);
-                const contract = await evm.getContract(authenticator, stkToken.address, stkToken.type);
-                if (!contract) {
-                    throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: stkToken.address });
-                }
-                const contractInstance = await contract.getContractInstance();
-
-                // Now we preview a deposit of 1 SYS to get the ratio
-                const oneSys = ethers.utils.parseUnits('1.0', sysToken.decimals);
-                const ratio:BigNumber = await contractInstance.previewDeposit(oneSys);
-                const ratioNumber = ethers.utils.formatUnits(ratio, stkToken.decimals);
-
-                // Now we calculate the price of 1 STK = (price of 1 SYS) / ratio
-                const stkPrice = convertCurrency(oneSys, sysToken.decimals, stkToken.decimals, ratioNumber);
-                const stkPriceNumber = ethers.utils.formatUnits(stkPrice, sysToken.decimals);
-
-                // Finally we update the STK token price
-                const stkMarketInfo = { price:stkPriceNumber } as MarketSourceInfo;
-                // TODO: this is removed until we decide what to do whith the STK token price
-                // https://github.com/telosnetwork/telos-wallet/issues/544
-                // stkToken.market = new TokenMarketData(stkMarketInfo);
-                this.trace('updateSystemTokensPrices', `STLOS price: ${toRaw(stkMarketInfo)}`);
 
             } catch (error) {
                 console.error(error);

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -79,12 +79,19 @@ export class WalletConnectAuth extends EVMAuthenticator {
             this.clearAuthenticator();
             const address = getAccount().address as addressString;
 
-            // We are successfully logged in. If we don't have a injected provider, we are using QR
+            // We are successfully logged in. Let's find out if we are using QR
+            this.usingQR = false;
             const injected = new InjectedConnector();
             const provider = toRaw(await injected.getProvider());
-            this.usingQR = typeof provider === 'undefined';
-            this.trace('login', 'using QR:', this.usingQR);
-
+            if (typeof provider === 'undefined') {
+                this.usingQR = true;
+            } else {
+                const providerAddress = (provider._state?.accounts) ? provider._state?.accounts[0] : '';
+                const sameAddress = providerAddress === address;
+                this.usingQR = !sameAddress;
+                this.trace('walletConnectLogin', 'providerAddress:', providerAddress, 'address:', address, 'sameAddress:', sameAddress);
+            }
+            this.trace('walletConnectLogin', 'using QR:', this.usingQR);
 
             // We are already logged in. Now let's try to force the wallet to connect to the correct network
             try {

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -44,6 +44,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
     private _debouncedPrepareTokenConfigResolver: ((value: unknown) => void) | null;
     private web3Modal: Web3Modal;
     private unsubscribeWeb3Modal: null | (() => void) = null;
+    private usingQR = false;
 
     options: Web3ModalConfig;
     wagmiClient: EthereumClient;
@@ -77,6 +78,13 @@ export class WalletConnectAuth extends EVMAuthenticator {
         try {
             this.clearAuthenticator();
             const address = getAccount().address as addressString;
+
+            // We are successfully logged in. If we don't have a injected provider, we are using QR
+            const injected = new InjectedConnector();
+            const provider = toRaw(await injected.getProvider());
+            this.usingQR = typeof provider === 'undefined';
+            this.trace('login', 'using QR:', this.usingQR);
+
 
             // We are already logged in. Now let's try to force the wallet to connect to the correct network
             try {
@@ -149,7 +157,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
                 this.trace('login', 'web3Modal.openModal()');
 
                 this.unsubscribeWeb3Modal = this.web3Modal.subscribeModal(async (newState) => {
-                    this.trace('login', 'web3Modal.subscribeModal ', newState, wagmiConnected);
+                    this.trace('login', 'web3Modal.subscribeModal ', toRaw(newState), wagmiConnected);
 
                     if (newState.open === true) {
                         this.trace(
@@ -198,6 +206,8 @@ export class WalletConnectAuth extends EVMAuthenticator {
     // having this two properties attached to the authenticator instance may bring some problems
     // so after we use them we nned to clear them to avoid that problems
     clearAuthenticator(): void {
+        this.trace('clearAuthenticator');
+        this.usingQR = false;
         this.options = null as unknown as Web3ModalConfig;
         this.wagmiClient = null as unknown as EthereumClient;
     }
@@ -354,11 +364,17 @@ export class WalletConnectAuth extends EVMAuthenticator {
 
     async web3Provider(): Promise<ethers.providers.Web3Provider> {
         let web3Provider = null;
-        if (usePlatformStore().isMobile) {
+        if (usePlatformStore().isMobile || this.usingQR) {
             const p:RpcEndpoint = (useChainStore().getChain(this.label).settings as EVMChainSettings).getRPCEndpoint();
             const url = `${p.protocol}://${p.host}:${p.port}${p.path ?? ''}`;
             web3Provider = new ethers.providers.JsonRpcProvider(url);
             this.trace('web3Provider', 'JsonRpcProvider ->', web3Provider);
+
+            // This is a hack to make the QR code work.
+            // this code is going to be used in EVMAuthenticator.ts login method
+            const listAccounts: () => Promise<`0x${string}`[]> = async () => [getAccount().address as addressString];
+            web3Provider.listAccounts = listAccounts;
+
         } else {
             web3Provider = new ethers.providers.Web3Provider(await this.externalProvider());
             this.trace('web3Provider', 'Web3Provider ->', web3Provider);
@@ -385,6 +401,16 @@ export class WalletConnectAuth extends EVMAuthenticator {
             }
             resolve(provider as unknown as ethers.providers.ExternalProvider);
         });
+    }
+
+    async ensureCorrectChain(): Promise<ethers.providers.Web3Provider> {
+        this.trace('ensureCorrectChain', 'QR:', this.usingQR);
+        if (this.usingQR) {
+            // we don't have tools to check the chain when using QR
+            return this.web3Provider();
+        } else {
+            return super.ensureCorrectChain();
+        }
     }
 
 }


### PR DESCRIPTION
# Fixes #557

## Description

When using WalletConnectAuth class it does distinguish between running on mobile from running on a desktop browser but did not take into account the possible combination of using QR from mobile while running on the browser.

This PR adds this differentiation and introduces a work-around to avoid the problem of trying to ensure the connection with the correct network on those cases. 

## Test scenarios
-- QR test --
- disable all your wallet extensions on the browser
- go to [this link](https://deploy-preview-559--wallet-develop-mainnet.netlify.app/)
- press WQ and wait for the QR to popup
- using your Metamask app on the device, read that QR (using the top-right button)
  - you should be logged in with no problems
  - you can perform some extra actions like Sending on Wrap/Unwrap everything should work fine

-- WC + browser ext --
- enable your Metamask extension in the browser
- go to [this link](https://deploy-preview-559--wallet-develop-mainnet.netlify.app/)
- press WQ and select Metamask
  - you should be logged in with no problems
  - you can perform some extra actions like Sending on Wrap/Unwrap everything should work fine



## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
