### PR TITLE
fixing the case when the injected provider does not have an account

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -374,7 +374,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         // we fix the supportedInterfaces property if it is undefined in the response but present in the request
         Object.values(response.contracts).forEach((contract) => {
             contract.supportedInterfaces = contract.supportedInterfaces ||
-                params.type ? [params.type?.toLocaleLowerCase() as string] : undefined;
+                params.type ? [params.type?.toLowerCase() as string] : undefined;
         });
 
         this.processNftContractsCalldata(response.contracts);

--- a/src/antelope/wallets/authenticators/WalletConnectAuth.ts
+++ b/src/antelope/wallets/authenticators/WalletConnectAuth.ts
@@ -84,10 +84,12 @@ export class WalletConnectAuth extends EVMAuthenticator {
             if (typeof provider === 'undefined') {
                 this.usingQR = true;
             } else {
-                const providerAddress = (provider._state?.accounts) ? provider._state?.accounts[0] : '';
+                const providerAddress = (provider._state?.accounts) ? provider._state?.accounts[0]??'' : '';
+                console.log('provider', provider); // FIXME:
+                this.trace('walletConnectLogin', 'providerAddress:', providerAddress, 'address:', address);
                 const sameAddress = providerAddress.toLocaleLowerCase() === address.toLocaleLowerCase();
                 this.usingQR = !sameAddress;
-                this.trace('walletConnectLogin', 'providerAddress:', providerAddress, 'address:', address, 'sameAddress:', sameAddress);
+                this.trace('walletConnectLogin', 'sameAddress:', sameAddress);
             }
             this.trace('walletConnectLogin', 'using QR:', this.usingQR);
 


### PR DESCRIPTION
# Fixes #694

## Description
When you run the web app on a desktop browser but you use WalletConnect and read the QR from your mobile, there was a workaround to try to deduce if we are using a locally injected provider (like MetaMask extension) or we are using a remote connection via QR.

There was an error trying to obtaing the current account from the local provider which may not have one.

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
