### PR TITLE
refactor - getContract for evm

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -379,57 +379,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
         return `${token.symbol}-${token.address}-${this.getNetwork()}`;
     }
 
-    /**
-     * This method returns the cached value for the requested contract which can be one of three values:
-     * - Promise<EvmContract> if the contract is already cached
-     * - Promise<null> if the contract was never requested before
-     * - Promise<false> if the contract was requested, not found and set as not existing (to avoid requesting it again)
-     * @param address contract requested
-     * @returns Promise for the requested contract or false if it doesn't exist
-     */
-    async getContract(address: string): Promise<EvmContract | false | null> {
-        const key = address.toLowerCase();
-        const returnValue = this.contracts[key]?.promise ?? null;
-        if (!this.contracts[key]) {
-            this.contracts[key] = {
-                promise: Promise.resolve(false),
-            };
-            this.contracts[key].promise = new Promise((resolve) => {
-                this.contracts[key].resolve = resolve;
-            });
-        }
-        return returnValue;
-    }
-
-    /**
-     * This method adds a contract to the cache and resolves the promise for it
-     * @param address address of the contract
-     * @param contract contract instance to be cached
-     */
-    addContract(address: string, contract: EvmContract | false) {
-        const key = address.toLowerCase();
-        if (!this.contracts[key]) {
-            this.contracts[key] = {
-                promise: Promise.resolve(contract),
-            };
-        } else {
-            if (this.contracts[key].resolve) {
-                this.contracts[key].resolve?.(contract);
-            } else {
-                console.error('Error: Contract already exists', address);
-            }
-        }
-    }
-
-    /**
-     * This method sets a contract as not existing and resolves the promise to false for it.
-     * This is done to distinguish between a contract that was never requested before and one that was requested and not found.
-     * @param address address of the contract
-     */
-    setContractAsNotExisting(address: string) {
-        return this.addContract(address, false);
-    }
-
     async getEVMTransactions(filter: IndexerTransactionsFilter): Promise<IndexerAccountTransactionsResponse> {
         const address = filter.address;
         const limit = filter.limit;
@@ -545,7 +494,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
             .then(response => response.data as AbiSignature);
     }
 
-    async getContractCreation(address: string): Promise<EvmContractCreationInfo> {
+    async fetchContractCreationInfo(address: string): Promise<EvmContractCreationInfo> {
         return this.hyperion.get(`/v2/evm/get_contract?contract=${address}`)
             .then(response => response.data as EvmContractCreationInfo);
     }

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -34,8 +34,8 @@ import {
     useAccountStore,
     useFeedbackStore,
     useChainStore,
-    useEVMStore,
     CURRENT_CONTEXT,
+    useContractStore,
 } from 'src/antelope';
 import { formatWei } from 'src/antelope/stores/utils';
 import { BigNumber, ethers } from 'ethers';
@@ -294,7 +294,7 @@ export const useBalancesStore = defineStore(store_name, {
         async prepareWagmiTokenTransferConfig(label: Label, token: TokenClass, to: string, amount: BigNumber): Promise<void> {
             const config = (await prepareWriteContract({
                 address: token.address as addressString,
-                abi: useEVMStore().getTokenABI(token.type),
+                abi: useContractStore().getTokenABI(token.type),
                 functionName: 'transfer',
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 args: [to, amount] as any[],

--- a/src/antelope/stores/contract.ts
+++ b/src/antelope/stores/contract.ts
@@ -13,22 +13,53 @@
 
 import { defineStore } from 'pinia';
 import {
+    useAccountStore,
     useFeedbackStore,
+    useChainStore,
+    useEVMStore,
 } from 'src/antelope';
+import {
+    AntelopeError,
+    erc1155Abi,
+    erc20Abi,
+    erc721Abi,
+    EvmABI,
+    EvmContractManagerI,
+    EvmContractCreationInfo,
+    EvmContractMetadata,
+    TokenClass,
+    ERC20_TYPE,
+    EvmTransaction,
+    EvmContractFactoryData,
+} from 'src/antelope/types';
+
 import { createTraceFunction, isTracingAll } from 'src/antelope/stores/feedback';
 import EvmContract, { Erc20Transfer } from 'src/antelope/stores/utils/contracts/EvmContract';
 import EvmContractFactory from 'src/antelope/stores/utils/contracts/EvmContractFactory';
-import { useChainStore } from 'src/antelope';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
-import { getTopicHash, TRANSFER_SIGNATURES } from 'src/antelope/stores/utils';
-import { AntelopeError, EvmContractFactoryData, EvmTransaction } from 'src/antelope/types';
+import { getTopicHash, toChecksumAddress, TRANSFER_SIGNATURES } from 'src/antelope/stores/utils';
+import { EVMAuthenticator } from 'src/antelope/wallets';
 import { ethers } from 'ethers';
+import { toRaw } from 'vue';
 
+const LOCAL_SORAGE_CONTRACTS_KEY = 'antelope.contracts';
+
+const createManager = (authenticator: EVMAuthenticator):EvmContractManagerI => ({
+    getSigner: async () => toRaw((await authenticator.web3Provider()).getSigner(useAccountStore().getAccount(authenticator.label).account)),
+    getWeb3Provider: () => authenticator.web3Provider(),
+    getFunctionIface: (hash:string) => toRaw(useEVMStore().getFunctionIface(hash)),
+    getEventIface: (hash:string) => toRaw(useEVMStore().getEventIface(hash)),
+});
 
 export interface ContractStoreState {
     __factory: EvmContractFactory;
-    __cachedContracts: Record<string, EvmContract>
-    __processing: Record<string, Promise<EvmContract | null>>
+    __contracts: {
+        [network: string]: {
+            metadata: Record<string, EvmContractFactoryData | null>
+            cached: Record<string, EvmContract | null>
+            processing: Record<string, Promise<EvmContract | null>>
+        },
+    }
 }
 
 const store_name = 'contract';
@@ -41,46 +72,250 @@ export const useContractStore = defineStore(store_name, {
         trace: createTraceFunction(store_name),
         init() {
             useFeedbackStore().setDebug(store_name, isTracingAll());
+            this.loadCache();
         },
 
-        async getContract(address: string): Promise<EvmContract | null> {
+
+        /**
+         * This function takes all contract's metadata and stores it in the localStorage
+         */
+        saveCache() {
+            this.trace('saveCache');
+            const cacheData: Record<string, Record<string, EvmContractFactoryData | null>> = {};
+
+            for (const network in this.__contracts) {
+                const metadata = this.__contracts[network].metadata;
+                cacheData[network] = {};
+
+                for (const address in metadata) {
+                    cacheData[network][address] = metadata[address];
+                }
+            }
+
+            const cacheString = JSON.stringify(cacheData);
+            localStorage.setItem(LOCAL_SORAGE_CONTRACTS_KEY, cacheString);
+        },
+
+        /**
+         * This function loads all contract's metadata from the localStorage.
+         */
+        loadCache() {
+            this.trace('loadCache');
+            const cacheString = localStorage.getItem(LOCAL_SORAGE_CONTRACTS_KEY);
+
+            if (cacheString) {
+                const cacheData: Record<string, Record<string, EvmContractFactoryData | null>> = JSON.parse(cacheString);
+
+                for (const network in cacheData) {
+                    const metadata = cacheData[network];
+
+                    if (!this.__contracts[network]) {
+                        this.__contracts[network] = {
+                            metadata: {},
+                            cached: {},
+                            processing: {},
+                        };
+                    }
+
+                    for (const address in metadata) {
+                        this.__contracts[network].metadata[address] = metadata[address];
+                    }
+                }
+
+                this.trace('loadCache ->', this.__contracts);
+            }
+        },
+
+        /**
+         * This functions returns immediately with the contract if it's already stored in the cache.
+         * @param label identifier for the chain
+         * @param address address of the contract
+         */
+        getContractIfStored(label: string, address: string): EvmContract | null {
+            const network = useChainStore().getChain(label).settings.getNetwork();
+            const addressLower = address.toLowerCase();
+            const cached:EvmContract | null = this.__contracts[network]?.cached[addressLower] ?? null;
+            return cached;
+        },
+
+        /**
+         * This is the entry point to get a contract. Internally it will get it from the indexer if it's healthy,
+         * otherwise it will get it from hyperion.
+         * @param label identifier for the chain
+         * @param address address of the contract
+         * @param suspectedToken if you know the contract is a token, you can pass the type here to speed up the process
+         * @returns the contract or null if it doesn't exist
+         */
+        async getContract(label: string, address:string, suspectedToken = ''): Promise<EvmContract | null> {
+            this.trace('getContract', label, address, suspectedToken);
+            const chainSettings = useChainStore().getChain(label).settings as EVMChainSettings;
+            const network = chainSettings.getNetwork();
             const addressLower = address.toLowerCase();
 
+            // we assert the network structure existence
+            if (!this.__contracts[network]) {
+                this.__contracts[network] = {
+                    metadata: {},
+                    cached: {},
+                    processing: {},
+                };
+            }
+
             // if we have it in cache, return it
-            if (typeof this.__cachedContracts[addressLower] !== 'undefined') {
-                return this.__cachedContracts[addressLower];
+            if (typeof this.__contracts[network].cached[addressLower] !== 'undefined') {
+                this.trace('getContract', 'returning cached contract', address, [this.__contracts[network].cached[addressLower]]);
+                return this.__contracts[network].cached[addressLower];
+            }
+
+            // if we have the metadata, we can create the contract and return it
+            if (typeof this.__contracts[network].metadata[addressLower] !== 'undefined') {
+                const metadata = this.__contracts[network].metadata[addressLower] as EvmContractFactoryData;
+                this.trace('getContract', 'returning cached metadata', address, [metadata]);
+                return this.createAndStoreContract(label, addressLower, metadata);
             }
 
             // maybe we already starting processing it, return the promise
-            if (typeof this.__processing[addressLower] !== 'undefined') {
-                return this.__processing[addressLower];
+            if (typeof this.__contracts[network].processing[addressLower] !== 'undefined') {
+                this.trace('getContract', 'returning processing contract', address);
+                return this.__contracts[network].processing[addressLower];
             }
 
-            // ok, we need to fetch it
-            this.__processing[addressLower] = new Promise(async (resolve) => {
+            this.trace('getContract', chainSettings.isIndexerHealthy() ? 'indexer is healthy' : 'indexer is not healthy');
 
-                let contract = { address: address };
+            // we don't have it, let's get it
+            if (chainSettings.isIndexerHealthy()) {
+                try {
+                    // we have a healthy indexer, let's get it from there first
+                    return await this.fetchContractUsingIndexer(label, address, suspectedToken);
+                } catch (e) {
+                    console.warn('Indexer did not worked, falling back to hyperion');
+                    return await this.fetchContractUsingHyperion(label, address, suspectedToken);
+                }
+            } else {
+                // we don't have a healthy indexer, let's get it from hyperion
+                return await this.fetchContractUsingHyperion(label, address, suspectedToken);
+            }
+        },
+
+        async fetchContractUsingIndexer(label: string, address:string, suspectedToken = ''): Promise<EvmContract | null> {
+            this.trace('fetchContractUsingIndexer', label, address, suspectedToken);
+            const network = useChainStore().getChain(label).settings.getNetwork();
+            const addressLower = address.toLowerCase();
+
+            // ok, we need to fetch it
+            this.__contracts[network].processing[addressLower] = new Promise(async (resolve) => {
+
+                let metadata = { address: address } as EvmContractFactoryData;
                 try {
                     const indexer = (useChainStore().loggedChain.settings as EVMChainSettings).getIndexer();
                     const response = await indexer.get(`/v1/contract/${address}?full=true&includeAbi=true`);
                     if (response.data?.success && response.data.results.length > 0){
-                        contract = response.data.results[0];
+                        metadata = response.data.results[0];
                     }
                 } catch (e) {
                     console.warn(`Could not retrieve contract ${address}: ${e}`);
-                    resolve(null);
+                    throw new AntelopeError('antelope.contracts.error_retrieving_contract', { address });
                 }
-                this.addContractToCache(address, contract);
-
-                resolve(this.$state.__factory.buildContract(contract));
+                const contract = this.createAndStoreContract(label, address, metadata);
+                resolve(contract);
             });
 
             // return the promise
-            return this.__processing[addressLower];
+            return this.__contracts[network].processing[addressLower];
         },
 
+        async fetchContractUsingHyperion(label: string, address:string, suspectedToken = ''): Promise<EvmContract | null> {
+            this.trace('fetchContractUsingHyperion', label, address, suspectedToken);
+            const addressLower = address.toLowerCase();
+            const network = useChainStore().getChain(label).settings.getNetwork();
+            this.__contracts[network].processing[addressLower] = new Promise(async (resolve) => {
+                try {
+                    // Then we try to get the contract creation info. If it fails we set the contract as not existing and return null
+                    const creationInfo = await this.fetchContractCreationInfo(label, addressLower);
+                    const metadata = await this.fetchContractMetadata(label, address);
+
+                    if (metadata && creationInfo) {
+                        this.trace('fetchContractUsingHyperion', 'returning verified contract', address, metadata, creationInfo);
+                        return resolve(this.createAndStoreVerifiedContract(label, addressLower, metadata, creationInfo, suspectedToken));
+                    }
+
+                    const contract = await this.createAndStoreContractFromTokenList(label, address, suspectedToken, creationInfo);
+                    if (contract) {
+                        this.trace('fetchContractUsingHyperion', 'returning contract from token list', address, contract);
+                        return resolve(contract);
+                    }
+
+                    if (creationInfo) {
+                        this.trace('fetchContractUsingHyperion', 'returning empty contract', address, creationInfo);
+                        return resolve(this.createAndStoreEmptyContract(label, addressLower, creationInfo));
+                    } else {
+                        // We mark this address as not existing so we don't query it again
+                        this.trace('fetchContractUsingHyperion', 'returning null', address);
+                        this.setContractAsNotExisting(label, addressLower);
+                        return resolve(null);
+                    }
+                } catch (e) {
+                    console.warn(`Could not retrieve contract ${address}: ${e}`);
+                    throw new AntelopeError('antelope.contracts.error_retrieving_contract', { address });
+                }
+            });
+
+            return this.__contracts[network].processing[addressLower];
+        },
+
+        getTokenABI(type:string): EvmABI {
+            if(type === 'erc721'){
+                return erc721Abi;
+            } else if(type === 'erc1155'){
+                return erc1155Abi;
+            }
+            return erc20Abi;
+        },
+
+        async getToken(label: string, address:string, suspectedType:string): Promise<TokenClass | null> {
+            if (suspectedType.toUpperCase() === ERC20_TYPE) {
+                const list = await useChainStore().getChain(label).settings.getTokenList();
+                const token = list.find(t => t.address.toUpperCase() === address.toUpperCase());
+                if (token) {
+                    return token;
+                }
+            }
+            return null;
+        },
+
+        async fetchContractCreationInfo(label: string, address:string): Promise<EvmContractCreationInfo | null> {
+            this.trace('fetchContractCreationInfo', label, address);
+            if (!address) {
+                console.error('address is null', address);
+                throw new AntelopeError('antelope.evm.error_invalid_address', { address });
+            }
+            try {
+                const chain_settings = useChainStore().getChain(label).settings as EVMChainSettings;
+                const info = await chain_settings.fetchContractCreationInfo(address);
+                this.trace('fetchContractCreationInfo', label, address, '-> info: ', [info]);
+                return info ?? null;
+            } catch (e) {
+                console.error(new AntelopeError('antelope.evm.error_getting_contract_creation', { address }));
+                return null;
+            }
+        },
+
+        async fetchContractMetadata(label: string, address:string): Promise<EvmContractMetadata | null> {
+            const checksumAddress = toChecksumAddress(address);
+            this.trace('fetchContractMetadata', label, address, ' -> ', checksumAddress);
+            try {
+                const chain_settings = useChainStore().getChain(label).settings as EVMChainSettings;
+                const metadataStr = await chain_settings.getContractMetadata(checksumAddress);
+                this.trace('fetchContractMetadata', label, address, ' metadataStr: ', [metadataStr]);
+                return JSON.parse(metadataStr);
+            } catch (e) {
+                return null;
+            }
+        },
+
+        // Transactions utility functions -----------------------
         // get transfer information from a transaction (ERC20 and native token only)
-        async getErc20TransfersFromTransaction(transaction: EvmTransaction): Promise<Erc20Transfer[]> {
+        async getErc20TransfersFromTransaction(label: string, transaction: EvmTransaction): Promise<Erc20Transfer[]> {
             if (!transaction.logs || transaction.logs?.length === 0){
                 return [];
             }
@@ -92,8 +327,8 @@ export const useContractStore = defineStore(store_name, {
                 const log = logs[i];
                 const sig = log.topics[0].slice(0, 10);
 
-                if(TRANSFER_SIGNATURES.includes(sig)){
-                    const contract = await this.getContract(log.address);
+                if(TRANSFER_SIGNATURES.includes(sig)) {
+                    const contract = await this.getContract(label, log.address);
                     let to = getTopicHash(log.topics[2]);
                     let from = getTopicHash(log.topics[1]);
 
@@ -137,27 +372,112 @@ export const useContractStore = defineStore(store_name, {
             return functionFragment?.name ?? '';
         },
 
-        // commits
-        addContractToCache(address: string, contractData: EvmContractFactoryData): void {
+        // utility functions ---------------------
+        async createAndStoreVerifiedContract(
+            label: string,
+            address:string,
+            metadata: EvmContractMetadata,
+            creationInfo: EvmContractCreationInfo,
+            suspectedType: string,
+        ): Promise<EvmContract> {
+            this.trace('createAndStoreVerifiedContract', label, address, [metadata], [creationInfo], suspectedType);
+            const token = await this.getToken(label, address, suspectedType) ?? undefined;
+            return this.createAndStoreContract(label, address, {
+                name: Object.values(metadata.settings?.compilationTarget ?? {})[0],
+                address,
+                abi: metadata.output?.abi,
+                token: token,
+                creationInfo,
+                verified: true,
+                supportedInterfaces: [token?.type ?? 'none'],
+            } as EvmContractFactoryData);
+        },
+
+        async createAndStoreEmptyContract(
+            label: string,
+            address:string,
+            creationInfo: EvmContractCreationInfo | null,
+        ): Promise<EvmContract> {
+            this.trace('createAndStoreEmptyContract', label, address, [creationInfo]);
+            return this.createAndStoreContract(label, address, {
+                name: `0x${address.slice(0, 16)}...`,
+                address,
+                creationInfo,
+                supportedInterfaces: [],
+            } as EvmContractFactoryData);
+        },
+
+        async createAndStoreContractFromTokenList(
+            label:string,
+            address:string,
+            suspectedType:string,
+            creationInfo:EvmContractCreationInfo | null,
+        ): Promise<EvmContract | null> {
+            const token = await this.getToken(label, address, suspectedType);
+            if (token) {
+                const abi = this.getTokenABI(ERC20_TYPE);
+                return this.createAndStoreContract(label, address, {
+                    name: `${token.name} (${token.symbol})`,
+                    address,
+                    creationInfo,
+                    abi,
+                    token,
+                    supportedInterfaces: [token.type],
+                } as EvmContractFactoryData);
+            } else {
+                return null;
+            }
+        },
+
+        // commits -----
+        createAndStoreContract(label: string, address: string, metadata: EvmContractFactoryData): EvmContract {
+            const network = useChainStore().getChain(label).settings.getNetwork();
+            this.trace('createAndStoreContract', label, network, address, [metadata]);
             if (!address) {
-                throw new AntelopeError('antelope.contracts.address_required');
+                throw new AntelopeError('antelope.contracts.error_address_required');
+            }
+            if (!label) {
+                throw new AntelopeError('antelope.contracts.error_label_required');
             }
             const index = address.toString().toLowerCase();
-            const contract = this.__factory.buildContract(contractData);
 
+            // If:
+            // - we don't have the contract in cache... or
+            // - we have the contract in cache but the new metadata has abi and the cached one doesn't... or
+            // - we have the contract in cache but the new metadata has more abi than the cached one
             if(
-                typeof this.__cachedContracts[index] === 'undefined'
-                || (contract.abi ?? []).length > 0 && !this.__cachedContracts[index].abi
-                || (contract.abi ?? []).length > 0 && (contract.abi ?? []).length > (this.__cachedContracts[index].abi?.length ?? 0)
-            ){
-                this.__cachedContracts[index] = contract;
+                typeof this.__contracts[network].cached[index] === 'undefined'
+                || (metadata.abi ?? []).length > 0 && !this.__contracts[network].cached[index]?.abi
+                || (metadata.abi ?? []).length > 0 && (metadata.abi ?? []).length > (this.__contracts[network].cached[index]?.abi?.length ?? 0)
+            ) {
+                // This manager provides the signer and the web3 provider
+                metadata.manager = createManager(useAccountStore().getAuthenticator(label) as EVMAuthenticator);
+
+                // we create the contract using the factory
+                const contract = this.__factory.buildContract(metadata);
+
+                // then we store them in the cache
+                this.__contracts[network].cached[index] = contract;
+                this.__contracts[network].metadata[index] = { ...metadata, manager: undefined };
+
+                // finally we save the cache and return the contract
+                this.saveCache();
+                return contract;
+            } else {
+                // else we return the cached contract
+                return this.__contracts[network].cached[index] as EvmContract;
             }
+        },
+
+        setContractAsNotExisting(label: string, address: string): void {
+            const network = useChainStore().getChain(label).settings.getNetwork();
+            const index = address.toString().toLowerCase();
+            this.__contracts[network].cached[index] = null;
         },
     },
 });
 
 const contractInitialState: ContractStoreState = {
-    __cachedContracts: {},
-    __processing: {},
+    __contracts: {},
     __factory: new EvmContractFactory(),
 };

--- a/src/antelope/stores/evm.ts
+++ b/src/antelope/stores/evm.ts
@@ -16,31 +16,17 @@ import { BehaviorSubject, filter } from 'rxjs';
 import { createInitFunction, createTraceFunction } from 'src/antelope/stores/feedback';
 
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
-import { events_signatures, functions_overrides, toChecksumAddress } from 'src/antelope/stores/utils';
-import EvmContract from 'src/antelope/stores/utils/contracts/EvmContract';
+import { events_signatures, functions_overrides } from 'src/antelope/stores/utils';
 import {
     AntelopeError,
-    erc1155Abi,
-    ERC1155_TRANSFER_SIGNATURE,
-    erc20Abi,
-    erc721Abi,
-    EvmABI,
-    EvmContractManagerI,
-    EvmLog,
     ExceptionError,
     supportsInterfaceAbi,
-    EvmContractCreationInfo,
-    EvmContractMetadata,
-    TokenClass,
-    ERC20_TYPE,
     ERC721_TYPE,
-    ERC1155_TYPE,
     NFTClass,
     EthereumProvider,
 } from 'src/antelope/types';
 import { toRaw } from 'vue';
 import {
-    CURRENT_CONTEXT,
     getAntelope,
     useAccountStore,
     useChainStore,
@@ -62,12 +48,7 @@ export interface EVMState {
 
 const store_name = 'evm';
 
-const createManager = (authenticator: EVMAuthenticator):EvmContractManagerI => ({
-    getSigner: async () => toRaw((await authenticator.web3Provider()).getSigner(useAccountStore().getAccount(authenticator.label).account)),
-    getWeb3Provider: () => authenticator.web3Provider(),
-    getFunctionIface: (hash:string) => toRaw(useEVMStore().getFunctionIface(hash)),
-    getEventIface: (hash:string) => toRaw(useEVMStore().getEventIface(hash)),
-});
+
 
 export const useEVMStore = defineStore(store_name, {
     state: (): EVMState => (evmInitialState),
@@ -277,13 +258,7 @@ export const useEVMStore = defineStore(store_name, {
                 throw new AntelopeError('antelope.evm.error_getting_function_interface', { prefix });
             }
         },
-
-        getTokenTypeFromLog(log:EvmLog): string {
-            const sig = log.topics[0].substring(0, 10);
-            const type = (log.topics.length === 4) ? ERC721_TYPE : ERC20_TYPE;
-            return (sig === ERC1155_TRANSFER_SIGNATURE) ? ERC1155_TYPE: type;
-        },
-
+        // Evm Contract Managment
         async getEventIface(hex:string): Promise<ethers.utils.Interface | null> {
             const prefix = hex.toLowerCase().slice(0, 10);
             if (Object.prototype.hasOwnProperty.call(this.eventInterfaces, prefix)) {
@@ -301,133 +276,6 @@ export const useEVMStore = defineStore(store_name, {
             } catch (e) {
                 throw new AntelopeError('antelope.evm.error_getting_event_interface', { hex });
             }
-        },
-
-        async getContractCreation(authenticator: EVMAuthenticator, address:string): Promise<EvmContractCreationInfo | null> {
-            this.trace('getContractCreation', address);
-            if (!address) {
-                console.error('address is null', address);
-                throw new AntelopeError('antelope.evm.error_invalid_address', { address });
-            }
-            try {
-                const chain_settings = useChainStore().getChain(authenticator.label).settings as EVMChainSettings;
-                return await chain_settings.getContractCreation(address);
-            } catch (e) {
-                console.error(new AntelopeError('antelope.evm.error_getting_contract_creation', { address }));
-                return null;
-            }
-        },
-
-        // suspectedToken is so we don't try to check for ERC20 info via eth_call unless we think this is a token...
-        // this is coming from the token transfer, transactions table & transaction (general + logs tabs) pages where we're
-        // looking for a contract based on a token transfer event
-        // handles erc721 & erc20 (w/ stubs for erc1155)
-        async getContract(authenticator: EVMAuthenticator, address:string, suspectedToken = ''): Promise<EvmContract | null> {
-            this.trace('getContract', [authenticator], address, suspectedToken);
-            if (!address) {
-                this.trace('getContract', 'address is null', address);
-                return null;
-            }
-            const addressLower = address.toLowerCase();
-
-            // Get from already queried contracts, add token data if needed & not present
-            // (ie: queried beforehand w/o suspectedToken or a wrong suspectedToken)
-            const chain_settings = useChainStore().getChain(authenticator.label).settings as EVMChainSettings;
-            const cached = await chain_settings.getContract(addressLower);
-            this.trace('getContract', address, 'cached:', cached);
-            // If cached is null, it means this is the first time this address is queried
-            if (cached !== null) {
-                if (
-                    !suspectedToken ||
-                    // cached === false means we already tried to get the contract creation info and it failed
-                    !cached ||
-                    cached.token && cached.token?.type === suspectedToken
-                ) {
-                    // this never return false
-                    this.trace('getContract', 'returning cached', addressLower, cached);
-                    return cached || null;
-                }
-            }
-
-            // Then we try to get the contract creation info. If it fails, we never overwrite the previous call to set contract as not existing
-            const creationInfo = await this.getContractCreation(authenticator, addressLower);
-            // The the contract passes the creation info check,
-            // we overwrite the previous call to set contract as not existing with the actual EvmContract
-
-            const metadata = await this.checkBucket(authenticator, address);
-
-            if (metadata && creationInfo) {
-                this.trace('getContract', 'returning verified contract', address, metadata, creationInfo);
-                return await this.getVerifiedContract(authenticator, addressLower, metadata, creationInfo, suspectedToken);
-            }
-
-            const contract = await this.getContractFromTokenList(authenticator, address, suspectedToken, creationInfo);
-            if (contract) {
-                this.trace('getContract', 'returning contract from token list', address, contract);
-                return contract;
-            }
-
-            if (creationInfo) {
-                this.trace('getContract', 'returning empty contract', address, creationInfo);
-                return await this.getEmptyContract(authenticator, addressLower, creationInfo);
-            } else {
-                // We mark this address as not existing so we don't query it again
-                this.trace('getContract', 'returning null', address);
-                chain_settings.setContractAsNotExisting(addressLower);
-                return null;
-            }
-        },
-
-        async checkBucket(authenticator: EVMAuthenticator, address:string): Promise<EvmContractMetadata | null> {
-            const checksumAddress = toChecksumAddress(address);
-            this.trace('checkBucket', [authenticator], address, ' -> ', checksumAddress);
-            try {
-                const chain_settings = useChainStore().getChain(authenticator.label).settings as EVMChainSettings;
-                const metadataStr = await chain_settings.getContractMetadata(checksumAddress);
-                return JSON.parse(metadataStr);
-            } catch (e) {
-                return null;
-            }
-        },
-
-        async getVerifiedContract(
-            authenticator: EVMAuthenticator,
-            address:string,
-            metadata: EvmContractMetadata,
-            creationInfo: EvmContractCreationInfo,
-            suspectedType: string,
-        ): Promise<EvmContract> {
-            const token = await this.getToken(authenticator, address, suspectedType) ?? undefined;
-            const contract = new EvmContract({
-                name: Object.values(metadata.settings?.compilationTarget ?? {})[0],
-                address,
-                abi: metadata.output?.abi,
-                manager: createManager(authenticator),
-                token: token,
-                creationInfo,
-                verified: true,
-                supportedInterfaces: [token?.type ?? 'none'],
-            });
-            const chain_settings = useChainStore().currentChain.settings as EVMChainSettings;
-            chain_settings.addContract(address, contract);
-            return contract;
-        },
-
-        async getEmptyContract(
-            authenticator: EVMAuthenticator,
-            address:string,
-            creationInfo: EvmContractCreationInfo | null,
-        ): Promise<EvmContract> {
-            const contract = new EvmContract({
-                name: `0x${address.slice(0, 16)}...`,
-                address,
-                creationInfo,
-                manager: createManager(authenticator),
-                supportedInterfaces: [],
-            });
-            const chain_settings = useChainStore().currentChain.settings as EVMChainSettings;
-            chain_settings.addContract(address, contract);
-            return contract;
         },
 
         async supportsInterface(authenticator: InjectedProviderAuth, address:string, iface:string): Promise<boolean> {
@@ -459,68 +307,12 @@ export const useEVMStore = defineStore(store_name, {
             return address;
         },
 
-        getTokenABI(type:string): EvmABI {
-            if(type === 'erc721'){
-                return erc721Abi;
-            } else if(type === 'erc1155'){
-                return erc1155Abi;
-            }
-            return erc20Abi;
-        },
-
-        async getContractFromAbi(authenticator: InjectedProviderAuth, address:string, abi:EvmABI): Promise<ethers.Contract> {
-            this.trace('getContractFromAbi', address, abi);
-            const provider = await authenticator.web3Provider();
-            if (!provider) {
-                throw new AntelopeError('antelope.evm.error_no_provider');
-            }
-            return  new ethers.Contract(address, abi, provider);
-        },
-
-        async getToken(authenticator: EVMAuthenticator, address:string, suspectedType:string): Promise<TokenClass | null> {
-            if (suspectedType.toUpperCase() === ERC20_TYPE) {
-                const chain = useChainStore().getChain(CURRENT_CONTEXT);
-                const list = await chain.settings.getTokenList();
-                const token = list.find(t => t.address.toUpperCase() === address.toUpperCase());
-                if (token) {
-                    return token;
-                }
-            }
-            return null;
-        },
-
         async getNFT(address:string, tokenId: string, suspectedType:string): Promise<NFTClass | null> {
             this.trace('getNFT', address, suspectedType, tokenId);
             if (suspectedType.toUpperCase() === ERC721_TYPE) {
                 // TODO: here we try to get NFT data from the chain directly as a fallback for indexer, see https://github.com/telosnetwork/telos-wallet/issues/446
             }
             return null;
-        },
-
-        async getContractFromTokenList(
-            authenticator: EVMAuthenticator,
-            address:string,
-            suspectedType:string,
-            creationInfo:EvmContractCreationInfo | null,
-        ): Promise<EvmContract | null> {
-            const token = await this.getToken(authenticator, address, suspectedType);
-            if (token) {
-                const abi = this.getTokenABI(ERC20_TYPE);
-                const token_contract = new EvmContract({
-                    name: `${token.name} (${token.symbol})`,
-                    address,
-                    creationInfo,
-                    abi,
-                    manager: createManager(authenticator),
-                    token,
-                    supportedInterfaces: [token.type],
-                });
-                const chain_settings = useChainStore().currentChain.settings as EVMChainSettings;
-                chain_settings.addContract(address, token_contract);
-                return token_contract;
-            } else {
-                return null;
-            }
         },
 
         // Commits --------------------

--- a/src/antelope/stores/feedback.ts
+++ b/src/antelope/stores/feedback.ts
@@ -40,7 +40,7 @@ export const createTraceFunction = (store_name: string) => function(action: stri
 // only if we are NOT in production mode search in the url for the trace flag
 // to turn on the Antelope trace mode
 let trace = false;
-if (process.env.NODE_ENV !== 'production') {
+if (document.location.hostname !== 'wallet.telos.net') {
     const urlParams = new URLSearchParams(window.location.search);
     trace = urlParams.get('trace') === 'true';
 }

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -126,7 +126,7 @@ export const useHistoryStore = defineStore(store_name, {
             }
 
             const chain = useChainStore().getChain(label);
-            const chain_settings = chain.settings as EVMChainSettings;
+            const chainSettings = chain.settings as EVMChainSettings;
             const contractStore = useContractStore();
 
 
@@ -143,7 +143,7 @@ export const useHistoryStore = defineStore(store_name, {
                     await this.fetchEvmNftTransfersForAccount(label, this.__evm_filter.address);
                 }
 
-                const transactionsResponse = await chain_settings.getEVMTransactions(toRaw(this.__evm_filter));
+                const transactionsResponse = await chainSettings.getEVMTransactions(toRaw(this.__evm_filter));
                 const contracts = transactionsResponse.contracts;
                 const transactions = transactionsResponse.results;
 
@@ -161,7 +161,7 @@ export const useHistoryStore = defineStore(store_name, {
 
                 // cache contracts
                 contractAddresses.forEach((address) => {
-                    contractStore.addContractToCache(address, parsedContracts[address]);
+                    contractStore.createAndStoreContract(label, address, parsedContracts[address]);
                 });
 
                 this.setEVMTransactions(label, transactions);
@@ -222,7 +222,7 @@ export const useHistoryStore = defineStore(store_name, {
                         };
                     });
                     contractAddresses.forEach((address) => {
-                        contractStore.addContractToCache(address, parsedContracts[address]);
+                        contractStore.createAndStoreContract(label, address, parsedContracts[address]);
                     });
                 });
 
@@ -255,13 +255,12 @@ export const useHistoryStore = defineStore(store_name, {
             const userStore = useUserStore();
             const chain = useChainStore().getChain(label);
             const nftStore = useNftsStore();
-            const chain_settings = chain.settings as EVMChainSettings;
+            const chainSettings = chain.settings as EVMChainSettings;
             const contractStore = useContractStore();
-            const chainSettings = (chain.settings as EVMChainSettings);
             const tlosInUsd = await chainSettings.getUsdPrice();
 
             const transactionShapePromises = transactions.map(async (tx) => {
-                const erc20Transfers = await contractStore.getErc20TransfersFromTransaction(tx);
+                const erc20Transfers = await contractStore.getErc20TransfersFromTransaction(label, tx);
                 const userAddressLower = this.__evm_filter.address.toLowerCase();
 
                 const gasUsedInTlosBn = BigNumber.from(tx.gasPrice).mul(tx.gasused);
@@ -272,8 +271,8 @@ export const useHistoryStore = defineStore(store_name, {
                 const systemTokenDecimals = chainSettings.getSystemToken().decimals;
 
                 // all contracts in transactions are already cached, no need to use getContract
-                const toPrettyName = contractStore.__cachedContracts[tx.to?.toLowerCase()]?.name ?? '';
-                const fromPrettyName = contractStore.__cachedContracts[tx.from?.toLowerCase()]?.name ?? '';
+                const toPrettyName = contractStore.getContractIfStored(label, tx.to?.toLowerCase())?.name ?? '';
+                const fromPrettyName = contractStore.getContractIfStored(label, tx.from?.toLowerCase())?.name ?? '';
 
                 const valuesIn: TransactionValueData[] = [];
                 const valuesOut: TransactionValueData[] = [];
@@ -287,7 +286,7 @@ export const useHistoryStore = defineStore(store_name, {
 
                 if (!isContractCreation && tx.to && tx.to.toLowerCase() !== userAddressLower) {
                     // if the user interacted with a contract, the 'to' field is that contract's address
-                    const contract = await contractStore.getContract(tx.to);
+                    const contract = await contractStore.getContract(label, tx.to);
                     if (contract && contract.abi) {
                         functionName = await contractStore.getFunctionNameFromTransaction(tx, contract);
                     }
@@ -366,7 +365,7 @@ export const useHistoryStore = defineStore(store_name, {
                                     userStore.fiatCurrency,
                                     tokenXfer.address,
                                     tokenXfer.symbol,
-                                    chain_settings.getNetwork(),
+                                    chainSettings.getNetwork(),
                                 );
 
                                 const tokenFiatPriceStr = tokenFiatPriceData?.str;

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -271,8 +271,8 @@ export const useHistoryStore = defineStore(store_name, {
                 const systemTokenDecimals = chainSettings.getSystemToken().decimals;
 
                 // all contracts in transactions are already cached, no need to use getContract
-                const toPrettyName = contractStore.getContractIfStored(label, tx.to?.toLowerCase())?.name ?? '';
-                const fromPrettyName = contractStore.getContractIfStored(label, tx.from?.toLowerCase())?.name ?? '';
+                const toPrettyName = contractStore.getContractIfStored(label, tx.to?.toLowerCase() ?? '')?.name ?? '';
+                const fromPrettyName = contractStore.getContractIfStored(label, tx.from?.toLowerCase() ?? '')?.name ?? '';
 
                 const valuesIn: TransactionValueData[] = [];
                 const valuesOut: TransactionValueData[] = [];

--- a/src/antelope/stores/rex.ts
+++ b/src/antelope/stores/rex.ts
@@ -16,7 +16,7 @@ import {
 import { AntelopeError, EvmRexDeposit, Label, TransactionResponse } from 'src/antelope/types';
 import { toRaw } from 'vue';
 import { AccountModel, useAccountStore } from 'src/antelope/stores/account';
-import { CURRENT_CONTEXT, getAntelope, useBalancesStore, useChainStore, useEVMStore } from 'src/antelope';
+import { CURRENT_CONTEXT, getAntelope, useBalancesStore, useChainStore, useContractStore } from 'src/antelope';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 import { WEI_PRECISION } from 'src/antelope/stores/utils';
 import { subscribeForTransactionReceipt } from 'src/antelope/stores/utils/trx-utils';
@@ -84,12 +84,8 @@ export const useRexStore = defineStore(store_name, {
          * @returns the contract instance
          */
         async getContractInstance(label: string, address: string) {
-            const authenticator = useAccountStore().getEVMAuthenticator(label);
-            if (!authenticator) {
-                this.trace('getContractInstance', label, '-> no authenticator');
-                throw new AntelopeError('antelope.chain.error_no_default_authenticator');
-            }
-            const contract = await useEVMStore().getContract(authenticator, address);
+            this.trace('getContractInstance', label);
+            const contract = await useContractStore().getContract(label, address);
             if (!contract) {
                 this.trace('getContractInstance', label, '-> no contract');
                 throw new AntelopeError('antelope.rex.error_contract_not_found', { address });

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -2,7 +2,7 @@
 
 import { BigNumber, ethers } from 'ethers';
 import { BehaviorSubject, filter, map } from 'rxjs';
-import { useEVMStore, useFeedbackStore, useRexStore } from 'src/antelope';
+import { useContractStore, useEVMStore, useFeedbackStore, useRexStore } from 'src/antelope';
 import {
     AntelopeError,
     ERC20_TYPE,
@@ -215,7 +215,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
 
     async getERC20TokenBalance(account: addressString | string, tokenAddress: addressString | string): Promise<ethers.BigNumber> {
         this.trace('getERC20TokenBalance', [account], tokenAddress);
-        const erc20ABI = useEVMStore().getTokenABI(ERC20_TYPE) as AbiItem[];
+        const erc20ABI = useContractStore().getTokenABI(ERC20_TYPE) as AbiItem[];
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const web3 = new Web3(this.getProvider() as any);
         const contract = new web3.eth.Contract(erc20ABI, tokenAddress);
@@ -230,8 +230,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
         if (token.isSystem) {
             return this.sendSystemToken(to, amount);
         } else {
-            const evm = useEVMStore();
-            const contract = await evm.getContract(this, token.address, token.type);
+            const contract = await useContractStore().getContract(this.label, token.address, token.type);
             if (contract) {
                 const contractInstance = await contract.getContractInstance();
                 const amountInWei = amount.toString();
@@ -257,8 +256,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
     async stakeSystemTokens(amount: BigNumber): Promise<EvmTransactionResponse> {
         this.trace('stakeSystemTokens', amount.toString());
         const stakedToken = this.getChainSettings().getStakedSystemToken();
-        const evm = useEVMStore();
-        const contract = await evm.getContract(this, stakedToken.address, stakedToken.type);
+        const contract = await useContractStore().getContract(this.label, stakedToken.address, stakedToken.type);
         if (contract) {
             const contractInstance = await contract.getContractInstance();
             const transaction = (await contractInstance.depositTLOS({ value: amount })) as EvmTransactionResponse;
@@ -276,8 +274,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
     async unstakeSystemTokens(amount: BigNumber): Promise<EvmTransactionResponse> {
         this.trace('unstakeSystemTokens', amount.toString());
         const stakedToken = this.getChainSettings().getStakedSystemToken();
-        const evm = useEVMStore();
-        const contract = await evm.getContract(this, stakedToken.address, stakedToken.type);
+        const contract = await useContractStore().getContract(this.label, stakedToken.address, stakedToken.type);
         if (contract) {
             const contractInstance = await contract.getContractInstance();
             const amountInWei = amount.toString();

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -19,7 +19,7 @@ import { Web3Modal, Web3ModalConfig } from '@web3modal/html';
 import { BigNumber, ethers } from 'ethers';
 import { TELOS_ANALYTICS_EVENT_IDS } from 'src/antelope/chains/chain-constants';
 import { useChainStore } from 'src/antelope/stores/chain';
-import { useEVMStore } from 'src/antelope/stores/evm';
+import { useContractStore } from 'src/antelope/stores/contract';
 import { useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
 import {
@@ -298,7 +298,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
                     chainId: +useChainStore().getChain(this.label).settings.getChainId(),
                 });
             } else {
-                const abi = useEVMStore().getTokenABI(token.type);
+                const abi = useContractStore().getTokenABI(token.type);
                 const functionName = 'transfer';
                 this.sendConfig = await prepareWriteContract({
                     chainId: +useChainStore().getChain(this.label).settings.getChainId(),

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -512,6 +512,7 @@ export default {
         contracts: {
             invalid_contract: 'Contract or contract ABI missing',
             contract_data_required: 'Contract data missing',
+            error_retrieving_contract: 'Error retrieving contract for address {address}',
         },
         evm: {
             error_support_provider_request: 'Provider does not support request method',
@@ -558,6 +559,8 @@ export default {
             error_invalid_network: 'Invalid network',
             error_no_default_authenticator: 'No default authenticator found',
             error_no_default_authenticator: 'No default authenticator found',
+            error_settings_not_found: 'Settings not found',
+            error_staked_ratio: 'Error in getting staked ratio',
         },
         account: {
             error_login_native: 'An error has occurred trying to login to the native chain',

--- a/test/jest/utils/antelope/store-contract.ts
+++ b/test/jest/utils/antelope/store-contract.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// -------- Contract Store --------
+
+const fetchContractCreationInfo = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+const getContract = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb1: any) => {
+        cb1({
+            getContractInstance: jest.fn().mockImplementation(() => ({
+                previewDeposit: jest.fn(),
+            })),
+        });
+    }),
+}));
+
+const fetchContractMetadata = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+
+const createAndStoreVerifiedContract = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+const createAndStoreEmptyContract = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+const getTokenABI = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+const getToken = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+const createAndStoreContractFromTokenList = jest.fn().mockImplementation(() => ({
+    then: jest.fn().mockImplementation((cb: any) => cb()),
+}));
+
+const ContractGetters = {
+};
+
+const ContractActions = {
+    fetchContractCreationInfo,
+    getContract,
+    fetchContractMetadata,
+    createAndStoreVerifiedContract,
+    createAndStoreEmptyContract,
+    getTokenABI,
+    getToken,
+    createAndStoreContractFromTokenList,
+};
+
+const ContractStore = { ...ContractActions, ...ContractGetters };
+
+const useContractStore = jest.fn().mockImplementation(() => ContractStore);
+
+jest.mock('src/antelope/stores/Contract', () => ({
+    useContractStore,
+}));
+
+export {
+    ContractStore,
+    useContractStore,
+};

--- a/test/jest/utils/antelope/store-evm.ts
+++ b/test/jest/utils/antelope/store-evm.ts
@@ -26,37 +26,10 @@ const getFunctionIface = jest.fn().mockImplementation(() => ({
     then: jest.fn().mockImplementation((cb: any) => cb()),
 }));
 
-const getTokenTypeFromLog = jest.fn().mockImplementation(() => '');
-
 const getEventIface = jest.fn().mockImplementation(() => ({
     then: jest.fn().mockImplementation((cb: any) => cb()),
 }));
 
-const getContractCreation = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
-
-const getContract = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb1: any) => {
-        cb1({
-            getContractInstance: jest.fn().mockImplementation(() => ({
-                previewDeposit: jest.fn(),
-            })),
-        });
-    }),
-}));
-
-const checkBucket = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
-
-const getVerifiedContract = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
-
-const getEmptyContract = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
 
 const supportsInterface = jest.fn().mockImplementation(() => ({
     then: jest.fn().mockImplementation((cb: any) => {
@@ -70,23 +43,9 @@ const isTokenType = jest.fn().mockImplementation(() => ({
     }),
 }));
 
-const getTokenABI = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
 
-const getContractFromAbi = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
-
-const getToken = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
 
 const getNFT = jest.fn().mockImplementation(() => ({
-    then: jest.fn().mockImplementation((cb: any) => cb()),
-}));
-
-const getContractFromTokenLis = jest.fn().mockImplementation(() => ({
     then: jest.fn().mockImplementation((cb: any) => cb()),
 }));
 
@@ -95,7 +54,6 @@ const addInjectedProvider = jest.fn().mockImplementation(() => ({
 }));
 
 const EVMGetters = {
-    isMetamaskSupported: true,
 };
 
 const EVMActions = {
@@ -104,20 +62,10 @@ const EVMActions = {
     ensureCorrectChain,
     switchChainInjected,
     getFunctionIface,
-    getTokenTypeFromLog,
     getEventIface,
-    getContractCreation,
-    getContract,
-    checkBucket,
-    getVerifiedContract,
-    getEmptyContract,
     supportsInterface,
     isTokenType,
-    getTokenABI,
-    getContractFromAbi,
-    getToken,
     getNFT,
-    getContractFromTokenLis,
     addInjectedProvider,
 };
 


### PR DESCRIPTION
# Fixes #598

## Description
This PR includes a refactoring solution for the problem described in #598. Now we have only one function `getContract` in the Contract Store which would use the **Indexer** or the **Hyperion** to retrieve the contract's metadata to create the contract instance and finally cache the metadata in the localStorage to avoid future fetchings for the same immutable data.

## Technical detail

The new structure of variables now takes into account the different possible networks to store the contracts separately.
https://github.com/telosnetwork/telos-wallet/blob/8c0e47dc5f38886803d66832e54809ea1031118d/src/antelope/stores/contract.ts#L54-L63

The saveCache and loadCache functions perform the job of remembering locally all metadata to quickly recreate contract instances and speed up future loadings.
https://github.com/telosnetwork/telos-wallet/blob/8c0e47dc5f38886803d66832e54809ea1031118d/src/antelope/stores/contract.ts#L79-L86

https://github.com/telosnetwork/telos-wallet/blob/8c0e47dc5f38886803d66832e54809ea1031118d/src/antelope/stores/contract.ts#L99-L106

Finally, the getContract function now is divided into three parts:
1 - It asserts the structure exists for the network
https://github.com/telosnetwork/telos-wallet/blob/8c0e47dc5f38886803d66832e54809ea1031118d/src/antelope/stores/contract.ts#L155-L162

2 - then tries to retrieve data from the cache (to skip fetchings)
https://github.com/telosnetwork/telos-wallet/blob/8c0e47dc5f38886803d66832e54809ea1031118d/src/antelope/stores/contract.ts#L164-L181

3 - It takes into account the health of the Indexer before using it and falls back into a Hyperion-based solution if the first one fails.
https://github.com/telosnetwork/telos-wallet/blob/8c0e47dc5f38886803d66832e54809ea1031118d/src/antelope/stores/contract.ts#L185-L197

## Test scenarios


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
