### PR TITLE
removed the loalStorage.clear() that was called in all sessions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,31 +11,33 @@ export default {
         const userIsNew = !localStorage.getItem('account');
         const currentVersion = packageInfo.version;
         const clientVersion = localStorage.getItem('appVersion');
-
         console.info('Wallet version: ', packageInfo.version);
 
-        if (clientVersion && clientVersion !== appVersionJustUpdated) {
-            console.info('Client version: ', clientVersion);
-        }
+        if (clientVersion !== currentVersion) {
+            if (clientVersion && clientVersion !== appVersionJustUpdated) {
+                console.info('Client version: ', clientVersion);
+            }
 
-        // when localstorage is cleared, we need to reload the page for it to take effect.
-        // however if we immediately reload the page here we cannot show a notification to the user.
-        // so the const appVersionUpdated lets us know after the reload that we just cleared the old localStorage
-        // and need to notify the user that they need to log in again
-        if (clientVersion === appVersionJustUpdated) {
-            console.info('App version mismatch, local storage cleared');
-            // App version was updated, localStorage was cleared, and the page reloaded
-            // Now inform the user that the app was updated & have them login again, and set the client app version
-            localStorage.setItem('appVersion', currentVersion);
-            (this as any).$notifySuccessMessage(
-                (this as any).$t('global.new_app_version'),
-            );
-        } else if (userIsNew) {
-            localStorage.setItem('appVersion', currentVersion);
-        } else if (clientVersion !== currentVersion) {
-            localStorage.clear();
-            localStorage.setItem('appVersion', appVersionJustUpdated);
-            window.location.reload();
+            // when localstorage is cleared, we need to reload the page for it to take effect.
+            // however if we immediately reload the page here we cannot show a notification to the user.
+            // so the const appVersionUpdated lets us know after the reload that we just cleared the old localStorage
+            // and need to notify the user that they need to log in again
+            if (clientVersion === appVersionJustUpdated) {
+                console.info('App version mismatch, local storage cleared');
+                // App version was updated, localStorage was cleared, and the page reloaded
+                // Now inform the user that the app was updated & have them login again, and set the client app version
+                localStorage.setItem('appVersion', currentVersion);
+                (this as any).$notifySuccessMessage(
+                    (this as any).$t('global.new_app_version'),
+                );
+            } else if (userIsNew) {
+                localStorage.clear();
+                localStorage.setItem('appVersion', currentVersion);
+            } else {
+                localStorage.clear();
+                localStorage.setItem('appVersion', appVersionJustUpdated);
+                window.location.reload();
+            }
         }
     },
     mounted() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,6 @@ export default {
                 (this as any).$t('global.new_app_version'),
             );
         } else if (userIsNew) {
-            localStorage.clear();
             localStorage.setItem('appVersion', currentVersion);
         } else if (clientVersion !== currentVersion) {
             localStorage.clear();


### PR DESCRIPTION
# Fixes #687

## Description
I removed that particular line because the present logic in that file was causing that line to execute repeatedly clearing the cache every new session and therefore emulating all cache strategies implemented.

## Urgent
However, this is urgent because there's another high-priority issue blocked by this one.

## Test scenarios
- Check the current state of develop branch and confirm the local storage gets cleared every new session
- go to this link and (log in an out) to see if the cache stays there across sessions.
