### PR TITLE
#601 | Fix iOS input focus issue

### DIFF
--- a/src/components/evm/inputs/CurrencyInput.vue
+++ b/src/components/evm/inputs/CurrencyInput.vue
@@ -554,18 +554,17 @@ export default defineComponent({
 
         // this method sets the caret position in the input element
         setInputCaretPosition(val: number) {
-            this.inputElement.selectionStart = val;
-            this.inputElement.selectionEnd = val;
+            // prevent the input from taking focus when two or more CurrencyInputs use the same v-model (such as on the Staking page)
+            // and this one is only used for displaying the value, rather than for user input
+            if (!this.isReadonly) {
+                this.inputElement.selectionStart = val;
+                this.inputElement.selectionEnd = val;
+            }
         },
 
         // this method is responsible for emitting a new modelValue, as well as performing certain formatting tasks
         // such as ensuring the user cannot paste invalid characters
         handleInput() {
-            if (this.isReadonly || this.isDisabled) {
-                // this prevents an issue on iOS safari where, when there are two inputs on the page and the second is readonly and depends on the first
-                // such as on the staking and wrapping pages, focus is lost when the user enters a value in to the first input
-                return;
-            }
             const zeroWithDecimalSeparator = `0${this.decimalSeparator}`;
 
             const emit = (val: BigNumber) => {

--- a/src/pages/evm/wrap/UnwrapTab.vue
+++ b/src/pages/evm/wrap/UnwrapTab.vue
@@ -10,7 +10,6 @@ import EVMSidebarPage from 'src/layouts/EVMSidebarPage.vue';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 import { ethers } from 'ethers';
 import { WEI_PRECISION, formatWei } from 'src/antelope/stores/utils';
-import { AntelopeError } from 'src/antelope/types';
 
 const { t: $t } = useI18n();
 const ant = getAntelope();

--- a/src/pages/evm/wrap/WrapTab.vue
+++ b/src/pages/evm/wrap/WrapTab.vue
@@ -17,7 +17,6 @@ import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
 import ConversionRateBadge from 'src/components/ConversionRateBadge.vue';
 import CurrencyInput from 'src/components/evm/inputs/CurrencyInput.vue';
 import { WEI_PRECISION, formatWei } from 'src/antelope/stores/utils';
-import { AntelopeError } from 'src/antelope/types';
 
 const { t: $t } = useI18n();
 const ant = getAntelope();


### PR DESCRIPTION
# Fixes #601

## Description
This PR fixes the issue where on iOS, typing a number on the wrap, unwrap, stake, or unstake pages would result in the input losing focus. The issue was that the method which sets the cursor position was being invoked for readonly inputs. This meant that when the readonly input (e.g. the STLOS input on the staking page) changed value programmatically, the it was being focused and thus the user would lose their focus on the input they were typing in.

Somehow we all thought this issue was fixed but it wasn't 🤷 i think it has to do with how that last PR was later updated to fix some logic related to cursor placement 

**Original testing notes:**

> this PR fixes 2 issues
> 1. on the staking and wrap pages, on iOS, entering a value into the top input would cause the keyboard to disappear
> 2. when entering a character in the middle of the input, if there was a large number separator in the input, the caret would be placed at the end of the input, e.g. if the input had "1,234" and you typed a number before the "2", the number would be entered then the input caret would be moved to after the "4"

## Test scenarios
**iOS**
- go to https://deploy-preview-629--wallet-staging.netlify.app/
- sign in
- go to staking
- type a number into the staking input
    - the input should remain focused as you would expect with the keyboard still open
- repeat this on the unstaking page and the wrap page

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
