### PR TITLE
Better solution for indexer's health check and user warning

### DIFF
--- a/src/pages/evm/nfts/NftInventoryPage.vue
+++ b/src/pages/evm/nfts/NftInventoryPage.vue
@@ -25,11 +25,7 @@ const chainStore = useChainStore();
 const accountStore = useAccountStore();
 const chainSettings = (chainStore.currentChain.settings as EVMChainSettings);
 
-//TODO: remove timeout, see https://github.com/telosnetwork/telos-wallet/issues/697
-setTimeout(() => {
-    // This warns the user (once per session) that the indexer is not healthy and can be outdated data
-    chainSettings.checkAndWarnIndexerHealth();
-}, 1000);
+chainSettings.checkAndWarnIndexerHealth();
 
 const router = useRouter();
 const route = useRoute();


### PR DESCRIPTION
# Fixes #697

## Description
We are making decisions based on the indexer's health and there are cases where those decisions are made before the indexer is consulted. So we may end up making a bad decision based on the wrong data.

To avoid this problem I added an observable variable to indicate if the indexer was already consulted in such a way that any local query about the health state will always run after the indexer is consulted at least once.

## Test scenarios
Reproduce the steps described in the issue https://github.com/telosnetwork/telos-wallet/issues/697
You will not get the indexer's health warning sign on Mainnet

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
