### PR TITLE
now all Authenticators handle cancel correctly

### DIFF
--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -202,10 +202,14 @@ export class OreIdAuth extends EVMAuthenticator {
         return this.userChainAccount?.chainAccount as addressString;
     }
 
-    handleCatchError(error: never): AntelopeError {
-        this.trace('handleCatchError', error);
-        console.error(error);
-        return new AntelopeError('antelope.evm.error_send_transaction', { error });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handleCatchError(error: Error): AntelopeError {
+        this.trace('handleCatchError', error.message);
+        if (error.message === 'Closed by user') {
+            return new AntelopeError('antelope.evm.error_transaction_canceled');
+        } else {
+            return new AntelopeError('antelope.evm.error_send_transaction', { error });
+        }
     }
 
     /**
@@ -226,7 +230,7 @@ export class OreIdAuth extends EVMAuthenticator {
     }
 
     async performOreIdTransaction(from: addressString, json: JSONObject): Promise<EvmTransactionResponse> {
-
+        this.trace('performOreIdTransaction', from, json);
         const oreIdInstance = oreId as OreId;
 
         // sign a blockchain transaction
@@ -253,10 +257,16 @@ export class OreIdAuth extends EVMAuthenticator {
         this.trace('sendSystemToken', to, amount.toString());
         const from = this.getAccountAddress();
         const value = amount.toHexString();
+
+        // Send the transaction
         return this.performOreIdTransaction(from, {
             from,
             to,
             value,
+        }).then(
+            (transaction: ethers.providers.TransactionResponse) => transaction,
+        ).catch((error) => {
+            throw this.handleCatchError(error);
         });
     }
 

--- a/src/antelope/wallets/authenticators/OreIdAuth.ts
+++ b/src/antelope/wallets/authenticators/OreIdAuth.ts
@@ -205,7 +205,10 @@ export class OreIdAuth extends EVMAuthenticator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleCatchError(error: Error): AntelopeError {
         this.trace('handleCatchError', error.message);
-        if (error.message === 'Closed by user') {
+        if (
+            error.message === 'Closed by user' ||
+            error.message === 'sign_transaction_cancelled_by_user'
+        ) {
             return new AntelopeError('antelope.evm.error_transaction_canceled');
         } else {
             return new AntelopeError('antelope.evm.error_send_transaction', { error });

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -290,7 +290,7 @@ export class WalletConnectAuth extends EVMAuthenticator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleCatchError(error: any): AntelopeError {
         this.trace('handleCatchError', error);
-        if (error.message.includes('rejected the request')) {
+        if (error.message.includes('User rejected the')) {
             return new AntelopeError('antelope.evm.error_transaction_canceled');
         } else {
             return new AntelopeError('antelope.evm.error_send_transaction', { error });


### PR DESCRIPTION
# Fixes #573

## Description
When the user cancels any transaction that generates an error that was handled with a error notification but now is a neutral notification. The responsible for verifying whether it's a cancellation or a different error is the Authenticator being used by the user. Therefore, the previous solution was only partially correct because it was not properly implemented across all Authenticators.

## Test scenarios
Login using Telos Wallet and start and cancel most of the possible transactions you can do and see if all of them show the correct cancel message. See video

[Grabación de pantalla desde 16-11-23 18:07:19.webm](https://github.com/telosnetwork/telos-wallet/assets/4420760/3a8feb07-091c-4ff3-86f9-6baa791f98e0)

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
