### PR TITLE
#692 | Fix IPFS failure

### DIFF
--- a/src/antelope/stores/utils/nft-utils.ts
+++ b/src/antelope/stores/utils/nft-utils.ts
@@ -1,7 +1,7 @@
 import { IndexerNftMetadata, NFTSourceTypes, NftSourceType } from 'src/antelope/types';
 import { urlIsAudio, urlIsPicture, urlIsVideo } from 'src/antelope/stores/utils/media-utils';
 
-export const IPFS_GATEWAY = 'https://cloudflare-ipfs.com/ipfs/';
+export const IPFS_GATEWAY = 'https://ipfs.telos.net/ipfs/';
 
 /**
  * Given an imageCache URL, tokenUri, and metadata, extract the image URL, mediaType, and mediaSource
@@ -109,7 +109,9 @@ export async function extractNftMetadata(
         }
     }
 
-    if (metadata?.image?.includes(IPFS_GATEWAY)) {
+    const metadataImageIsMediaUrl = await urlIsVideo(metadata?.image ?? '') || await urlIsAudio(metadata?.image ?? '') || urlIsPicture(metadata?.image ?? '');
+
+    if (metadata?.image?.includes(IPFS_GATEWAY) && !metadataImageIsMediaUrl) {
         mediaType = await determineIpfsMediaType(metadata?.image);
 
         if (mediaType === NFTSourceTypes.IMAGE) {


### PR DESCRIPTION
# Fixes #692 

## Description
Currently, too many calls are being made to the IPFS gateway because the logic is incorrect; the IPFS gateway should only be hit during NFT construction when it is unclear if an image is media or not (if the URL for the image/video/audio has no extension, like `.mp4`, that is when we must hit the endpoint and determine the media type). Also this PR switches from using the cloudflare IPFS gateway to the Telos one.

## Test scenarios
- go to https://deploy-preview-695--wallet-develop-mainnet.netlify.app/
- log in with an account that has IPFS NFTs
- go to NFT inventory
    - NFTs should load fine

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
