### PR TITLE
notify cancelation changed from error to neutral notification

### DIFF
--- a/src/antelope/config/index.ts
+++ b/src/antelope/config/index.ts
@@ -43,6 +43,9 @@ export class AntelopeConfig {
     // localization handler --
     private __localization_handler: (key: string, payload?: Record<string, unknown>) => string = (key: string) => key;
 
+    // transaction error handler --
+    private __transaction_error_handler: (err: AntelopeError, trxFailed: string) => void = () => void 0;
+
     // error to string handler --
     private __error_to_string_handler: (error: unknown) => string = (error: unknown) => {
         try {
@@ -164,6 +167,10 @@ export class AntelopeConfig {
         return this.__localization_handler;
     }
 
+    get transactionErrorHandler() {
+        return this.__transaction_error_handler;
+    }
+
     get errorToStringHandler() {
         return this.__error_to_string_handler;
     }
@@ -226,6 +233,11 @@ export class AntelopeConfig {
     // setting translation handler --
     public setLocalizationHandler(handler: (key: string, payload?: Record<string, unknown>) => string) {
         this.__localization_handler = handler;
+    }
+
+    // setting transaction error handler --
+    public setTransactionErrorHandler(handler: (err: AntelopeError, trxFailed: string) => void) {
+        this.__transaction_error_handler = handler;
     }
 
     // setting error to string handler --

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -278,10 +278,11 @@ export const useBalancesStore = defineStore(store_name, {
             this.setWagmiSystemTokenTransferConfig(null, label);
         },
         async transferTokens(token: TokenClass, to: string, amount: BigNumber, memo?: string): Promise<TransactionResponse> {
-            this.trace('transferTokens', token, to, amount.toString(), memo);
+            const funcname = 'transferTokens';
+            this.trace(funcname, token, to, amount.toString(), memo);
             const label = 'logged';
             try {
-                useFeedbackStore().setLoading('transferTokens');
+                useFeedbackStore().setLoading(funcname);
                 const chain = useChainStore().loggedChain;
                 if (chain.settings.isNative()) {
                     const chain_settings = chain.settings as NativeChainSettings;
@@ -295,18 +296,20 @@ export const useBalancesStore = defineStore(store_name, {
                         .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
                 }
             } catch (error) {
-                console.error(error);
-                throw getAntelope().config.wrapError('antelope.evm.error_transfer_failed', error);
+                const trxError = getAntelope().config.wrapError('antelope.evm.error_transfer_failed', error);
+                getAntelope().config.transactionErrorHandler(trxError, funcname);
+                throw trxError;
             } finally {
-                useFeedbackStore().unsetLoading('transferTokens');
+                useFeedbackStore().unsetLoading(funcname);
                 await useBalancesStore().updateBalancesForAccount(label, toRaw(useAccountStore().loggedAccount));
             }
         },
         async wrapSystemTokens(amount: BigNumber): Promise<TransactionResponse> {
-            this.trace('wrapSystemTokens', amount.toString());
+            const funcname = 'wrapSystemTokens';
+            this.trace(funcname, amount.toString());
             const label = 'logged';
             try {
-                useFeedbackStore().setLoading('wrapSystemTokens');
+                useFeedbackStore().setLoading(funcname);
                 const chain = useChainStore().loggedChain;
                 if (chain.settings.isNative()) {
                     console.error('ERROR: wrap not supported on native');
@@ -318,17 +321,19 @@ export const useBalancesStore = defineStore(store_name, {
                         .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
                 }
             } catch (error) {
-                console.error(error);
-                throw getAntelope().config.wrapError('antelope.evm.error_wrap_failed', error);
+                const trxError = getAntelope().config.wrapError('antelope.evm.error_wrap_failed', error);
+                getAntelope().config.transactionErrorHandler(trxError, funcname);
+                throw trxError;
             } finally {
-                useFeedbackStore().unsetLoading('wrapSystemTokens');
+                useFeedbackStore().unsetLoading(funcname);
             }
         },
         async unwrapSystemTokens(amount: BigNumber): Promise<TransactionResponse> {
-            this.trace('unwrapSystemTokens', amount.toString());
+            const funcname = 'unwrapSystemTokens';
+            this.trace(funcname, amount.toString());
             const label = 'logged';
             try {
-                useFeedbackStore().setLoading('unwrapSystemTokens');
+                useFeedbackStore().setLoading(funcname);
                 const chain = useChainStore().loggedChain;
                 if (chain.settings.isNative()) {
                     console.error('ERROR: unwrap not supported on native');
@@ -340,10 +345,11 @@ export const useBalancesStore = defineStore(store_name, {
                         .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
                 }
             } catch (error) {
-                console.error(error);
-                throw getAntelope().config.wrapError('antelope.evm.error_unwrap_failed', error);
+                const trxError = getAntelope().config.wrapError('antelope.evm.error_unwrap_failed', error);
+                getAntelope().config.transactionErrorHandler(trxError, funcname);
+                throw trxError;
             } finally {
-                useFeedbackStore().unsetLoading('unwrapSystemTokens');
+                useFeedbackStore().unsetLoading(funcname);
             }
         },
         async transferNativeTokens(

--- a/src/pages/demo/SendPageErrors.vue
+++ b/src/pages/demo/SendPageErrors.vue
@@ -190,16 +190,6 @@ export default defineComponent({
                 }
             }).catch((err) => {
                 console.error(err);
-                if (err instanceof AntelopeError) {
-                    const evmErr = err as AntelopeError;
-                    if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
-                        ant.config.notifyNeutralMessageHandler(this.$t(evmErr.message));
-                    } else {
-                        ant.config.notifyFailureMessage(this.$t(evmErr.message), evmErr.payload);
-                    }
-                } else {
-                    ant.config.notifyFailureMessage(this.$t('evm_wallet.general_error'));
-                }
             });
 
         },

--- a/src/pages/demo/SendPageErrors.vue
+++ b/src/pages/demo/SendPageErrors.vue
@@ -192,7 +192,11 @@ export default defineComponent({
                 console.error(err);
                 if (err instanceof AntelopeError) {
                     const evmErr = err as AntelopeError;
-                    ant.config.notifyFailureMessage(this.$t(evmErr.message), evmErr.payload);
+                    if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
+                        ant.config.notifyNeutralMessageHandler(this.$t(evmErr.message));
+                    } else {
+                        ant.config.notifyFailureMessage(this.$t(evmErr.message), evmErr.payload);
+                    }
                 } else {
                     ant.config.notifyFailureMessage(this.$t('evm_wallet.general_error'));
                 }

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -269,7 +269,11 @@ export default defineComponent({
                     console.error(err);
                     if (err instanceof AntelopeError) {
                         const evmErr = err as AntelopeError;
-                        ant.config.notifyFailureMessage(this.$t(evmErr.message), evmErr.payload);
+                        if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
+                            ant.config.notifyNeutralMessageHandler(this.$t(evmErr.message));
+                        } else {
+                            ant.config.notifyFailureMessage(this.$t(evmErr.message), evmErr.payload);
+                        }
                     } else {
                         ant.config.notifyFailureMessage(this.$t('evm_wallet.general_error'));
                     }

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -267,16 +267,6 @@ export default defineComponent({
                     }
                 }).catch((err) => {
                     console.error(err);
-                    if (err instanceof AntelopeError) {
-                        const evmErr = err as AntelopeError;
-                        if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
-                            ant.config.notifyNeutralMessageHandler(this.$t(evmErr.message));
-                        } else {
-                            ant.config.notifyFailureMessage(this.$t(evmErr.message), evmErr.payload);
-                        }
-                    } else {
-                        ant.config.notifyFailureMessage(this.$t('evm_wallet.general_error'));
-                    }
                 });
             } else {
                 ant.config.notifyFailureMessage(this.$t('evm_wallet.invalid_form'));

--- a/src/pages/evm/wrap/UnwrapTab.vue
+++ b/src/pages/evm/wrap/UnwrapTab.vue
@@ -109,7 +109,11 @@ async function handleUnwrapClick() {
             console.error(err);
             if (err instanceof AntelopeError) {
                 const evmErr = err as AntelopeError;
-                ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
+                if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
+                    ant.config.notifyNeutralMessageHandler($t(evmErr.message));
+                } else {
+                    ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
+                }
             } else {
                 ant.config.notifyFailureMessage($t('evm_wallet.general_error'));
             }

--- a/src/pages/evm/wrap/UnwrapTab.vue
+++ b/src/pages/evm/wrap/UnwrapTab.vue
@@ -107,16 +107,6 @@ async function handleUnwrapClick() {
             });
         } catch (err) {
             console.error(err);
-            if (err instanceof AntelopeError) {
-                const evmErr = err as AntelopeError;
-                if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
-                    ant.config.notifyNeutralMessageHandler($t(evmErr.message));
-                } else {
-                    ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
-                }
-            } else {
-                ant.config.notifyFailureMessage($t('evm_wallet.general_error'));
-            }
         }
     }
 }

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -125,7 +125,11 @@ async function handleCtaClick() {
             console.error(err);
             if (err instanceof AntelopeError) {
                 const evmErr = err as AntelopeError;
-                ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
+                if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
+                    ant.config.notifyNeutralMessageHandler($t(evmErr.message));
+                } else {
+                    ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
+                }
             } else {
                 ant.config.notifyFailureMessage($t('evm_wallet.general_error'));
             }

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -123,16 +123,6 @@ async function handleCtaClick() {
             });
         } catch (err) {
             console.error(err);
-            if (err instanceof AntelopeError) {
-                const evmErr = err as AntelopeError;
-                if (evmErr.message === 'antelope.evm.error_transaction_canceled') {
-                    ant.config.notifyNeutralMessageHandler($t(evmErr.message));
-                } else {
-                    ant.config.notifyFailureMessage($t(evmErr.message), evmErr.payload);
-                }
-            } else {
-                ant.config.notifyFailureMessage($t('evm_wallet.general_error'));
-            }
         }
     }
 }


### PR DESCRIPTION
# Fixes #573

## Description

We have changed the way of notification to the user who has canceled the operation. Previously an error message was displayed and now a neutral message is displayed

## Test scenarios
- got to [this link](https://deploy-preview-575--wallet-staging.netlify.app/) and login
- Start a token sending but cancel it before last confirmation
  - you should be notified of that event but using a neutral notification
- go to Wrap page
- Start a wrap or an unwrap action and cancel it before last confirmation
  - you should be notified of that event but using a neutral notification

## Screenshots

![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/ae44ff36-291d-48ba-98be-7409843347e6)



## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x]  My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
