### PR TITLE
#601 | Currency input fixes

### DIFF
--- a/src/components/evm/inputs/CurrencyInput.vue
+++ b/src/components/evm/inputs/CurrencyInput.vue
@@ -523,7 +523,19 @@ export default defineComponent({
                 this.inputIsDirty = true;
             }
 
+            // save caret position and number of large number separators (e.g. comma or dot) for later
+            let caretPosition = this.inputElement.selectionStart || 0;
+            const savedLargeNumberSeparatorCount = (this.inputElement.value.match(this.largeNumberSeparatorRegex) || []).length;
+
             this.inputElement.value = val;
+
+            // get information needed to preserve user caret position in case commas/dots are added/removed
+            const newLargeNumberSeparatorCount = (
+                this.inputElement.value.match(this.notIntegerOrDecimalSeparatorRegex) ?? []
+            ).length;
+            const deltaLargeNumberSeparatorCount = newLargeNumberSeparatorCount - savedLargeNumberSeparatorCount;
+
+            this.setInputCaretPosition(caretPosition + deltaLargeNumberSeparatorCount);
 
             // set the indent amount for the symbol label inside the input
             // 1's are 7px, other numbers are 8px, separators like commas are 2px
@@ -549,6 +561,11 @@ export default defineComponent({
         // this method is responsible for emitting a new modelValue, as well as performing certain formatting tasks
         // such as ensuring the user cannot paste invalid characters
         handleInput() {
+            if (this.isReadonly || this.isDisabled) {
+                // this prevents an issue on iOS safari where, when there are two inputs on the page and the second is readonly and depends on the first
+                // such as on the staking and wrapping pages, focus is lost when the user enters a value in to the first input
+                return;
+            }
             const zeroWithDecimalSeparator = `0${this.decimalSeparator}`;
 
             const emit = (val: BigNumber) => {
@@ -619,10 +636,6 @@ export default defineComponent({
                     .replace(this.notIntegerOrSeparatorRegex, ''),
             );
 
-            // save caret position and number of large number separators (e.g. comma or dot) for later
-            let caretPosition = this.inputElement.selectionStart || 0;
-            const savedLargeNumberSeparatorCount = (this.inputElement.value.match(this.largeNumberSeparatorRegex) || []).length;
-
             // if input element value is zero-ish, emit 0
             if (['', null, undefined, '0', zeroWithDecimalSeparator, this.decimalSeparator].includes(this.inputElement.value)) {
                 // if the user types a decimal separator in a blank input, add a zero before the separator
@@ -633,6 +646,8 @@ export default defineComponent({
                 emit(BigNumber.from(0));
                 return;
             }
+
+            let caretPosition = this.inputElement.selectionStart || 0;
 
             // don't format or emit if the user is about to type a decimal
             if (
@@ -672,14 +687,6 @@ export default defineComponent({
             } else {
                 newValue = getBigNumberFromLocalizedNumberString(this.inputElement.value, this.decimals, this.locale);
             }
-
-            // get information needed to preserve user caret position in case commas/dots are added/removed
-            const newLargeNumberSeparatorCount = (
-                this.inputElement.value.match(this.notIntegerOrDecimalSeparatorRegex) ?? []
-            ).length;
-            const deltaLargeNumberSeparatorCount = newLargeNumberSeparatorCount - savedLargeNumberSeparatorCount;
-
-            this.setInputCaretPosition(caretPosition + deltaLargeNumberSeparatorCount);
 
             emit(newValue);
         },


### PR DESCRIPTION
# Fixes #601 

## Description
this PR fixes 2 issues
1. on the staking and wrap pages, on iOS, entering a value into the top input would cause the keyboard to disappear
2. when entering a character in the middle of the input, if there was a large number separator in the input, the caret would be placed at the end of the input, e.g. if the input had "1,234" and you typed a number before the "2", the number would be entered then the input caret would be moved to after the "4"

## Test scenarios
**iOS**
- go to https://deploy-preview-629--wallet-staging.netlify.app/
- sign in
- go to staking
- type a number into the staking input
    - the input should remain focused as you would expect with the keyboard still open
- repeat this on the unstaking page and the wrap page

**Any device**
- go to https://deploy-preview-629--wallet-staging.netlify.app/evm/send
- type a number into the currency field like "12345"
- place your cursor in the middle of the number, such as after the "2"
- type a number
    - your cursor should not move to the end of the input
    - you should be able to keep typing new numbers into the middle of the input

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
