### PR TITLE
adding generic signCustomTransaction function needed on EVMAuthenticators

### DIFF
--- a/src/antelope/types/EvmContractData.ts
+++ b/src/antelope/types/EvmContractData.ts
@@ -100,3 +100,5 @@ export interface EvmContractFactoryData {
     timestamp?: string;
     manager?: EvmContractManagerI;
 }
+
+export type EvmFunctionParam = string | number | boolean;

--- a/src/antelope/types/EvmTransaction.ts
+++ b/src/antelope/types/EvmTransaction.ts
@@ -143,3 +143,4 @@ export interface EvmTransfer {
     timestamp: number; // integer representing ms from epoch
     id?: string; // id of the NFT transferred (ERC721 or ERC1155 only)
 }
+

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -8,7 +8,7 @@ import { useChainStore } from 'src/antelope/stores/chain';
 import { useEVMStore } from 'src/antelope/stores/evm';
 import { createTraceFunction, isTracingAll, useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
-import { AntelopeError, EvmTransactionResponse, ExceptionError, TokenClass, addressString } from 'src/antelope/types';
+import { AntelopeError, EvmABI, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString } from 'src/antelope/types';
 
 export abstract class EVMAuthenticator {
 
@@ -25,6 +25,7 @@ export abstract class EVMAuthenticator {
     abstract logout(): Promise<void>;
     abstract getSystemTokenBalance(address: addressString | string): Promise<BigNumber>;
     abstract getERC20TokenBalance(address: addressString | string, tokenAddress: addressString | string): Promise<BigNumber>;
+    abstract signCustomTransaction(contract: string, abi: EvmABI, parameters: EvmFunctionParam[], value?: BigNumber): Promise<EvmTransactionResponse | WriteContractResult>;
     abstract transferTokens(token: TokenClass, amount: BigNumber, to: addressString | string): Promise<EvmTransactionResponse | SendTransactionResult | WriteContractResult>;
     abstract prepareTokenForTransfer(token: TokenClass | null, amount: BigNumber, to: string): Promise<void>;
     abstract wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse | WriteContractResult>;

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -7,6 +7,8 @@ import {
     AntelopeError,
     ERC20_TYPE,
     EthereumProvider,
+    EvmABI,
+    EvmFunctionParam,
     EvmTransactionResponse,
     TokenClass,
     addressString,
@@ -71,6 +73,22 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
     }
 
     // EVMAuthenticator API ----------------------------------------------------------
+
+    async signCustomTransaction(contract: string, abi: EvmABI, parameters: EvmFunctionParam[], value?: BigNumber): Promise<EvmTransactionResponse> {
+        this.trace('signCustomTransaction', contract, [abi], parameters, value?.toString());
+        // TODO: implement this method and remove this comment
+        // https://github.com/telosnetwork/telos-wallet/issues/625
+
+        const method = abi[0].name;
+        if (abi.length > 1) {
+            console.warn(
+                `signCustomTransaction: abi contains more than one function,
+                we asume the first one (${method}) is the one to be called`,
+            );
+        }
+
+        return Promise.resolve({} as EvmTransactionResponse);
+    }
 
     async wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse> {
         this.trace('wrapSystemToken', amount.toString());

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -2,6 +2,8 @@ import { AuthProvider, ChainNetwork, OreId, OreIdOptions, JSONObject, UserChainA
 import { BigNumber, ethers } from 'ethers';
 import { WebPopup } from 'oreid-webpopup';
 import {
+    EvmABI,
+    EvmFunctionParam,
     erc20Abi,
     escrowAbiWithdraw,
     stlosAbiDeposit,
@@ -291,6 +293,40 @@ export class OreIdAuth extends EVMAuthenticator {
         } as EvmTransactionResponse;
     }
 
+    async signCustomTransaction(contract: string, abi: EvmABI, parameters: EvmFunctionParam[], value?: BigNumber): Promise<EvmTransactionResponse> {
+        this.trace('signCustomTransaction', contract, [abi], parameters, value?.toString());
+        this.checkIntegrity();
+
+        const from = this.getAccountAddress();
+        const method = abi[0].name;
+
+        // if the developer is passing more than one function in the abi
+        // we must warn we asume the first one is the one to be called
+        if (abi.length > 1) {
+            console.warn(
+                `signCustomTransaction: abi contains more than one function,
+                we asume the first one (${method}) is the one to be called`,
+            );
+        }
+
+        // transaction body: wrap system token
+        const transactionBody = {
+            from,
+            to: contract,
+            'contract': {
+                abi,
+                parameters,
+                'method': abi[0].name,
+            },
+        } as unknown as JSONObject;
+
+        if (value) {
+            transactionBody.value = value.toHexString();
+        }
+
+        return this.performOreIdTransaction(from, transactionBody);
+    }
+
     async wrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse> {
         this.trace('wrapSystemToken', amount);
         this.checkIntegrity();
@@ -298,23 +334,13 @@ export class OreIdAuth extends EVMAuthenticator {
         // prepare variables
         const chainSettings = this.getChainSettings();
         const wrappedSystemTokenContractAddress = chainSettings.getWrappedSystemToken().address as addressString;
-        const from = this.getAccountAddress();
-        const value = amount.toHexString();
-        const abi = wtlosAbiDeposit;
 
-        // transaction body: wrap system token
-        const wrapTransaction = {
-            from,
-            to: wrappedSystemTokenContractAddress,
-            value,
-            'contract': {
-                abi,
-                'parameters': [],
-                'method': 'deposit',
-            },
-        } as unknown as JSONObject;
-
-        return this.performOreIdTransaction(from, wrapTransaction);
+        return this.signCustomTransaction(
+            wrappedSystemTokenContractAddress,
+            wtlosAbiDeposit,
+            [],
+            amount,
+        );
     }
 
     async unwrapSystemToken(amount: BigNumber): Promise<EvmTransactionResponse> {
@@ -324,22 +350,13 @@ export class OreIdAuth extends EVMAuthenticator {
         // prepare variables
         const chainSettings = this.getChainSettings();
         const wrappedSystemTokenContractAddress = chainSettings.getWrappedSystemToken().address as addressString;
-        const from = this.getAccountAddress();
         const value = amount.toHexString();
-        const abi = wtlosAbiWithdraw;
 
-        // transaction body: unwrap system token
-        const unwrapTransaction = {
-            from,
-            to: wrappedSystemTokenContractAddress,
-            'contract': {
-                abi,
-                'parameters': [value],
-                'method': 'withdraw',
-            },
-        } as unknown as JSONObject;
-
-        return this.performOreIdTransaction(from, unwrapTransaction);
+        return this.signCustomTransaction(
+            wrappedSystemTokenContractAddress,
+            wtlosAbiWithdraw,
+            [value],
+        );
     }
 
     async stakeSystemTokens(amount: BigNumber): Promise<EvmTransactionResponse> {
@@ -349,23 +366,13 @@ export class OreIdAuth extends EVMAuthenticator {
         // prepare variables
         const chainSettings = this.getChainSettings();
         const stakedSystemTokenContractAddress = chainSettings.getStakedSystemToken().address as addressString;
-        const from = this.getAccountAddress();
-        const value = amount.toHexString();
-        const abi = stlosAbiDeposit;
 
-        // transaction body: stake system token
-        const stakeTransaction = {
-            from,
-            to: stakedSystemTokenContractAddress,
-            value,
-            'contract': {
-                abi,
-                'parameters': [],
-                'method': stlosAbiDeposit[0].name,
-            },
-        } as unknown as JSONObject;
-
-        return this.performOreIdTransaction(from, stakeTransaction);
+        return this.signCustomTransaction(
+            stakedSystemTokenContractAddress,
+            stlosAbiDeposit,
+            [],
+            amount,
+        );
     }
 
     async unstakeSystemTokens(amount: BigNumber): Promise<EvmTransactionResponse> {
@@ -375,22 +382,14 @@ export class OreIdAuth extends EVMAuthenticator {
         // prepare variables
         const chainSettings = this.getChainSettings();
         const stakedSystemTokenContractAddress = chainSettings.getStakedSystemToken().address as addressString;
-        const from = this.getAccountAddress();
         const value = amount.toHexString();
-        const abi = stlosAbiWithdraw;
+        const from = this.getAccountAddress();
 
-        // transaction body: unstake system token
-        const unstakeTransaction = {
-            from,
-            to: stakedSystemTokenContractAddress,
-            'contract': {
-                abi,
-                'parameters': [value, from, from],
-                'method': 'withdraw',
-            },
-        } as unknown as JSONObject;
-
-        return this.performOreIdTransaction(from, unstakeTransaction);
+        return this.signCustomTransaction(
+            stakedSystemTokenContractAddress,
+            stlosAbiWithdraw,
+            [value, from, from],
+        );
     }
 
     async withdrawUnstakedTokens() : Promise<EvmTransactionResponse> {
@@ -400,21 +399,12 @@ export class OreIdAuth extends EVMAuthenticator {
         // prepare variables
         const chainSettings = this.getChainSettings();
         const escrowContractAddress = chainSettings.getEscrowContractAddress();
-        const from = this.getAccountAddress();
-        const abi = escrowAbiWithdraw;
 
-        // transaction body: withdraw staked tokens
-        const withdrawTransaction = {
-            from,
-            to: escrowContractAddress,
-            'contract': {
-                abi,
-                'parameters': [],
-                'method': 'withdraw',
-            },
-        } as unknown as JSONObject;
-
-        return this.performOreIdTransaction(from, withdrawTransaction);
+        return this.signCustomTransaction(
+            escrowContractAddress,
+            escrowAbiWithdraw,
+            [],
+        );
     }
 
     async isConnectedTo(chainId: string): Promise<boolean> {

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -25,6 +25,7 @@ import { usePlatformStore } from 'src/antelope/stores/platform';
 import {
     AntelopeError,
     EvmABI,
+    EvmFunctionParam,
     TokenClass,
     addressString,
     escrowAbiWithdraw,
@@ -240,6 +241,22 @@ export class WalletConnectAuth extends EVMAuthenticator {
         const chainId = +useChainStore().getChain(this.label).settings.getChainId();
         const balance = await fetchBalance({ address, chainId, token }).then(balanceBn => balanceBn.value);
         return BigNumber.from(balance);
+    }
+
+    async signCustomTransaction(contract: string, abi: EvmABI, parameters: EvmFunctionParam[], value?: BigNumber): Promise<SendTransactionResult | WriteContractResult> {
+        this.trace('signCustomTransaction', contract, [abi], parameters, value?.toString());
+        // TODO: implement this method and remove this comment
+        // https://github.com/telosnetwork/telos-wallet/issues/626
+
+        const method = abi[0].name;
+        if (abi.length > 1) {
+            console.warn(
+                `signCustomTransaction: abi contains more than one function,
+                we asume the first one (${method}) is the one to be called`,
+            );
+        }
+
+        return Promise.resolve({} as SendTransactionResult);
     }
 
     async transferTokens(token: TokenClass, amount: BigNumber, to: addressString): Promise<SendTransactionResult | WriteContractResult> {


### PR DESCRIPTION
# Fixes #624

## Description
This PR includes the generic function signCustomTransaction and fully implements it for OreIdAuth. Also, all pre-existing functions in this class were rewritten to use this generic function passing the correct parameters.

## Test scenarios
All transaction signing should be tested using OreId so you need to run this locally

```bash
git fetch origin
git checkout 624-generic-signcustomtransaction-function-needed-on-evmauthenticators
yarn
yarn dev
```
Try the following:
- Send ERC20 Tokens
- Wrap / Unwrap
- Stake / Unstake / withdraw



## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
