### PR TITLE
fallback solution works when indexer is down

### DIFF
--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -98,7 +98,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     async getUsdPrice(): Promise<number> {
-        if (this.hasIndexerSupport()) {
+        if (this.hasIndexerSupport() && this.isIndexerHealthy()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
             const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer, this);

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -98,7 +98,7 @@ export default class TelosEVMTestnet extends EVMChainSettings {
     }
 
     async getUsdPrice(): Promise<number> {
-        if (this.hasIndexerSupport()) {
+        if (this.hasIndexerSupport() && this.isIndexerHealthy()) {
             const nativeTokenSymbol = this.getSystemToken().symbol;
             const fiatCode = useUserStore().fiatCurrency;
             const fiatPrice = await getFiatPriceFromIndexer(nativeTokenSymbol, NativeCurrencyAddress, fiatCode, this.indexer, this);

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -147,6 +147,7 @@ export const useBalancesStore = defineStore(store_name, {
                             this.trace('updateBalancesForAccount', 'Indexer is NOT healthy!', chain_settings.getNetwork(), toRaw(chain_settings.indexerHealthState));
                             // In case the chain does not support index, we need to fetch the balances using Web3
                             await this.updateSystemTokensPrices(label);
+                            this.trace('updateBalancesForAccount', 'chain_settings.getTokenList()');
                             const tokens = await chain_settings.getTokenList();
                             await this.updateSystemBalanceForAccount(label, account.account as addressString);
                             this.trace('updateBalancesForAccount', 'tokens:', toRaw(tokens));
@@ -183,7 +184,9 @@ export const useBalancesStore = defineStore(store_name, {
                 const wrpToken = chain_settings.getWrappedSystemToken();
 
                 // get the price for both system and wrapped tokens
+                this.trace('updateSystemTokensPrices', 'await chain_settings.getUsdPrice()');
                 const price = (await chain_settings.getUsdPrice()).toString();
+                this.trace('updateSystemTokensPrices', 'price:', price);
                 const marketInfo = { price } as MarketSourceInfo;
                 sysToken.market = new TokenMarketData(marketInfo);
                 wrpToken.market = new TokenMarketData(marketInfo);

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -83,7 +83,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             const wethContract = new ethers.Contract(wrappedSystemTokenContractAddress, wtlosAbiDeposit, signer);
 
             if (!wethContract) {
-                console.debug('wrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
+                this.trace('wrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
                 throw 'Unable to get wrapped system contract instance';
             }
             wrappedSystemTokenContractInstance = wethContract;
@@ -114,7 +114,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             const wrappedSystemTokenContract = new ethers.Contract(wrappedSystemTokenContractAddress, wtlosAbiWithdraw, signer);
 
             if (!wrappedSystemTokenContract) {
-                console.debug('unwrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
+                this.trace('unwrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
                 throw 'Unable to get wrapped system contract instance';
             }
             wrappedSystemTokenContractInstance = wrappedSystemTokenContract;

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -83,7 +83,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             const wethContract = new ethers.Contract(wrappedSystemTokenContractAddress, wtlosAbiDeposit, signer);
 
             if (!wethContract) {
-                console.log('wrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
+                console.debug('wrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
                 throw 'Unable to get wrapped system contract instance';
             }
             wrappedSystemTokenContractInstance = wethContract;
@@ -114,7 +114,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             const wrappedSystemTokenContract = new ethers.Contract(wrappedSystemTokenContractAddress, wtlosAbiWithdraw, signer);
 
             if (!wrappedSystemTokenContract) {
-                console.log('unwrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
+                console.debug('unwrapSystemToken', 'address:', wrappedSystemTokenContractAddress, 'signer:', signer);
                 throw 'Unable to get wrapped system contract instance';
             }
             wrappedSystemTokenContractInstance = wrappedSystemTokenContract;

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -21,7 +21,6 @@ const priceCache: { [tokenId: string]: CachedPrice } = {};
 export const getCoingeckoUsdPrice = async (
     tokenId: string,
 ): Promise<number> => {
-    console.log('getCoingeckoUsdPrice()', tokenId);
     const now = Date.now();
 
     if (priceCache[tokenId] &&

--- a/src/api/price.ts
+++ b/src/api/price.ts
@@ -21,6 +21,7 @@ const priceCache: { [tokenId: string]: CachedPrice } = {};
 export const getCoingeckoUsdPrice = async (
     tokenId: string,
 ): Promise<number> => {
+    console.log('getCoingeckoUsdPrice()', tokenId);
     const now = Date.now();
 
     if (priceCache[tokenId] &&


### PR DESCRIPTION
# Fixes #616

## Description
The fallback solution when the indexer is down is not working and balances never load.

This PR changes the strategy so it takes into account when the indexer is down and does not block the execution flow. Now the balances load despite the indexer not working.

<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Screenshot
You can see that now is loading the balances although the indexer is still down.
![Captura desde 2023-09-25 11-08-50](https://github.com/telosnetwork/telos-wallet/assets/4420760/ef65961e-e2ac-4bb3-a78a-00f0a0acf7d5)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
