### PR TITLE
fixing wrong usingQR flag

### DIFF
--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -89,9 +89,13 @@ export class WalletConnectAuth extends EVMAuthenticator {
                 this.usingQR = true;
             } else {
                 const providerAddress = (provider._state?.accounts) ? provider._state?.accounts[0] : '';
-                const sameAddress = providerAddress === address;
+                const sameAddress = providerAddress.toLocaleLowerCase() === address.toLocaleLowerCase();
                 this.usingQR = !sameAddress;
                 this.trace('walletConnectLogin', 'providerAddress:', providerAddress, 'address:', address, 'sameAddress:', sameAddress);
+
+                // FIXME: remove the following logs
+                console.log('walletConnectLogin', 'using QR:', this.usingQR);
+                console.log('walletConnectLogin', 'providerAddress:', providerAddress, 'address:', address, 'sameAddress:', sameAddress);
             }
             this.trace('walletConnectLogin', 'using QR:', this.usingQR);
 


### PR DESCRIPTION
# Fixes #636

## Description
This PR fixes the wrong flag `usingQR` set internally when WalletConnectAuth tries to decide if the user is using an injected provider (Desktop) or is logged from the Mobile throw the QR. If the second is detected the internal flag usingQR is set on and that makes the class skip checking if the local provider is connected to the correct blockchain. That check was skipped and that generated an error every time the user tried to sign a new transaction.

## Test scenarios
- First, check that this is actually a bug. Follow instructions here: #636
- Then repeat the same steps but using this link



<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
