### PR TITLE
modify notification message

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -615,7 +615,7 @@ export default {
     },
     temporal: {
         telos_cloud_discontinued_title: 'Important',
-        telos_cloud_discontinued_message_title: 'Telos Cloud Wallet will be discontinued',
-        telos_cloud_discontinued_message_body: 'It is crucial for you to transfer your assets out of your Telos Cloud Wallet Accounts before December 31st.',
+        telos_cloud_discontinued_message_title: 'Dear User: Telos Cloud Wallet will be discontinued.',
+        telos_cloud_discontinued_message_body:'Attention: The Telos Cloud Wallet sign-in option will be discontinued after December 31st. If you use the Telos Cloud Wallet to access your account, please transfer your assets to another wallet before this deadline. This change does not impact users accessing their accounts via Metamask, WalletConnect, Anchor, or other sign-in methods.',
     },
 };


### PR DESCRIPTION
Please verify the message and that it was changed in all the places it needed to be changed.
The new message should read as follows:

'Attention: The Telos Cloud Wallet sign-in option will be discontinued after December 31st. If you use the Telos Cloud Wallet to access your account, please transfer your assets to another wallet before this deadline. This change does not impact users accessing their accounts via Metamask, WalletConnect, Anchor, or other sign-in methods.'