### PR TITLE
Transfer 721 and 1155 collectibles

### DIFF
--- a/src/antelope/config/index.ts
+++ b/src/antelope/config/index.ts
@@ -4,6 +4,7 @@ import { getAntelope } from 'src/antelope';
 import { AntelopeError, AntelopeErrorPayload } from 'src/antelope/types';
 
 export class AntelopeConfig {
+    // @TODO rename this method, it's used for token and NFT transfers as well
     wrapError(description: string, error: unknown): AntelopeError {
         if (error instanceof AntelopeError) {
             return error as AntelopeError;

--- a/src/antelope/config/index.ts
+++ b/src/antelope/config/index.ts
@@ -4,8 +4,7 @@ import { getAntelope } from 'src/antelope';
 import { AntelopeError, AntelopeErrorPayload } from 'src/antelope/types';
 
 export class AntelopeConfig {
-    // @TODO rename this method, it's used for token and NFT transfers as well
-    wrapError(description: string, error: unknown): AntelopeError {
+    transactionError(description: string, error: unknown): AntelopeError {
         if (error instanceof AntelopeError) {
             return error as AntelopeError;
         }

--- a/src/antelope/stores/balances.ts
+++ b/src/antelope/stores/balances.ts
@@ -244,7 +244,7 @@ export const useBalancesStore = defineStore(store_name, {
                 this.processBalanceForToken(label, sys_token, balanceBn);
             } catch (error) {
                 console.error(error);
-                throw getAntelope().config.wrapError('antelope.evm.error_update_system_balance_failed', error);
+                throw getAntelope().config.transactionError('antelope.evm.error_update_system_balance_failed', error);
             }
         },
         shouldAddTokenBalance(label: string, balanceBn: BigNumber, token: TokenClass): boolean {
@@ -322,7 +322,7 @@ export const useBalancesStore = defineStore(store_name, {
                         .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
                 }
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_transfer_failed', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_transfer_failed', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {
@@ -347,7 +347,7 @@ export const useBalancesStore = defineStore(store_name, {
                         .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
                 }
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_wrap_failed', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_wrap_failed', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {
@@ -371,7 +371,7 @@ export const useBalancesStore = defineStore(store_name, {
                         .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
                 }
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_unwrap_failed', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_unwrap_failed', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {
@@ -403,7 +403,7 @@ export const useBalancesStore = defineStore(store_name, {
                 });
             } catch (error) {
                 console.error(error);
-                throw getAntelope().config.wrapError('antelope.evm.error_transfer_failed', error);
+                throw getAntelope().config.transactionError('antelope.evm.error_transfer_failed', error);
             } finally {
                 useFeedbackStore().unsetLoading('transferNativeTokens');
             }
@@ -423,7 +423,7 @@ export const useBalancesStore = defineStore(store_name, {
                 return result as EvmTransactionResponse | SendTransactionResult;
             } catch (error) {
                 console.error(error);
-                throw getAntelope().config.wrapError('antelope.evm.error_transfer_failed', error);
+                throw getAntelope().config.transactionError('antelope.evm.error_transfer_failed', error);
             } finally {
                 useFeedbackStore().unsetLoading('transferEVMTokens');
             }

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -305,7 +305,7 @@ export const useNftsStore = defineStore(store_name, {
                 return await authenticator.transferNft(contractAddress, tokenId, type, from, to)
                     .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_transfer_nft', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_transfer_nft', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {

--- a/src/antelope/stores/rex.ts
+++ b/src/antelope/stores/rex.ts
@@ -248,7 +248,7 @@ export const useRexStore = defineStore(store_name, {
                 return await authenticator.stakeSystemTokens(amount)
                     .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_stakes_failed', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_stakes_failed', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {
@@ -272,7 +272,7 @@ export const useRexStore = defineStore(store_name, {
                 return await authenticator.unstakeSystemTokens(amount)
                     .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_unstakes_failed', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_unstakes_failed', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {
@@ -296,7 +296,7 @@ export const useRexStore = defineStore(store_name, {
                 return await authenticator.withdrawUnstakedTokens()
                     .then(r => this.subscribeForTransactionReceipt(account, r as TransactionResponse));
             } catch (error) {
-                const trxError = getAntelope().config.wrapError('antelope.evm.error_withdraw_failed', error);
+                const trxError = getAntelope().config.transactionError('antelope.evm.error_withdraw_failed', error);
                 getAntelope().config.transactionErrorHandler(trxError, funcname);
                 throw trxError;
             } finally {

--- a/src/antelope/types/Filters.ts
+++ b/src/antelope/types/Filters.ts
@@ -40,4 +40,5 @@ export interface IndexerTransfersFilter {
     startBlock?: number; // first block to include in the query
     contract?: string; // filter by contract address
     includeAbi?: boolean; // indicate whether to include abi
+    tokenId?: number; // optional id for an NFT in a given collection
 }

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -37,7 +37,7 @@ export abstract class EVMAuthenticator {
     abstract externalProvider(): Promise<ethers.providers.ExternalProvider>;
     abstract web3Provider(): Promise<ethers.providers.Web3Provider>;
     abstract getSigner(): Promise<ethers.Signer>;
-    abstract transferNft(contract: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | WriteContractResult | undefined>;
+    abstract transferNft(contract: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString, quantity?: number): Promise<EvmTransactionResponse | WriteContractResult | undefined>;
 
     // to easily clone the authenticator
     abstract newInstance(label: string): EVMAuthenticator;

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -8,7 +8,7 @@ import { useChainStore } from 'src/antelope/stores/chain';
 import { useEVMStore } from 'src/antelope/stores/evm';
 import { createTraceFunction, isTracingAll, useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
-import { AntelopeError, EvmTransactionResponse, ExceptionError, TokenClass, addressString } from 'src/antelope/types';
+import { AntelopeError, EvmTransactionResponse, ExceptionError, NftTokenInterface, TokenClass, addressString } from 'src/antelope/types';
 
 export abstract class EVMAuthenticator {
 
@@ -36,6 +36,7 @@ export abstract class EVMAuthenticator {
     abstract externalProvider(): Promise<ethers.providers.ExternalProvider>;
     abstract web3Provider(): Promise<ethers.providers.Web3Provider>;
     abstract getSigner(): Promise<ethers.Signer>;
+    abstract transferNft(contract: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | WriteContractResult | undefined>;
 
     // to easily clone the authenticator
     abstract newInstance(label: string): EVMAuthenticator;

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -243,7 +243,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
         }
     }
 
-    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString, quantity = 1): Promise<EvmTransactionResponse | undefined> {
         this.trace('transferNft', contractAddress, tokenId, type, from, to);
         const contract = await useContractStore().getContract(this.label, contractAddress);
         if (contract) {
@@ -251,7 +251,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
             if (type === ERC721_TYPE){
                 return this.signCustomTransaction(contractAddress, [transferAbi[0]], [from, to, tokenId]);
             }else if (type === ERC1155_TYPE){
-                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, 1]);
+                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, quantity]);
             }
         } else {
             throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -248,17 +248,11 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
         this.trace('transferNft', contractAddress, tokenId, type, from, to);
         const contract = await useContractStore().getContract(this.label, contractAddress);
         if (contract) {
-            // const contractInstance = await contract.getContractInstance();
-            debugger;
             const transferAbi = erc721Abi.filter((abi:EvmABIEntry) => abi.name === 'safeTransferFrom');
-            debugger;
             if (type === ERC721_TYPE){
                 return this.signCustomTransaction(contractAddress, [transferAbi[0]], [from, to, tokenId]);
-                // return contractInstance['safeTransferFrom(address,address,uint256)'](from, to, tokenId);
             }else if (type === ERC1155_TYPE){
                 return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, 1]);
-
-                // return contractInstance['safeTransferFrom(address,address,uint256,bytes)'](from, to, tokenId, 1);
             }
         } else {
             throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -10,12 +10,14 @@ import {
     ERC721_TYPE,
     EthereumProvider,
     EvmABI,
+    EvmABIEntry,
     EvmFunctionParam,
     EvmTransactionResponse,
     NftTokenInterface,
     TokenClass,
     addressString,
     erc20Abi,
+    erc721Abi,
     escrowAbiWithdraw,
     stlosAbiDeposit,
     stlosAbiWithdraw,
@@ -87,6 +89,7 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
     // EVMAuthenticator API ----------------------------------------------------------
 
     async signCustomTransaction(contract: string, abi: EvmABI, parameters: EvmFunctionParam[], value?: BigNumber): Promise<EvmTransactionResponse> {
+        debugger;
         this.trace('signCustomTransaction', contract, [abi], parameters, value?.toString());
 
         const method = abi[0].name;
@@ -245,11 +248,17 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
         this.trace('transferNft', contractAddress, tokenId, type, from, to);
         const contract = await useContractStore().getContract(this.label, contractAddress);
         if (contract) {
-            const contractInstance = await contract.getContractInstance();
+            // const contractInstance = await contract.getContractInstance();
+            debugger;
+            const transferAbi = erc721Abi.filter((abi:EvmABIEntry) => abi.name === 'safeTransferFrom');
+            debugger;
             if (type === ERC721_TYPE){
-                return contractInstance['safeTransferFrom(address,address,uint256)'](from, to, tokenId);
+                return this.signCustomTransaction(contractAddress, [transferAbi[0]], [from, to, tokenId]);
+                // return contractInstance['safeTransferFrom(address,address,uint256)'](from, to, tokenId);
             }else if (type === ERC1155_TYPE){
-                return contractInstance['safeTransferFrom(address,address,uint256,bytes)'](from, to, tokenId, 1);
+                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, 1]);
+
+                // return contractInstance['safeTransferFrom(address,address,uint256,bytes)'](from, to, tokenId, 1);
             }
         } else {
             throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -5,9 +5,11 @@ import { BehaviorSubject, filter, map } from 'rxjs';
 import { useContractStore, useEVMStore, useFeedbackStore, useRexStore } from 'src/antelope';
 import {
     AntelopeError,
+    ERC1155_TYPE,
     ERC20_TYPE,
     EthereumProvider,
     EvmTransactionResponse,
+    NftTokenInterface,
     TokenClass,
     addressString,
     wtlosAbiDeposit,
@@ -237,6 +239,21 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
                 return contractInstance.transfer(to, amountInWei);
             } else {
                 throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: token.address });
+            }
+        }
+    }
+
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
+        this.trace('transferNft', contractAddress, tokenId, type, to);
+        if (type === ERC1155_TYPE) {
+            console.log(ERC1155_TYPE);
+        } else {
+            const contract = await useContractStore().getContract(this.label, contractAddress);
+            if (contract) {
+                const contractInstance = await contract.getContractInstance();
+                return contractInstance['safeTransferFrom(address,address,uint256)'](from, to, tokenId);
+            } else {
+                throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });
             }
         }
     }

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -7,6 +7,7 @@ import {
     AntelopeError,
     ERC1155_TYPE,
     ERC20_TYPE,
+    ERC721_TYPE,
     EthereumProvider,
     EvmTransactionResponse,
     NftTokenInterface,
@@ -244,17 +245,17 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
     }
 
     async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
-        this.trace('transferNft', contractAddress, tokenId, type, to);
-        if (type === ERC1155_TYPE) {
-            console.log(ERC1155_TYPE);
-        } else {
-            const contract = await useContractStore().getContract(this.label, contractAddress);
-            if (contract) {
-                const contractInstance = await contract.getContractInstance();
+        this.trace('transferNft', contractAddress, tokenId, type, from, to);
+        const contract = await useContractStore().getContract(this.label, contractAddress);
+        if (contract) {
+            const contractInstance = await contract.getContractInstance();
+            if (type === ERC721_TYPE){
                 return contractInstance['safeTransferFrom(address,address,uint256)'](from, to, tokenId);
-            } else {
-                throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });
+            }else if (type === ERC1155_TYPE){
+                return contractInstance['safeTransferFrom(address,address,uint256,bytes)'](from, to, tokenId, 1);
             }
+        } else {
+            throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });
         }
     }
 

--- a/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
+++ b/src/antelope/wallets/authenticators/InjectedProviderAuth.ts
@@ -89,7 +89,6 @@ export abstract class InjectedProviderAuth extends EVMAuthenticator {
     // EVMAuthenticator API ----------------------------------------------------------
 
     async signCustomTransaction(contract: string, abi: EvmABI, parameters: EvmFunctionParam[], value?: BigNumber): Promise<EvmTransactionResponse> {
-        debugger;
         this.trace('signCustomTransaction', contract, [abi], parameters, value?.toString());
 
         const method = abi[0].name;

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -405,7 +405,7 @@ export class OreIdAuth extends EVMAuthenticator {
         }
     }
 
-    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString, quantity = 1): Promise<EvmTransactionResponse | undefined> {
         this.trace('transferNft', contractAddress, tokenId, type, from, to);
         const contract = await useContractStore().getContract(this.label, contractAddress);
         if (contract) {
@@ -413,7 +413,7 @@ export class OreIdAuth extends EVMAuthenticator {
             if (type === ERC721_TYPE){
                 return this.signCustomTransaction(contractAddress, [transferAbi[0]], [from, to, tokenId]);
             }else if (type === ERC1155_TYPE){
-                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, 1]);
+                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, quantity]);
             }
         } else {
             throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -2,10 +2,14 @@ import { AuthProvider, ChainNetwork, OreId, OreIdOptions, JSONObject, UserChainA
 import { BigNumber, ethers } from 'ethers';
 import { WebPopup } from 'oreid-webpopup';
 import {
+    ERC1155_TYPE,
+    ERC721_TYPE,
     EvmABI,
+    EvmABIEntry,
     EvmFunctionParam,
     NftTokenInterface,
     erc20Abi,
+    erc721Abi,
     escrowAbiWithdraw,
     stlosAbiDeposit,
     stlosAbiWithdraw,
@@ -23,6 +27,7 @@ import { useFeedbackStore } from 'src/antelope/stores/feedback';
 import { useChainStore } from 'src/antelope/stores/chain';
 import { RpcEndpoint } from 'universal-authenticator-library';
 import { TELOS_ANALYTICS_EVENT_IDS } from 'src/antelope/chains/chain-constants';
+import { useContractStore } from 'src/antelope/stores/contract';
 
 
 const name = 'OreId';
@@ -400,10 +405,19 @@ export class OreIdAuth extends EVMAuthenticator {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
-        // @TODO
-        return;
+        this.trace('transferNft', contractAddress, tokenId, type, from, to);
+        const contract = await useContractStore().getContract(this.label, contractAddress);
+        if (contract) {
+            const transferAbi = erc721Abi.filter((abi:EvmABIEntry) => abi.name === 'safeTransferFrom');
+            if (type === ERC721_TYPE){
+                return this.signCustomTransaction(contractAddress, [transferAbi[0]], [from, to, tokenId]);
+            }else if (type === ERC1155_TYPE){
+                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, 1]);
+            }
+        } else {
+            throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });
+        }
     }
 
     async isConnectedTo(chainId: string): Promise<boolean> {

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -2,12 +2,9 @@ import { AuthProvider, ChainNetwork, OreId, OreIdOptions, JSONObject, UserChainA
 import { BigNumber, ethers } from 'ethers';
 import { WebPopup } from 'oreid-webpopup';
 import {
-<<<<<<< HEAD
-    NftTokenInterface,
-=======
     EvmABI,
     EvmFunctionParam,
->>>>>>> 2002c7da98f8bfc1bd510b2a1b25cae152565a97
+    NftTokenInterface,
     erc20Abi,
     escrowAbiWithdraw,
     stlosAbiDeposit,
@@ -401,6 +398,12 @@ export class OreIdAuth extends EVMAuthenticator {
                 [to, value],
             );
         }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
+        // @TODO
+        return;
     }
 
     async isConnectedTo(chainId: string): Promise<boolean> {

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -2,6 +2,7 @@ import { AuthProvider, ChainNetwork, OreId, OreIdOptions, JSONObject, UserChainA
 import { BigNumber, ethers } from 'ethers';
 import { WebPopup } from 'oreid-webpopup';
 import {
+    NftTokenInterface,
     erc20Abi,
     escrowAbiWithdraw,
     stlosAbiDeposit,
@@ -244,6 +245,12 @@ export class OreIdAuth extends EVMAuthenticator {
         }
 
         return this.performOreIdTransaction(from, transactionBody);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
+        // @TODO
+        return;
     }
 
     async prepareTokenForTransfer(token: TokenClass | null, amount: ethers.BigNumber, to: string): Promise<void> {

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -25,6 +25,8 @@ import { usePlatformStore } from 'src/antelope/stores/platform';
 import {
     AntelopeError,
     EvmABI,
+    EvmTransactionResponse,
+    NftTokenInterface,
     TokenClass,
     addressString,
     escrowAbiWithdraw,
@@ -256,6 +258,12 @@ export class WalletConnectAuth extends EVMAuthenticator {
                 return await writeContract(this.sendConfig as PrepareWriteContractResult<EvmABI, 'transfer', number>);
             }
         }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | undefined> {
+        // @TODO
+        return;
     }
 
     readyForTransfer(): boolean {

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -315,7 +315,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
         }
     }
 
-    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString): Promise<EvmTransactionResponse | WriteContractResult | undefined> {
+    async transferNft(contractAddress: string, tokenId: string, type: NftTokenInterface, from: addressString, to: addressString, quantity = 1): Promise<EvmTransactionResponse | WriteContractResult | undefined> {
         this.trace('transferNft', contractAddress, tokenId, type, from, to);
         const contract = await useContractStore().getContract(this.label, contractAddress);
         if (contract) {
@@ -323,7 +323,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
             if (type === ERC721_TYPE){
                 return this.signCustomTransaction(contractAddress, [transferAbi[0]], [from, to, tokenId]);
             }else if (type === ERC1155_TYPE){
-                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, 1]);
+                return this.signCustomTransaction(contractAddress, [transferAbi[1]], [from, to, tokenId, quantity]);
             }
         } else {
             throw new AntelopeError('antelope.balances.error_token_contract_not_found', { address: contractAddress });

--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -123,7 +123,7 @@ export default defineComponent({
             // if the user has come from an external source, pressing back should go to the parent route
             const navigatedFromApp = sessionStorage.getItem('navigatedFromApp');
 
-            if (navigatedFromApp) {
+            if (navigatedFromApp && this.$route.query.tab !== 'attributes') { // @TODO refactor to avoid explicit conditionals, required to nav back from details page but retain tab navigation history
                 this.$router.go(-1);
             } else {
                 const parent = this.$route.meta.parent as string;

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -31,7 +31,8 @@ export default defineComponent({
                     }
 
                     if (!this.tabs.includes(newValue.query.tab)) {
-                        this.$router.replace({ query: { tab: this.tabs[0] } });
+                        this.$router.push({ path: this.$route.path, query: { ...this.$route.query, tab: this.tabs[0] } });
+                        // this.$router.replace ({ query: { tab: this.tabs[0] } });
                     }
                 }
             },

--- a/src/components/evm/AppPage.vue
+++ b/src/components/evm/AppPage.vue
@@ -32,7 +32,6 @@ export default defineComponent({
 
                     if (!this.tabs.includes(newValue.query.tab)) {
                         this.$router.push({ path: this.$route.path, query: { ...this.$route.query, tab: this.tabs[0] } });
-                        // this.$router.replace ({ query: { tab: this.tabs[0] } });
                     }
                 }
             },

--- a/src/css/global/_global.scss
+++ b/src/css/global/_global.scss
@@ -1,0 +1,8 @@
+.q-btn.wallet-btn {
+    @include text--header-5;
+    width: auto;
+    padding: 13px 24px;
+    &+& {
+        margin-left: 16px;
+    }
+}

--- a/src/css/global/global-index.scss
+++ b/src/css/global/global-index.scss
@@ -6,3 +6,4 @@
 @import 'z-index';
 @import 'media-queries';
 @import 'typography';
+@import 'global';

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -178,6 +178,11 @@ export default {
         empty_collection_message: 'Purchase your first collectible',
         empty_collection_link_text: 'here',
         collectibles_per_page: 'Collectibles per page',
+        // transfer
+        transfer: 'Transfer',
+        transfer_collectible: 'transfer collectible',
+        transfer_from: 'from',
+        transfer_on_telos: 'on Telos',
     },
     evm_wrap: {
         wrap: 'Wrap',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -553,6 +553,7 @@ export default {
             error_unstakes_failed: 'An unknown error occurred when unstaking tokens',
             error_withdraw_failed: 'An unknown error occurred when withdrawing tokens',
             error_fetching_token_price: 'An unknown error occurred when fetching token price data',
+            error_transfer_nft: 'An error occured while transferring collectible',
         },
         history: {
             error_fetching_transactions: 'Unexpected error fetching transactions. Please refresh the page to try again.',

--- a/src/pages/demo/SendPageErrors.vue
+++ b/src/pages/demo/SendPageErrors.vue
@@ -309,14 +309,6 @@ export default defineComponent({
 </template>
 
 <style lang="scss">
-.q-btn.wallet-btn {
-    @include text--header-5;
-    &+& {
-        margin-left: 16px;
-    }
-}
-
-
 .c-send-page-errors {
     &__title-container {
         flex-direction: column;

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -48,6 +48,10 @@ onBeforeMount(async () => {
             nft.value = erc1155Details;
             nftType = ERC1155_TYPE;
         }
+
+        if (nft.value.ownerAddress !== loggedAccount.value.address){
+            removeTransferTab();
+        }
         loading.value = false;
     }
 });
@@ -97,10 +101,14 @@ async function startTransfer(){
             dismiss();
         });
         router.push({ query: { tab: 'attributes' } });
-        tabs.value.pop(); // remove 'transfer' tab option
+        removeTransferTab();
     }catch(e){
         console.error(e); // tx error notification handled in store
     }
+}
+
+function removeTransferTab(){
+    tabs.value.splice(tabs.value.findIndex(item => item === 'transfer'), 1);
 }
 
 </script>

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -56,6 +56,8 @@ onBeforeMount(async () => {
 
         if (nft.value.ownerAddress !== loggedAccount.value.address){
             removeTab(TRANSFER);
+        }
+
         loading.value = false;
     }
 });

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -27,7 +27,10 @@ const accountStore = useAccountStore();
 const explorerUrl = (chainStore.currentChain.settings as EVMChainSettings).getExplorerUrl();
 let addressIsValid = false;
 
-const tabs = ref<String[]>(['attributes', 'transfer']);
+const ATTRIBUTES = 'attributes';
+const TRANSFER = 'transfer';
+
+const tabs = ref<String[]>([ATTRIBUTES, TRANSFER]);
 const nft = ref<ShapedNFT | null>(null);
 const loading = ref(true);
 const address = ref('');
@@ -108,7 +111,7 @@ async function startTransfer(){
 }
 
 function removeTransferTab(){
-    tabs.value.splice(tabs.value.findIndex(item => item === 'transfer'), 1);
+    tabs.value.splice(tabs.value.findIndex(item => item === TRANSFER), 1);
 }
 
 </script>

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -19,6 +19,8 @@ const { t: $t } = useI18n();
 const nftStore = useNftsStore();
 const chainStore = useChainStore();
 
+const tabs = ['attributes', 'transfer'];
+
 const nft = ref<ShapedNFT | null>(null);
 const loading = ref(true);
 
@@ -71,7 +73,7 @@ const filteredAttributes = computed(() =>
 </script>
 
 <template>
-<AppPage>
+<AppPage :tabs="tabs">
     <template v-slot:header>
         <div
             :class="{
@@ -125,87 +127,91 @@ const filteredAttributes = computed(() =>
         </div>
     </template>
 
-    <div class="c-nft-details__body-container">
-        <q-skeleton v-if="loading" type="text" class="c-nft-details__body-header-skeleton"/>
-        <h4
-            v-else
-            :class="{
-                'q-mb-lg': true,
-                'u-text--center': nft === null,
-            }"
-        >
-            <template v-if="nft === null">
-                {{ $t('nft.collectible_not_found_recommendation') }}
-            </template>
-            <template v-else>
-                {{ $t('global.attributes') }}
-            </template>
-        </h4>
+    <template v-slot:attributes>
+        <div class="c-nft-details__body-container">
+            <q-skeleton v-if="loading" type="text" class="c-nft-details__body-header-skeleton"/>
+            <h4
+                v-else
+                :class="{
+                    'q-mb-lg': true,
+                    'u-text--center': nft === null,
+                }"
+            >
+                <template v-if="nft === null">
+                    {{ $t('nft.collectible_not_found_recommendation') }}
+                </template>
+                <template v-else>
+                    {{ $t('global.attributes') }}
+                </template>
+            </h4>
 
-        <div
-            :class="{
-                'c-nft-details__attributes-container': true,
-                'c-nft-details__attributes-container--not-found': nft === null && !loading,
-            }"
-        >
-            <template v-if="loading">
-                <q-skeleton
-                    v-for="index in 9"
-                    :key="`nft-detail-body-skeleton-${index}`"
-                    class="c-nft-details__attribute-skeleton"
-                />
-            </template>
+            <div
+                :class="{
+                    'c-nft-details__attributes-container': true,
+                    'c-nft-details__attributes-container--not-found': nft === null && !loading,
+                }"
+            >
+                <template v-if="loading">
+                    <q-skeleton
+                        v-for="index in 9"
+                        :key="`nft-detail-body-skeleton-${index}`"
+                        class="c-nft-details__attribute-skeleton"
+                    />
+                </template>
 
-            <template v-else-if="nft === null">
-                <NumberedList>
-                    <template v-slot:1>
-                        <p>
-                            {{ $t('nft.collectible_not_found_contract_part_1') }}
-                            <span class="o-text--paragraph-bold">
-                                {{ $t('nft.collectible_not_found_contract_part_2_bold') }}
-                            </span>
-                            {{ $t('nft.collectible_not_found_contract_part_3') }}
+                <template v-else-if="nft === null">
+                    <NumberedList>
+                        <template v-slot:1>
+                            <p>
+                                {{ $t('nft.collectible_not_found_contract_part_1') }}
+                                <span class="o-text--paragraph-bold">
+                                    {{ $t('nft.collectible_not_found_contract_part_2_bold') }}
+                                </span>
+                                {{ $t('nft.collectible_not_found_contract_part_3') }}
 
-                            <template v-if="contractAddressIsValid">
-                                {{ $t('nft.collectible_not_found_contract_part_4') }}
-                                <br>
-                                <ExternalLink :text="contractAddress" :url="contractLink" />
-                            </template>
+                                <template v-if="contractAddressIsValid">
+                                    {{ $t('nft.collectible_not_found_contract_part_4') }}
+                                    <br>
+                                    <ExternalLink :text="contractAddress" :url="contractLink" />
+                                </template>
 
-                            <template v-else>
-                                {{ $t('nft.collectible_not_found_contract_invalid') }}
-                            </template>
-                        </p>
-                    </template>
+                                <template v-else>
+                                    {{ $t('nft.collectible_not_found_contract_invalid') }}
+                                </template>
+                            </p>
+                        </template>
 
-                    <template v-slot:2>
-                        <p>
-                            {{ $t('nft.collectible_not_found_nft_id_part_1') }}
-                            <span class="o-text--paragraph-bold">
-                                {{ $t('global.id') }}
-                            </span>
-                            {{ $t('nft.collectible_not_found_nft_id_part_3') }}
-                        </p>
-                    </template>
-                </NumberedList>
-            </template>
+                        <template v-slot:2>
+                            <p>
+                                {{ $t('nft.collectible_not_found_nft_id_part_1') }}
+                                <span class="o-text--paragraph-bold">
+                                    {{ $t('global.id') }}
+                                </span>
+                                {{ $t('nft.collectible_not_found_nft_id_part_3') }}
+                            </p>
+                        </template>
+                    </NumberedList>
+                </template>
 
-            <template v-else>
-                <p v-if="!nft.attributes?.length">
-                    {{ $t('nft.no_attributes') }}
-                </p>
+                <template v-else>
+                    <p v-if="!nft.attributes?.length">
+                        {{ $t('nft.no_attributes') }}
+                    </p>
 
-                <NftDetailsCard
-                    v-for="(attribute, index) in filteredAttributes"
-                    :key="`nft-attr-${index}`"
-                    :title="attribute.label"
-                    class="q-mb-sm"
-                >
-                    {{ attribute.text }}
-                </NftDetailsCard>
-            </template>
+                    <NftDetailsCard
+                        v-for="(attribute, index) in filteredAttributes"
+                        :key="`nft-attr-${index}`"
+                        :title="attribute.label"
+                        class="q-mb-sm"
+                    >
+                        {{ attribute.text }}
+                    </NftDetailsCard>
+                </template>
+            </div>
         </div>
-    </div>
+    </template>
+    <template v-slot:transfer>
+    </template>
 </AppPage>
 </template>
 

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -81,7 +81,6 @@ const loggedAccount = computed(() =>
 );
 
 async function startTransfer(){
-
     const nameString = `${nft.value.contractPrettyName || nft.value.contractAddress} #${nft.value.id}`;
     const dismiss = ant.config.notifyNeutralMessageHandler(
         $t('notification.neutral_message_sending', { quantity: nameString, address: address.value }),
@@ -93,6 +92,7 @@ async function startTransfer(){
             `${explorerUrl}/tx/${trx.hash}`,
         );
         router.push({ query: { tab: 'attributes' } });
+        tabs.value.pop(); // remove 'transfer' tab option
     }catch(e){
         console.error(e); // tx error notification handled in store
     }

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -23,13 +23,16 @@ const chainStore = useChainStore();
 const accountStore = useAccountStore();
 
 const tabs = ['attributes', 'transfer'];
-const address = '';
+const explorerUrl = (chainStore.currentChain.settings as EVMChainSettings).getExplorerUrl();
+let addressIsValid = false;
 
 const nft = ref<ShapedNFT | null>(null);
 const loading = ref(true);
+const address = ref('');
 
 const contractAddress = route.query.contract as string;
 const nftId = route.query.id as string;
+let nftType: ERC1155_TYPE | ERC721_TYPE | null = null;
 
 onBeforeMount(async () => {
     if (contractAddress && nftId) {
@@ -38,18 +41,15 @@ onBeforeMount(async () => {
 
         if (erc721Details) {
             nft.value = erc721Details;
+            nftType = ERC721_TYPE;
         } else if (erc1155Details) {
             nft.value = erc1155Details;
+            nftType = ERC1155_TYPE;
         }
         loading.value = false;
     }
 });
 
-// data
-const explorerUrl = (chainStore.currentChain.settings as EVMChainSettings).getExplorerUrl();
-const addressIsValid = false;
-
-// computed
 const contractAddressIsValid = computed(
     () => isValidAddressFormat(contractAddress),
 );
@@ -78,7 +78,9 @@ const loggedAccount = computed(() =>
     accountStore.loggedEvmAccount,
 );
 
-const startTransfer = () => console.log('test');
+async function startTransfer(){
+    await nftStore.transferNft(CURRENT_CONTEXT, contractAddress, nftId, nftType, loggedAccount.value.address, address.value);
+}
 
 </script>
 
@@ -442,6 +444,10 @@ const startTransfer = () => console.log('test');
 
         &--small{
             font-size: 16px;
+                // override UserInfo component styling
+            .o-text--header-4{
+                font-size: 16px !important;
+            }
         }
 
         &--bold{
@@ -450,7 +456,7 @@ const startTransfer = () => console.log('test');
     }
 }
 
-// refactor as global
+// refactor as global used in several places
 .q-btn.wallet-btn {
     @include text--header-5;
     &+& {
@@ -458,8 +464,4 @@ const startTransfer = () => console.log('test');
     }
 }
 
-// override UserInfo component styling
-.o-text--header-4{
-    font-size: 16px !important;
-}
 </style>

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -29,8 +29,9 @@ let addressIsValid = false;
 
 const ATTRIBUTES = 'attributes';
 const TRANSFER = 'transfer';
+const OWNERS = 'owners'; // for 1155 only
 
-const tabs = ref<String[]>([ATTRIBUTES, TRANSFER]);
+const tabs = ref<String[]>([ATTRIBUTES, TRANSFER, OWNERS]);
 const nft = ref<ShapedNFT | null>(null);
 const loading = ref(true);
 const address = ref('');
@@ -47,14 +48,14 @@ onBeforeMount(async () => {
         if (erc721Details) {
             nft.value = erc721Details;
             nftType = ERC721_TYPE;
+            removeTab(OWNERS);
         } else if (erc1155Details) {
             nft.value = erc1155Details;
             nftType = ERC1155_TYPE;
         }
 
         if (nft.value.ownerAddress !== loggedAccount.value.address){
-            removeTransferTab();
-        }
+            removeTab(TRANSFER);
         loading.value = false;
     }
 });
@@ -104,14 +105,14 @@ async function startTransfer(){
             dismiss();
         });
         router.push({ query: { tab: 'attributes' } });
-        removeTransferTab();
+        removeTab(TRANSFER);
     }catch(e){
         console.error(e); // tx error notification handled in store
     }
 }
 
-function removeTransferTab(){
-    tabs.value.splice(tabs.value.findIndex(item => item === TRANSFER), 1);
+function removeTab(tab: string){
+    tabs.value.splice(tabs.value.findIndex(item => item === tab), 1);
 }
 
 </script>

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -490,13 +490,4 @@ function removeTab(tab: string){
         }
     }
 }
-
-// refactor as global used in several places
-.q-btn.wallet-btn {
-    @include text--header-5;
-    &+& {
-        margin-left: 16px;
-    }
-}
-
 </style>

--- a/src/pages/evm/nfts/NftDetailsPage.vue
+++ b/src/pages/evm/nfts/NftDetailsPage.vue
@@ -82,15 +82,20 @@ const loggedAccount = computed(() =>
 
 async function startTransfer(){
     const nameString = `${nft.value.contractPrettyName || nft.value.contractAddress} #${nft.value.id}`;
-    const dismiss = ant.config.notifyNeutralMessageHandler(
-        $t('notification.neutral_message_sending', { quantity: nameString, address: address.value }),
-    );
     try{
         const trx = await nftStore.transferNft(CURRENT_CONTEXT, contractAddress, nftId, nftType, loggedAccount.value.address, address.value);
-        dismiss();
-        ant.config.notifySuccessfulTrxHandler(
-            `${explorerUrl}/tx/${trx.hash}`,
+        const dismiss = ant.config.notifyNeutralMessageHandler(
+            $t('notification.neutral_message_sending', { quantity: nameString, address: address.value }),
         );
+        trx.wait().then(() => {
+            ant.config.notifySuccessfulTrxHandler(
+                `${explorerUrl}/tx/${trx.hash}`,
+            );
+        }).catch((err) => {
+            console.error(err);
+        }).finally(() => {
+            dismiss();
+        });
         router.push({ query: { tab: 'attributes' } });
         tabs.value.pop(); // remove 'transfer' tab option
     }catch(e){

--- a/src/pages/evm/nfts/NftInventoryPage.vue
+++ b/src/pages/evm/nfts/NftInventoryPage.vue
@@ -254,7 +254,6 @@ watch(searchFilter, (filter) => {
     }
 });
 
-
 // methods
 function getCollectionUrl(address: string) {
     const explorer = (chainStore.currentChain.settings as EVMChainSettings).getExplorerUrl();

--- a/src/pages/evm/wallet/ReceivePage.vue
+++ b/src/pages/evm/wallet/ReceivePage.vue
@@ -79,15 +79,6 @@ export default defineComponent({
 </template>
 
 <style lang="scss">
-.q-btn.wallet-btn {
-    @include text--header-5;
-    width: auto;
-    padding: 13px 24px;
-    &+& {
-        margin-left: 16px;
-    }
-}
-
 .c-receive-page {
     &__title-container {
         animation: #{$anim-slide-in-left};
@@ -122,6 +113,4 @@ export default defineComponent({
         max-width: 200px;
     }
 }
-
-
 </style>

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -158,10 +158,10 @@ export default defineComponent({
                 return ethers.constants.Zero;
             }
         },
-        isAddressValid(): boolean {
-            const regex = /^0x[a-fA-F0-9]{40}$/;
-            return regex.test(this.address);
-        },
+        // isAddressValid(): boolean {
+        //     const regex = /^0x[a-fA-F0-9]{40}$/;
+        //     return regex.test(this.address);
+        // },
         isFormValid(): boolean {
             return this.addressIsValid && !(this.amount.isZero() || this.amount.isNegative() || this.amount.gt(this.availableInTokensBn));
         },

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -402,14 +402,6 @@ export default defineComponent({
 </template>
 
 <style lang="scss">
-.q-btn.wallet-btn {
-    @include text--header-5;
-    &+& {
-        margin-left: 16px;
-    }
-}
-
-
 .c-send-page {
     &__title-container {
         flex-direction: column;

--- a/src/pages/evm/wallet/SendPage.vue
+++ b/src/pages/evm/wallet/SendPage.vue
@@ -158,10 +158,6 @@ export default defineComponent({
                 return ethers.constants.Zero;
             }
         },
-        // isAddressValid(): boolean {
-        //     const regex = /^0x[a-fA-F0-9]{40}$/;
-        //     return regex.test(this.address);
-        // },
         isFormValid(): boolean {
             return this.addressIsValid && !(this.amount.isZero() || this.amount.isNegative() || this.amount.gt(this.availableInTokensBn));
         },


### PR DESCRIPTION
# Feature #448 

## Description
See issue

## Test scenarios

-  viewing nft details page, owner should be correct
-  clicking 'transfer' tab and clicking 'back' should return to 'attributes' tab
-  clicking 'back' from 'attributes' tab should return to inventory page
-  on successful transfer, should see pending and success notifications
-  on successful transfer, 'transfer' tab should be removed, user should be returned to 'attributes' tab
-  *on return to inventory page, NFT that was sent should no longer be disaplayed
-  NFTs should be visible via direct link without having to be logged in, example:
https://deploy-preview-646--wallet-develop-mainnet.netlify.app/evm/collectible-details?contract=0x72dAee1A82bbf3430e2b059Af1E88B72Ff301586&id=437&tab=attributes
-  'transfer' tab should only be present while logged in and viewing an NFT owned by logged in account
-  *successful transfer via WalletConnect (mobile)
-  *successful transfer via Cloud Wallet (mobile)
-  *successful transfer via Cloud Wallet (desktop)
-  *successful transfer via MetaMask (desktop)

\* There is a bug in the indexer where the owner is no longer being updated, you can confirm that the transfer was successful by viewing the transaction in teloscan however until this is fixed, it will remain in inventory. 

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
