### PR TITLE
#563 | Prevent stale prices

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -26,6 +26,7 @@ import {
 import EvmContract from 'src/antelope/stores/utils/contracts/EvmContract';
 import { ethers } from 'ethers';
 import { toStringNumber } from 'src/antelope/stores/utils/currency-utils';
+import { dateIsWithinXMinutes } from 'src/antelope/stores/utils/date-utils';
 import { getAntelope } from 'src/antelope';
 
 
@@ -268,8 +269,10 @@ export default abstract class EVMChainSettings implements ChainSettings {
                     const balance = ethers.BigNumber.from(result.balance);
                     const tokenBalance = new TokenBalance(token, balance);
                     tokens.push(tokenBalance);
-                    // If we have market data we use it
-                    if (typeof contractData.calldata === 'object') {
+                    const priceUpdatedWithinTenMins = !!contractData.calldata.marketdata_updated && dateIsWithinXMinutes(+contractData.calldata.marketdata_updated, 10);
+
+                    // If we have market data we use it, as long as the price was updated within the last 10 minutes
+                    if (typeof contractData.calldata === 'object' && priceUpdatedWithinTenMins) {
                         const price = (+(contractData.calldata.price ?? 0)).toFixed(12);
                         const marketInfo = { ...contractData.calldata, price } as MarketSourceInfo;
                         const marketData = new TokenMarketData(marketInfo);

--- a/src/antelope/stores/utils/date-utils.ts
+++ b/src/antelope/stores/utils/date-utils.ts
@@ -1,0 +1,12 @@
+export function dateIsWithinXMinutes(epochMs: number, minutes: number) {
+    if (epochMs <= 0) {
+        throw new Error('epochMs must be greater than 0');
+    }
+
+    // make a date object which represents the time X minutes ago
+    const xMinsAgo = new Date();
+    xMinsAgo.setMinutes(xMinsAgo.getMinutes() - minutes);
+
+    // return true if the date is within the defined timeframe
+    return new Date(epochMs) > xMinsAgo;
+}

--- a/test/jest/__tests__/antelope/stores/utils/date-utils.spec.ts
+++ b/test/jest/__tests__/antelope/stores/utils/date-utils.spec.ts
@@ -1,0 +1,25 @@
+import { dateIsWithinXMinutes } from 'src/antelope/stores/utils/date-utils';
+
+describe('dateIsWithinXMinutes', () => {
+    it('should throw an error if epochMs is less than or equal to 0', () => {
+        expect(() => dateIsWithinXMinutes(0, 1)).toThrow();
+        expect(() => dateIsWithinXMinutes(-1, 1)).toThrow();
+    });
+
+    it('should return true if the date is within the defined timeframe', () => {
+        const now = Date.now();
+        const fiveMinutesAgo = now - 1000 * 60 * 5;
+        const timeframeMinutes = 10;
+
+        expect(dateIsWithinXMinutes(fiveMinutesAgo, timeframeMinutes)).toBe(true);
+    });
+
+    it('should return false if the date is not within the defined timeframe', () => {
+        const now = Date.now();
+        const tenMinutesAgo = now - 1000 * 60 * 10;
+        const timeframeMinutes = 5;
+
+        // timeframe here is 5 minutes
+        expect(dateIsWithinXMinutes(tenMinutesAgo, timeframeMinutes)).toBe(false);
+    });
+});


### PR DESCRIPTION
# Fixes #563

## Description
This PR checks if individual token prices are out of date, and if so, prevents the price from being displayed

## Test scenarios
- this will need to be tested locally with mainnet; run `git fetch --all && git checkout 563-prevent-stale-prices && echo 'NETWORK="mainnet"' > .env && yarn dev`
- log in with an account that has USDT (you can message me for USDT if you don't have any)
    - there should be no price displayed for USDT on the balances page (since the price is outdated in the indexer)
- revert `.env` if you want to

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
