### PR TITLE
ensuring supportedInterfaces property when quering nfts transactions

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -576,7 +576,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         return this.indexer.get(url, { params })
             .then(response => response.data as IndexerAccountTransfersResponse)
             .then((data) => {
-                // we recreate the supportedInterfaces property if is not pressent in the response
+                // set supportedInterfaces property if undefined in the response
                 Object.values(data.contracts).forEach((contract) => {
                     if (contract.supportedInterfaces === null && type !== undefined) {
                         contract.supportedInterfaces = [type];

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -423,6 +423,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // process the shaped raw data into NFTs
     async processNftRawData(shapedRawNfts: NftRawData[]): Promise<Collectible[]> {
+        console.log('EVMChainSettings.processNftRawData()', shapedRawNfts);
         const contractStore = useContractStore();
         const nftsStore = useNftsStore();
 
@@ -461,6 +462,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
             const ownersUpdatedWithinThreeMins = dateIsWithinXMinutes(nft.ownerDataLastFetched, 3);
 
             if (!ownersUpdatedWithinThreeMins) {
+                console.log('EVMChainSettings.processNftRawData() antes de .getContractInstance()', nft.contractAddress, data, contract);
                 const contractInstance = await (await contractStore.getContract(CURRENT_CONTEXT, nft.contractAddress))?.getContractInstance();
                 if (!contractInstance) {
                     throw new AntelopeError('antelope.utils.error_contract_instance');
@@ -574,7 +576,16 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const url = `v1/account/${account}/transfers`;
 
         return this.indexer.get(url, { params })
-            .then(response => response.data as IndexerAccountTransfersResponse);
+            .then(response => response.data as IndexerAccountTransfersResponse)
+            .then((data) => {
+                // we recreate the supportedInterfaces property if is not pressent in the response
+                Object.values(data.contracts).forEach((contract) => {
+                    if (contract.supportedInterfaces === null && type !== undefined) {
+                        contract.supportedInterfaces = [type];
+                    }
+                });
+                return data;
+            });
     }
 
     async getTokenList(): Promise<TokenClass[]> {

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -423,7 +423,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // process the shaped raw data into NFTs
     async processNftRawData(shapedRawNfts: NftRawData[]): Promise<Collectible[]> {
-        console.log('EVMChainSettings.processNftRawData()', shapedRawNfts);
         const contractStore = useContractStore();
         const nftsStore = useNftsStore();
 
@@ -462,7 +461,6 @@ export default abstract class EVMChainSettings implements ChainSettings {
             const ownersUpdatedWithinThreeMins = dateIsWithinXMinutes(nft.ownerDataLastFetched, 3);
 
             if (!ownersUpdatedWithinThreeMins) {
-                console.log('EVMChainSettings.processNftRawData() antes de .getContractInstance()', nft.contractAddress, data, contract);
                 const contractInstance = await (await contractStore.getContract(CURRENT_CONTEXT, nft.contractAddress))?.getContractInstance();
                 if (!contractInstance) {
                     throw new AntelopeError('antelope.utils.error_contract_instance');

--- a/src/antelope/types/Filters.ts
+++ b/src/antelope/types/Filters.ts
@@ -39,7 +39,7 @@ export interface IndexerTransactionsFilter extends IndexerPaginationFilter {
 
 export interface IndexerTransfersFilter extends IndexerPaginationFilter {
     account: string;
-    type?: 'erc20' | 'erc721' | 'erc1155'; // filter by token type
+    type?: 'erc20' | 'erc721' | 'erc1155' | 'none'; // filter by token type
     includePagination?: boolean; // include the total count and more flag in response
     endBlock?: number; // last block to include in the query
     startBlock?: number; // first block to include in the query


### PR DESCRIPTION
# Fixes #668

## Description
The History Store was pre-fetching the last transactions and that action generates to fetch and cache the metadata for all contracts without the fix of restoring the supportedInterfaces property. Once in the caché they never get restored. Therefore to see the changes you need to clean your local caché to fetch all contract metadata again. This time, the fetch process ends with the fix so it ends up saving locally the correct version of the metadata.

## Test scenarios
- Clean your localstorage (F12 -> Aplication -> Clean Storage)
- Login using the Team Account
- Go to the inventory. You should see three of the ERC721 I made without that property

 ![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/eb60b673-f927-4d74-b0a2-b44547f33882)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
