### PR TITLE
#606 | Edit and revoke allowances

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -382,6 +382,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
             imageCache: nftResponse.imageCache,
             tokenUri: nftResponse.tokenUri,
             supply: nftResponse.supply,
+            owner: nftResponse.owner,
         }));
 
         // we fix the supportedInterfaces property if it is undefined in the response but present in the request

--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -728,6 +728,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const params = {
             ...filter,
             type: 'erc20',
+            all: true,
         };
         const response = await this.indexer.get(`v1/account/${account}/approvals`, { params });
         return response.data as IndexerAllowanceResponseErc20;
@@ -737,6 +738,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const params = {
             ...filter,
             type: 'erc721',
+            all: true,
         };
         const response = await this.indexer.get(`v1/account/${account}/approvals`, { params });
         return response.data as IndexerAllowanceResponseErc721;
@@ -746,6 +748,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
         const params = {
             ...filter,
             type: 'erc1155',
+            all: true,
         };
         const response = await this.indexer.get(`v1/account/${account}/approvals`, { params });
         return response.data as IndexerAllowanceResponseErc1155;

--- a/src/antelope/chains/chain-constants.ts
+++ b/src/antelope/chains/chain-constants.ts
@@ -15,3 +15,5 @@ export const TELOS_ANALYTICS_EVENT_IDS = {
     loginFailedWalletConnect: '9V4IV1BV',
     loginSuccessfulWalletConnect: '2EG2OR3H',
 };
+
+export const ZERO_ADDRESS = '0x'.concat('0'.repeat(40));

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -194,19 +194,19 @@ export const useAllowancesStore = defineStore(store_name, {
             const allowanceStore = useAllowancesStore();
             if (tokenId) {
                 return allowanceStore.singleErc721Allowances(label).find(allowance =>
-                    allowance.spenderAddress === spenderAddress &&
-                    allowance.collectionAddress === tokenAddress &&
-                    allowance.tokenId === tokenId,
+                    allowance.spenderAddress.toLowerCase() === spenderAddress.toLowerCase() &&
+                    allowance.collectionAddress.toLowerCase() === tokenAddress.toLowerCase() &&
+                    allowance.tokenId.toLowerCase() === tokenId.toLowerCase(),
                 );
             }
 
             return allowanceStore.allowances(label).find((allowance) => {
-                const spenderAddressMatches = allowance.spenderAddress === spenderAddress;
+                const spenderAddressMatches = allowance.spenderAddress.toLowerCase() === spenderAddress.toLowerCase();
                 if (isErc20AllowanceRow(allowance)) {
-                    return spenderAddressMatches && allowance.tokenAddress === tokenAddress;
+                    return spenderAddressMatches && allowance.tokenAddress.toLowerCase() === tokenAddress.toLowerCase();
                 }
 
-                return spenderAddressMatches && allowance.collectionAddress === tokenAddress;
+                return spenderAddressMatches && allowance.collectionAddress.toLowerCase() === tokenAddress.toLowerCase();
             });
         },
     },

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -34,6 +34,7 @@ import {
 } from 'src/antelope/types';
 import { createTraceFunction, isTracingAll } from 'src/antelope/stores/feedback';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
+import { ZERO_ADDRESS } from 'src/antelope/chains/chain-constants';
 
 const store_name = 'allowances';
 
@@ -366,8 +367,8 @@ export const useAllowancesStore = defineStore(store_name, {
                 }
 
                 // note: there can only be one operator for a single ERC721 token ID
-                // to revoke an allowance, the approve method is called with an operator address of '0x0'
-                const newOperator = allowed ? operator : '0x0';
+                // to revoke an allowance, the approve method is called with an operator address of '0x0000...0000'
+                const newOperator = allowed ? operator : ZERO_ADDRESS;
 
                 const tx = await nftContractInstance.approve(newOperator, tokenId);
 
@@ -575,6 +576,12 @@ export const useAllowancesStore = defineStore(store_name, {
             }
         },
         async shapeErc721AllowanceRow(data: IndexerErc721AllowanceResult): Promise<ShapedAllowanceRowSingleERC721 | ShapedAllowanceRowNftCollection | null> {
+            // if the operator is the zero address, it means the allowance has been revoked;
+            // we should hide it from the UI rather than showing it with operator '0x0000...0000'
+            if (data.operator === ZERO_ADDRESS) {
+                return null;
+            }
+
             try {
                 const spenderContract = await useContractStore().getContract(CURRENT_CONTEXT, data.operator);
 

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -552,7 +552,7 @@ export const useAllowancesStore = defineStore(store_name, {
                 const maxSupply = await tokenContractInstance?.totalSupply() as BigNumber | undefined;
                 const balance = await tokenContractInstance?.balanceOf(data.owner) as BigNumber | undefined;
 
-                if (!spenderContract || !balance || !tokenInfo || !maxSupply) {
+                if (!balance || !tokenInfo || !maxSupply) {
                     return null;
                 }
 
@@ -583,12 +583,12 @@ export const useAllowancesStore = defineStore(store_name, {
             }
 
             try {
-                const spenderContract = await useContractStore().getContract(CURRENT_CONTEXT, data.operator);
+                const operatorContract = await useContractStore().getContract(CURRENT_CONTEXT, data.operator);
 
                 const commonAttributes = {
                     lastUpdated: data.updated,
                     spenderAddress: data.operator,
-                    spenderName: spenderContract?.name,
+                    spenderName: operatorContract?.name,
                     allowed: data.approved,
                 };
 
@@ -624,7 +624,7 @@ export const useAllowancesStore = defineStore(store_name, {
                 const network = useChainStore().getChain(CURRENT_CONTEXT).settings.getNetwork();
                 const nftsStore = useNftsStore();
 
-                const spenderContract = await useContractStore().getContract(CURRENT_CONTEXT, data.operator);
+                const operatorContract = await useContractStore().getContract(CURRENT_CONTEXT, data.operator);
                 const collectionInfo = await useContractStore().getContract(CURRENT_CONTEXT, data.contract);
                 await nftsStore.fetchNftsFromCollection(CURRENT_CONTEXT, data.contract);
                 const collectionNftIds = (nftsStore.__contracts[network][data.contract.toLowerCase()]?.list ?? []).map(nft => nft.id);
@@ -647,7 +647,7 @@ export const useAllowancesStore = defineStore(store_name, {
                 return collectionInfo ? {
                     lastUpdated: data.updated,
                     spenderAddress: data.operator,
-                    spenderName: spenderContract?.name,
+                    spenderName: operatorContract?.name,
                     allowed: data.approved,
                     collectionAddress: collectionInfo.address,
                     collectionName: collectionInfo.name,

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -586,7 +586,7 @@ export const useAllowancesStore = defineStore(store_name, {
                 };
 
                 if (data.single) {
-                    const tokenId = data.tokenId as string;
+                    const tokenId = String(data.tokenId);
                     const nftDetails = await useNftsStore().fetchNftDetails(CURRENT_CONTEXT, data.contract, tokenId);
 
                     return nftDetails ? {

--- a/src/antelope/stores/contract.ts
+++ b/src/antelope/stores/contract.ts
@@ -192,8 +192,7 @@ export const useContractStore = defineStore(store_name, {
             }
 
             // eztodo check when not logged in
-            const authenticator = useAccountStore().getAuthenticator(label) as EVMAuthenticator;
-            const provider = await authenticator.web3Provider();
+            const provider = await getAntelope().wallets.getWeb3Provider();
 
             async function checkIsContract(address: string) {
                 const code = await provider.getCode(address);
@@ -209,8 +208,7 @@ export const useContractStore = defineStore(store_name, {
             const isContract = this.__accounts[network]?.includes(addressLower) || await checkIsContract(address);
 
             if (!isContract) {
-                console.log(address);
-
+                // address is an account, not a contract
                 return null;
             }
 

--- a/src/antelope/stores/contract.ts
+++ b/src/antelope/stores/contract.ts
@@ -191,7 +191,6 @@ export const useContractStore = defineStore(store_name, {
                 return this.__contracts[network].cached[addressLower];
             }
 
-            // eztodo check when not logged in
             const provider = await getAntelope().wallets.getWeb3Provider();
 
             async function checkIsContract(address: string) {

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -37,9 +37,8 @@ export interface NFTsCollection {
     list: Collectible[];
     loading: boolean;
 
-    // this is to prevent the scenario where we fetch a single NFT from a collection, add it to the contracts `list`
+    // this is to prevent the scenario where we fetch a single NFT from a collection, add it to a contract's `list`
     // and then in future checks we assume that the entire collection has been fetched (as we have at least one item in the list)
-    //
     entireCollectionFetched: boolean;
 }
 

--- a/src/antelope/stores/utils/abi/erc20.ts
+++ b/src/antelope/stores/utils/abi/erc20.ts
@@ -223,4 +223,29 @@ export const erc20Abi = [
         'name': 'Approval',
         'type': 'event',
     },
-]  as EvmABI;
+] as EvmABI;
+
+export const erc20AbiApprove = [{
+    'inputs': [
+        {
+            'internalType': 'address',
+            'name': 'spender',
+            'type': 'address',
+        },
+        {
+            'internalType': 'uint256',
+            'name': 'amount',
+            'type': 'uint256',
+        },
+    ],
+    'name': 'approve',
+    'outputs': [
+        {
+            'internalType': 'bool',
+            'name': '',
+            'type': 'bool',
+        },
+    ],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+}] as EvmABI;

--- a/src/antelope/stores/utils/abi/erc721.ts
+++ b/src/antelope/stores/utils/abi/erc721.ts
@@ -354,3 +354,16 @@ export const erc721Abi = [{
     'stateMutability': 'nonpayable',
     'type': 'function',
 }] as EvmABI;
+
+export const erc721ApproveAbi = [{
+    'inputs': [{ 'internalType': 'address', 'name': 'to', 'type': 'address' }, {
+        'internalType': 'uint256',
+        'name': 'tokenId',
+        'type': 'uint256',
+    }],
+    'name': 'approve',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+}] as unknown as EvmABI; // eztodo fix this
+

--- a/src/antelope/stores/utils/abi/erc721.ts
+++ b/src/antelope/stores/utils/abi/erc721.ts
@@ -365,5 +365,5 @@ export const erc721ApproveAbi = [{
     'outputs': [],
     'stateMutability': 'nonpayable',
     'type': 'function',
-}] as unknown as EvmABI; // eztodo fix this
+}] as unknown as EvmABI;
 

--- a/src/antelope/stores/utils/abi/setApprovalForAllAbi.ts
+++ b/src/antelope/stores/utils/abi/setApprovalForAllAbi.ts
@@ -1,0 +1,13 @@
+import { EvmABI } from '.';
+
+export const setApprovalForAllAbi = [{
+    'inputs': [{ 'internalType': 'address', 'name': 'operator', 'type': 'address' }, {
+        'internalType': 'bool',
+        'name': 'approved',
+        'type': 'bool',
+    }],
+    'name': 'setApprovalForAll',
+    'outputs': [],
+    'stateMutability': 'nonpayable',
+    'type': 'function',
+}] as unknown as EvmABI;

--- a/src/antelope/types/IndexerTypes.ts
+++ b/src/antelope/types/IndexerTypes.ts
@@ -209,15 +209,3 @@ export interface IndexerAllowanceResponseErc1155 {
 }
 
 export type IndexerAllowanceResponse = IndexerAllowanceResponseErc20 | IndexerAllowanceResponseErc721 | IndexerAllowanceResponseErc1155;
-
-export function isIndexerAllowanceResponseErc20(response: IndexerAllowanceResponse): response is IndexerAllowanceResponseErc20 {
-    return (response as IndexerAllowanceResponseErc20).results.some(result => result.spender);
-}
-
-export function isIndexerAllowanceResponseErc721(response: IndexerAllowanceResponse): response is IndexerAllowanceResponseErc721 {
-    return (response as IndexerAllowanceResponseErc721).results.some(result => result.hasOwnProperty('single') || result.hasOwnProperty('tokenId'));
-}
-
-export function isIndexerAllowanceResponseErc1155(response: IndexerAllowanceResponse): response is IndexerAllowanceResponseErc1155 {
-    return !isIndexerAllowanceResponseErc20(response) && !isIndexerAllowanceResponseErc721(response);
-}

--- a/src/antelope/types/IndexerTypes.ts
+++ b/src/antelope/types/IndexerTypes.ts
@@ -179,7 +179,7 @@ export interface IndexerErc721AllowanceResult extends IndexerAllowanceResult {
     approved: boolean; // whether the user has approved the spender
     operator: string; // address of the spender contract
 
-    tokenId?: string; // only present if single === true
+    tokenId?: string | number; // only present if single === true
 }
 
 export interface IndexerErc1155AllowanceResult extends IndexerAllowanceResult {

--- a/src/antelope/types/IndexerTypes.ts
+++ b/src/antelope/types/IndexerTypes.ts
@@ -48,6 +48,7 @@ interface IndexerNftResult {
 // results from the /contract/{address}/nfts endpoint
 export interface IndexerCollectionNftResult extends IndexerNftResult {
     supply?: number; // present only for ERC1155
+    owner?: string; // present only for ERC721
 }
 
 // results from the /account/{address}/nfts endpoint

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -8,6 +8,7 @@ import { useChainStore } from 'src/antelope/stores/chain';
 import { useEVMStore } from 'src/antelope/stores/evm';
 import { createTraceFunction, isTracingAll, useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
+import { setApprovalForAllAbi } from 'src/antelope/stores/utils/abi/setApprovalForAllAbi';
 import { AntelopeError, NftTokenInterface, ERC1155_TYPE, ERC721_TYPE, EvmABI, EvmABIEntry, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString, erc20Abi, erc721Abi, escrowAbiWithdraw, stlosAbiDeposit, stlosAbiWithdraw, wtlosAbiDeposit, wtlosAbiWithdraw, erc1155Abi, erc20AbiApprove, erc721ApproveAbi } from 'src/antelope/types';
 
 export abstract class EVMAuthenticator {
@@ -373,6 +374,10 @@ export abstract class EVMAuthenticator {
 
     /**
      * This method creates a Transaction to update an ERC20 allowance by calling the approve function
+     * @param spender address of the spender
+     * @param tokenContractAddress address of the ERC20 token contract
+     * @param allowance amount of tokens to allow
+     *
      * @returns transaction response
      */
     async updateErc20Allowance(
@@ -396,6 +401,10 @@ export abstract class EVMAuthenticator {
 
     /**
     * This method creates a Transaction to update an ERC721 allowance by calling the approve function
+    * @param operator address of the operator
+    * @param nftContractAddress address of the ERC721 token contract
+    * @param tokenId id of the token to set allowance for
+    *
     * @returns transaction response
     */
     async updateSingleErc721Allowance(
@@ -411,6 +420,34 @@ export abstract class EVMAuthenticator {
             [
                 operator,
                 tokenId,
+            ],
+        ).catch((error) => {
+            throw this.handleCatchError(error as never);
+        });
+    }
+
+    /**
+    * This method creates a Transaction to update an NFT collection (ERC721 or ERC1155) allowance
+    * by calling the setApprovalForAll function
+    * @param operator address of the operator
+    * @param nftContractAddress address of the ERC721 token contract
+    * @param allowed boolean to set allowance
+    *
+    * @returns transaction response
+    */
+    async updateNftCollectionAllowance(
+        operator: string,
+        nftContractAddress: string,
+        allowed: boolean,
+    ): Promise<EvmTransactionResponse | WriteContractResult> {
+        this.trace('updateNftCollectionAllowance', operator, nftContractAddress, allowed);
+
+        return this.signCustomTransaction(
+            nftContractAddress,
+            setApprovalForAllAbi,
+            [
+                operator,
+                allowed,
             ],
         ).catch((error) => {
             throw this.handleCatchError(error as never);

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -8,7 +8,7 @@ import { useChainStore } from 'src/antelope/stores/chain';
 import { useEVMStore } from 'src/antelope/stores/evm';
 import { createTraceFunction, isTracingAll, useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
-import { AntelopeError, NftTokenInterface, ERC1155_TYPE, ERC721_TYPE, EvmABI, EvmABIEntry, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString, erc20Abi, erc721Abi, escrowAbiWithdraw, stlosAbiDeposit, stlosAbiWithdraw, wtlosAbiDeposit, wtlosAbiWithdraw, erc1155Abi } from 'src/antelope/types';
+import { AntelopeError, NftTokenInterface, ERC1155_TYPE, ERC721_TYPE, EvmABI, EvmABIEntry, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString, erc20Abi, erc721Abi, escrowAbiWithdraw, stlosAbiDeposit, stlosAbiWithdraw, wtlosAbiDeposit, wtlosAbiWithdraw, erc1155Abi, erc20AbiApprove } from 'src/antelope/types';
 
 export abstract class EVMAuthenticator {
 
@@ -366,6 +366,29 @@ export abstract class EVMAuthenticator {
             escrowContractAddress,
             escrowAbiWithdraw,
             [],
+        ).catch((error) => {
+            throw this.handleCatchError(error as never);
+        });
+    }
+
+    /**
+     * This method creates a Transaction to update an ERC20 allowance by calling the approve function
+     * @returns transaction response
+     */
+    async updateErc20Allowance(
+        spender: string,
+        tokenContractAddress: string,
+        allowance: BigNumber,
+    ): Promise<EvmTransactionResponse | WriteContractResult> {
+        this.trace('updateErc20Allowance', spender, tokenContractAddress, allowance.toString());
+
+        return this.signCustomTransaction(
+            tokenContractAddress,
+            erc20AbiApprove,
+            [
+                spender,
+                allowance.toHexString(),
+            ],
         ).catch((error) => {
             throw this.handleCatchError(error as never);
         });

--- a/src/antelope/wallets/authenticators/EVMAuthenticator.ts
+++ b/src/antelope/wallets/authenticators/EVMAuthenticator.ts
@@ -8,7 +8,7 @@ import { useChainStore } from 'src/antelope/stores/chain';
 import { useEVMStore } from 'src/antelope/stores/evm';
 import { createTraceFunction, isTracingAll, useFeedbackStore } from 'src/antelope/stores/feedback';
 import { usePlatformStore } from 'src/antelope/stores/platform';
-import { AntelopeError, NftTokenInterface, ERC1155_TYPE, ERC721_TYPE, EvmABI, EvmABIEntry, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString, erc20Abi, erc721Abi, escrowAbiWithdraw, stlosAbiDeposit, stlosAbiWithdraw, wtlosAbiDeposit, wtlosAbiWithdraw, erc1155Abi, erc20AbiApprove } from 'src/antelope/types';
+import { AntelopeError, NftTokenInterface, ERC1155_TYPE, ERC721_TYPE, EvmABI, EvmABIEntry, EvmFunctionParam, EvmTransactionResponse, ExceptionError, TokenClass, addressString, erc20Abi, erc721Abi, escrowAbiWithdraw, stlosAbiDeposit, stlosAbiWithdraw, wtlosAbiDeposit, wtlosAbiWithdraw, erc1155Abi, erc20AbiApprove, erc721ApproveAbi } from 'src/antelope/types';
 
 export abstract class EVMAuthenticator {
 
@@ -388,6 +388,29 @@ export abstract class EVMAuthenticator {
             [
                 spender,
                 allowance.toHexString(),
+            ],
+        ).catch((error) => {
+            throw this.handleCatchError(error as never);
+        });
+    }
+
+    /**
+    * This method creates a Transaction to update an ERC721 allowance by calling the approve function
+    * @returns transaction response
+    */
+    async updateSingleErc721Allowance(
+        operator: string,
+        nftContractAddress: string,
+        tokenId: string,
+    ): Promise<EvmTransactionResponse | WriteContractResult> {
+        this.trace('updateSingleErc721Allowance', operator, nftContractAddress, tokenId);
+
+        return this.signCustomTransaction(
+            nftContractAddress,
+            erc721ApproveAbi,
+            [
+                operator,
+                tokenId,
             ],
         ).catch((error) => {
             throw this.handleCatchError(error as never);

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -667,6 +667,9 @@ export default {
         nfts: {
             error_fetching_collection_nfts: 'An unknown error occurred while fetching collection NFTs',
         },
+        allowances: {
+            error_fetching_allowances: 'An unknown error occurred while fetching allowances',
+        },
         words: {
             seconds: 'seconds',
             minutes: 'minutes',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -320,7 +320,7 @@ export default {
         erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
         revoking_allowances_title: 'Revoking {total} allowances ({remaining} remaining)',
         revoking_allowances_description: 'Please wait while we revoke the selected allowances. You will need to approve each transaction in your wallet.',
-        revoking_allowances_cancel_note: "Note: clicking 'Cancel' will not cancel transactions which have already been approved. Any pending transaction(s) must be cancelled in your wallet.",
+        revoking_allowances_cancel_note: 'Note: clicking \'Cancel\' will not cancel transactions which have already been approved. Any pending transaction(s) must be cancelled in your wallet.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -343,7 +343,7 @@ export default {
         neutral_message_unwrapping: 'Unwrapping <b>{quantity} {symbol}</b>',
         neutral_message_withdrawing: 'Withdrawing <b>{quantity} {symbol}</b>',
         neutral_message_updating_erc20_allowance: 'Updating <b>{symbol}</b> allowance for <b>{spender}</b>',
-        neutral_message_updating_single_erc721_allowance: 'Updating <b>{tokenText}</b> allowance for <b>{operator}</b>',
+        neutral_message_updating_nft_allowance: 'Updating <b>{tokenText}</b> allowance for <b>{operator}</b>',
         dont_show_message_again: 'Don\'t show me this message again',
     },
     resources: {

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -317,7 +317,7 @@ export default {
         edit_modal_description: 'Define new token allowance for spender',
         entire_collection: 'Entire Collection',
         token_amount_input_label: 'Token Amount',
-        erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender (or \'operator\') for this type of collectible (ERC-721). Approving a new spender will revoke the previous approval.',
+        erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -320,6 +320,7 @@ export default {
         erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
         revoking_allowances_title: 'Revoking {total} allowances ({remaining} remaining)',
         revoking_allowances_description: 'Please wait while we revoke the selected allowances. You will need to approve the transactions in your wallet as they come up.',
+        revoking_allowances_cancel_note: 'Note: clicking Cancel will not cancel already-approved transactions. After clicking Cancel, you may also need to cancel the current transaction in your wallet.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -320,7 +320,7 @@ export default {
         erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
         revoking_allowances_title: 'Revoking {total} allowances ({remaining} remaining)',
         revoking_allowances_description: 'Please wait while we revoke the selected allowances; this may take up to 10 minutes. You will need to approve the transactions in your wallet as they come up.',
-        revoking_allowances_cancel_note: 'Note: clicking Cancel will not cancel transactions which have already been approved. After clicking Cancel, you may also need to cancel the current transaction in your wallet.',
+        revoking_allowances_cancel_note: "Note: clicking 'Cancel' will not cancel transactions which have already been approved. Any pending transaction(s) must be cancelled in your wallet.",
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -319,7 +319,7 @@ export default {
         token_amount_input_label: 'Token Amount',
         erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
         revoking_allowances_title: 'Revoking {total} allowances ({remaining} remaining)',
-        revoking_allowances_description: 'Please wait while we revoke the selected allowances; this may take up to 10 minutes. You will need to approve the transactions in your wallet as they come up.',
+        revoking_allowances_description: 'Please wait while we revoke the selected allowances. You will need to approve each transaction in your wallet.',
         revoking_allowances_cancel_note: "Note: clicking 'Cancel' will not cancel transactions which have already been approved. Any pending transaction(s) must be cancelled in your wallet.",
     },
     notification:{

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -319,8 +319,8 @@ export default {
         token_amount_input_label: 'Token Amount',
         erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
         revoking_allowances_title: 'Revoking {total} allowances ({remaining} remaining)',
-        revoking_allowances_description: 'Please wait while we revoke the selected allowances. You will need to approve the transactions in your wallet as they come up.',
-        revoking_allowances_cancel_note: 'Note: clicking Cancel will not cancel already-approved transactions. After clicking Cancel, you may also need to cancel the current transaction in your wallet.',
+        revoking_allowances_description: 'Please wait while we revoke the selected allowances; this may take up to 10 minutes. You will need to approve the transactions in your wallet as they come up.',
+        revoking_allowances_cancel_note: 'Note: clicking Cancel will not cancel transactions which have already been approved. After clicking Cancel, you may also need to cancel the current transaction in your wallet.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -341,6 +341,7 @@ export default {
         neutral_message_wrapping: 'Wrapping <b>{quantity} {symbol}</b>',
         neutral_message_unwrapping: 'Unwrapping <b>{quantity} {symbol}</b>',
         neutral_message_withdrawing: 'Withdrawing <b>{quantity} {symbol}</b>',
+        neutral_message_updating_erc20_allowance: 'Updating <b>{symbol}</b> allowance for <b>{spender}</b>',
         dont_show_message_again: 'Don\'t show me this message again',
     },
     resources: {
@@ -619,7 +620,8 @@ export default {
             error_unstakes_failed: 'An unknown error occurred when unstaking tokens',
             error_withdraw_failed: 'An unknown error occurred when withdrawing tokens',
             error_fetching_token_price: 'An unknown error occurred when fetching token price data',
-            error_transfer_nft: 'An error occured while transferring collectible',
+            error_transfer_nft: 'An error occurred while transferring collectible',
+            error_updating_allowance: 'An error occurred while updating allowance',
         },
         history: {
             error_fetching_transactions: 'Unexpected error fetching transactions. Please refresh the page to try again.',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -320,6 +320,7 @@ export default {
         entire_collection: 'Entire Collection',
         unlimited_allowance_option_tooltip: 'Technically there is no \'unlimited\' allowance; this is actually equivalent to (2^256 - 1) {symbol}',
         token_amount_input_label: 'Token Amount',
+        erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender (or \'operator\') for this type of collectible (ERC-721). Approving a new spender will revoke the previous approval.',
     },
     notification:{
         success_title_trx: 'Success',
@@ -342,6 +343,7 @@ export default {
         neutral_message_unwrapping: 'Unwrapping <b>{quantity} {symbol}</b>',
         neutral_message_withdrawing: 'Withdrawing <b>{quantity} {symbol}</b>',
         neutral_message_updating_erc20_allowance: 'Updating <b>{symbol}</b> allowance for <b>{spender}</b>',
+        neutral_message_updating_single_erc721_allowance: 'Updating <b>{tokenText}</b> allowance for <b>{operator}</b>',
         dont_show_message_again: 'Don\'t show me this message again',
     },
     resources: {

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -166,7 +166,6 @@ export default {
         owners: 'Owners',
         quantity: 'Quantity',
         required_field: 'This field is required',
-        revoke: 'Revoke',
         rows_per_page: 'Rows per page',
         search: 'Search',
         sign_out: 'Disconnect',

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -318,6 +318,8 @@ export default {
         entire_collection: 'Entire Collection',
         token_amount_input_label: 'Token Amount',
         erc_721_single_allowance_blurb: 'Note: there may only be up to one approved spender for this type of collectible (ERC-721). Making a change here will revoke the previous approval.',
+        revoking_allowances_title: 'Revoking {total} allowances ({remaining} remaining)',
+        revoking_allowances_description: 'Please wait while we revoke the selected allowances. You will need to approve the transactions in your wallet as they come up.',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -208,9 +208,7 @@ function handleRevokeSelectedClicked() {
         showRevokeInProgressModal.value = false;
     };
 
-    // eztodo close modal when user cancels from metamask
     // eztodo handle row already cancelled
-    // eztodo set cancel button loading while waiting for tx?
 
     promise.finally(() => {
         cancelBatchRevokeButtonLoading.value = true;

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -202,6 +202,8 @@ function handleRevokeSelectedClicked() {
     };
 
     // eztodo close modal when user cancels from metamask
+    // eztodo handle row already cancelled
+    // eztodo set cancel button loading while waiting for tx?
 
     promise.finally(() => {
         cancelBatchRevokeButtonLoading.value = true;

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -44,6 +44,7 @@ const sort = ref<{ descending: boolean; sortBy: AllowanceTableColumns }>({
 });
 const searchText = ref('');
 const timeout = ref<ReturnType<typeof setTimeout> | null>(null);
+const selectedRows = ref<Record<string, boolean>>({});
 
 // computed
 const userAddress = computed(() => useAccountStore().currentAccount.account);
@@ -123,6 +124,14 @@ const shapedAllowanceRows = computed(() => {
     return allowances;
 });
 
+const enableRevokeButton = computed(() => {
+    const selectedRowsKeys = Object.keys(selectedRows.value);
+    const selectedRowsValues = Object.values(selectedRows.value);
+    debugger;
+
+    return selectedRowsKeys.length > 0 && selectedRowsValues.some(isSelected => isSelected);
+});
+
 // watchers
 watch(userAddress, (address) => {
     if (address) {
@@ -161,6 +170,15 @@ function handleSortChanged(newSort: { descending: boolean, sortBy: AllowanceTabl
         sortBy: newSort.sortBy,
     };
 }
+
+function handleSelectedRowsChange(newSelectedRows: Record<string, boolean>) {
+    // rows are keyed like: `${row.spenderAddress}-${tokenAddress/collectionAddress}`
+    selectedRows.value = newSelectedRows;
+}
+
+function handleRevokeSelectedClicked() {
+    console.log('revoke selected clicked');
+}
 </script>
 
 <template>
@@ -179,9 +197,10 @@ function handleSortChanged(newSort: { descending: boolean, sortBy: AllowanceTabl
         />
 
         <AllowancesPageControls
-            :enable-revoke-button="false"
+            :enable-revoke-button="enableRevokeButton"
             @search-updated="handleSearchUpdated"
             @include-cancelled-updated="handleIncludeCancelledUpdated"
+            @revoke-selected="handleRevokeSelectedClicked"
         />
 
         <div v-if="loading" class="q-mt-lg">
@@ -192,7 +211,12 @@ function handleSortChanged(newSort: { descending: boolean, sortBy: AllowanceTabl
                 type="rect"
             />
         </div>
-        <AllowancesTable v-else :rows="shapedAllowanceRows" @sortChanged="handleSortChanged"/>
+        <AllowancesTable
+            v-else
+            :rows="shapedAllowanceRows"
+            @sort-changed="handleSortChanged"
+            @selected-rows-changed="handleSelectedRowsChange"
+        />
     </div>
 </AppPage>
 </template>

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -8,6 +8,7 @@ import {
     nextTick,
 } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { WriteContractResult } from '@wagmi/core';
 
 import AppPage from 'components/evm/AppPage.vue';
 import AllowancesPageControls from 'pages/evm/allowances/AllowancesPageControls.vue';

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -208,8 +208,6 @@ function handleRevokeSelectedClicked() {
         showRevokeInProgressModal.value = false;
     };
 
-    // eztodo handle row already cancelled
-
     promise.finally(() => {
         cancelBatchRevokeButtonLoading.value = true;
 

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -207,7 +207,7 @@ function handleRevokeSelectedClicked() {
         cancelBatchRevokeButtonLoading.value = true;
 
         setTimeout(() => {
-            useAllowancesStore().fetchAllowancesForAccount(userAddress.value).then(() => {
+            useAllowancesStore().fetchAllowancesForAccount(userAddress.value).finally(() => {
                 cancelBatchRevokeButtonLoading.value = false;
                 showRevokeInProgressModal.value = false;
                 cancelBatchRevoke.value = null;

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -191,10 +191,6 @@ function handleRevokeSelectedClicked() {
     batchRevokeAllowancesRemaining.value = selectedRows.value.length;
 
     function handleRevokeCompleted(completed: number, remaining: number) {
-        console.log('completed:', completed);
-        console.log('remaining:', remaining);
-        console.log('\n\n');
-
         batchRevokeAllowancesRemaining.value = remaining;
     }
 

--- a/src/pages/evm/allowances/AllowancesPageControls.vue
+++ b/src/pages/evm/allowances/AllowancesPageControls.vue
@@ -22,7 +22,7 @@ const includeCancelledLabel = computed(
 
 // methods
 function handleRevokeSelected() {
-    console.log('Revoke selected');
+    emit('revoke-selected');
 }
 </script>
 

--- a/src/pages/evm/allowances/AllowancesPageControls.vue
+++ b/src/pages/evm/allowances/AllowancesPageControls.vue
@@ -51,7 +51,9 @@ function handleRevokeSelected() {
     </q-btn>
 </div>
 
+<!-- https://github.com/telosnetwork/telos-wallet/issues/719 -->
 <q-toggle
+    v-if="false"
     v-model="includeCancelled"
     :label="includeCancelledLabel"
     color="primary"

--- a/src/pages/evm/allowances/AllowancesTable.vue
+++ b/src/pages/evm/allowances/AllowancesTable.vue
@@ -2,7 +2,12 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { AllowanceTableColumns, ShapedAllowanceRow, isErc20AllowanceRow, isErc721SingleAllowanceRow } from 'src/antelope/types/Allowances';
+import {
+    AllowanceTableColumns,
+    ShapedAllowanceRow,
+    isErc20AllowanceRow,
+    isErc721SingleAllowanceRow,
+} from 'src/antelope/types/Allowances';
 import { useUserStore } from 'src/antelope';
 import { getCurrencySymbol } from 'src/antelope/stores/utils/currency-utils';
 

--- a/src/pages/evm/allowances/AllowancesTable.vue
+++ b/src/pages/evm/allowances/AllowancesTable.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
     rows: ShapedAllowanceRow[];
 }>();
 
-const emit = defineEmits(['sortChanged']);
+const emit = defineEmits(['sortChanged', 'selectedRowsChanged']);
 
 const { t: $t } = useI18n();
 const { fiatLocale, fiatCurrency } = useUserStore();
@@ -98,6 +98,10 @@ watch(tableRows, (newRows) => {
     updateAllRevokeCheckboxes();
     pagination.value.rowsNumber = props.rows.length;
 }, { immediate: true });
+
+watch(revokeCheckboxesModel, () => {
+    emit('selectedRowsChanged', revokeCheckboxesModel.value);
+}, { deep: true });
 
 // methods
 function getAriaLabelForTh(columnName: AllowanceTableColumns) {

--- a/src/pages/evm/allowances/AllowancesTable.vue
+++ b/src/pages/evm/allowances/AllowancesTable.vue
@@ -2,7 +2,7 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { AllowanceTableColumns, ShapedAllowanceRow, isErc20AllowanceRow } from 'src/antelope/types/Allowances';
+import { AllowanceTableColumns, ShapedAllowanceRow, isErc20AllowanceRow, isErc721SingleAllowanceRow } from 'src/antelope/types/Allowances';
 import { useUserStore } from 'src/antelope';
 import { getCurrencySymbol } from 'src/antelope/stores/utils/currency-utils';
 
@@ -169,9 +169,16 @@ function getCheckboxModelForRow(row: ShapedAllowanceRow) {
 
 function toggleRevokeChecked(row: ShapedAllowanceRow) {
     const rowIsErc20 = isErc20AllowanceRow(row);
-    const tokenAddress = rowIsErc20 ? row.tokenAddress : row.collectionAddress;
-    const key = `${row.spenderAddress}-${tokenAddress}`;
+    const rowIsSingleErc721Row = isErc721SingleAllowanceRow(row);
 
+    const tokenAddress = rowIsErc20 ? row.tokenAddress : row.collectionAddress;
+    let key = `${row.spenderAddress}-${tokenAddress}`;
+
+    if (rowIsSingleErc721Row) {
+        key += `-${row.tokenId}`;
+    }
+
+    // rows are keyed like: `${row.spenderAddress}-${tokenAddress/collectionAddress}${ isSingleErc721 ? `-${tokenId}` : ''}`
     revokeCheckboxesModel.value[key] = !revokeCheckboxesModel.value[key];
 
     if (!revokeCheckboxesModel.value[key]) {

--- a/src/pages/evm/allowances/AllowancesTable.vue
+++ b/src/pages/evm/allowances/AllowancesTable.vue
@@ -96,6 +96,7 @@ watch(tableRows, (newRows) => {
 
     revokeAllCheckboxChecked.value = false;
     updateAllRevokeCheckboxes();
+    pagination.value.rowsNumber = props.rows.length;
 }, { immediate: true });
 
 // methods

--- a/src/pages/evm/allowances/AllowancesTableRow.vue
+++ b/src/pages/evm/allowances/AllowancesTableRow.vue
@@ -77,7 +77,7 @@ const assetTextFull = computed(() => {
     let prettyAmount: string;
 
     if (isSingleErc721Row) {
-        prettyAmount = '1 '.concat(props.row.tokenName);
+        prettyAmount = `1 ${props.row.tokenName} (${props.row.collectionName ?? truncateAddress(props.row.collectionAddress)} #${props.row.tokenId})`;
     } else if (isErc20Row) {
         const { balance, tokenSymbol, tokenDecimals } = props.row;
         prettyAmount = prettyPrintCurrency(balance, WEI_PRECISION, fiatLocale, false, tokenSymbol, false, tokenDecimals, true);

--- a/src/pages/evm/allowances/EditAllowanceModal.vue
+++ b/src/pages/evm/allowances/EditAllowanceModal.vue
@@ -183,6 +183,37 @@ async function handleSubmit() {
         }).finally(() => {
             dismiss();
         });
+    } else if (rowIsSingleErc721Row.value) {
+        const tx = await useAllowancesStore().updateSingleErc721Allowance(
+            userAddress.value,
+            props.row.spenderAddress,
+            rowAsSingleErc721Row.value.collectionAddress,
+            rowAsSingleErc721Row.value.tokenId,
+            newNftAllowanceIsAllowed.value,
+        );
+
+        const tokenText = `${rowAsSingleErc721Row.value.collectionName || truncateAddress(rowAsSingleErc721Row.value.collectionAddress)} #${rowAsSingleErc721Row.value.tokenId}`;
+
+        const dismiss = ant.config.notifyNeutralMessageHandler(
+            $t(
+                'notification.neutral_message_updating_single_erc721_allowance',
+                {
+                    tokenText,
+                    operator: props.row.spenderName || truncateAddress(props.row.spenderAddress),
+                },
+            ),
+        );
+
+        tx?.wait().then(() => {
+            ant.config.notifySuccessfulTrxHandler(
+                `${explorerUrl}/tx/${tx.hash}`,
+            );
+            emit('close');
+        }).catch((err) => {
+            console.error(err);
+        }).finally(() => {
+            dismiss();
+        });
     } else {
         console.log('New allowed is ', newNftAllowanceIsAllowed.value);
     }
@@ -203,6 +234,9 @@ async function handleSubmit() {
                 <br>
                 <span class="o-text--paragraph-bold">{{ tokenText }}</span>
                 <br>
+                <span v-if="rowIsSingleErc721Row">
+                    {{ $t('evm_allowances.erc_721_single_allowance_blurb') }}
+                </span>
                 <br>
                 {{ $t('global.allowance') }}
                 <br>

--- a/src/pages/evm/allowances/EditAllowanceModal.vue
+++ b/src/pages/evm/allowances/EditAllowanceModal.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, ref, watch } from 'vue';
+import {
+    computed,
+    onBeforeMount,
+    ref,
+    watch,
+} from 'vue';
 import { useI18n } from 'vue-i18n';
 import { BigNumber } from 'ethers';
 

--- a/src/pages/evm/allowances/EditAllowanceModal.vue
+++ b/src/pages/evm/allowances/EditAllowanceModal.vue
@@ -221,10 +221,11 @@ async function handleSubmit() {
         ant.config.notifySuccessfulTrxHandler(
             `${explorerUrl}/tx/${tx.hash}`,
         );
-        emit('close');
     }).catch((err) => {
+        ant.config.notifyErrorHandler(err);
         console.error(err);
     }).finally(() => {
+        emit('close');
         dismiss();
     });
 }
@@ -244,9 +245,11 @@ async function handleSubmit() {
                 <br>
                 <span class="o-text--paragraph-bold">{{ tokenText }}</span>
                 <br>
-                <span v-if="rowIsSingleErc721Row">
+                <template v-if="rowIsSingleErc721Row">
+                    <br>
                     {{ $t('evm_allowances.erc_721_single_allowance_blurb') }}
-                </span>
+                    <br>
+                </template>
                 <br>
                 {{ $t('global.allowance') }}
                 <br>


### PR DESCRIPTION
# Fixes #606 

## Description
This PR adds the ability to edit and batch revoke allowances. It also updates the contract store to prevent non-contract addresses from being saved as contracts incorrectly.

note: the toggle to show cancelled approvals has been temporarily removed from the page, as the indexer does not yet support showing cancelled approvals. there is a separate issue to fix that, #719 

note: there are 3 different kinds of approvals to be aware of (this is also commented in the code for future reference): 
1. ERC20 approvals, which consist of a spender address and an amount which that spender can spend on your behalf. This is done using the `approve` method
2. ERC721 single approvals. For these, you approve an operator address to send a particular ERC721 NFT on your behalf. For each token ID, there can only be one operator approved at a time; approving a new operator will automatically 'revoke' the previous operator's approval. To revoke without adding a new operator, the convention is to approve the zero address as the operator, `0x0000...0000`, as there is no actual 'revoke' method to call. This is done using the `approve` method
3. NFT Collection approvals. These can be split into 2 categories, ERC721 and ERC1155, however both operate the same way, by calling the `setApprovalForAll` method, which exists for both ERC721 and ERC1155 contracts. When calling `setApprovalForAll`, you provide an operator address and a boolean. If the boolean is `true`, the operator is allowed to send _all token IDs in that collection_ which are owned by you, on your behalf

## Test scenarios
**Setup**
- checkout and run the branch locally on mainnet: `git fetch --all && git checkout 606-revoke-allowances-api-integration && echo 'NETWORK="mainnet"' > .env && yarn dev`
- go to http://localhost:8081
- log in using team account `0x3783...8949`
- go to the Approvals tab
- set the table to show 100 rows so you can see all of the approvals on the account
    - you should see a bunch of approvals, including at least: 1 ERC20 approval (icon is a token icon), 1 NFT collection approval (icon is a stack of 3 NFTs), and 1 single ERC721 approval (icon is a single NFT)
    - if you do not see the approvals listed above, add them:
        1.  go to the contract page for a token/NFT contract on teloscan (for ERC20, you can find this from the Wallet tab > click overflow menu on a token > click "Contract" ; for erc721 and erc1155, you can do this by going to the NFT inventory page, clicking on an NFT, and then clicking the "Collection" link)
        4. on the teloscan page for the contract, go to the Contract tab
        5. make sure you are logged in on teloscan as the team account
        6. if the contract is verified (green checkmark next to the contract name at the top), click the Write tab. If it is not verified, click the appropriate ABI (ERC20/ERC721/ERC1155) and then click the Write tab
        7. add approvals
            - to add an approval for ERC20, open the `approve` dropdown, enter an address for the spender (I suggest you choose an address owned by you, or a known contract like Staked TLOS which will not abuse the approval) and an amount, then click Write and approve the tx.
            - for a single ERC721 approval, open the `approve` dropdown, enter an address like with ERC20, enter a token ID (which can be gotten from the NFT detail page on the Wallet app), and click Write and approve the TX. 
            - for entire collection approvals, open the `setApprovalForAll` dropdown, fill an address and set approved = true, then click Write and approve the tx

**Edit allowances** (note: complete these steps on desktop and mobile walletconnect with both MetaMask & SafePal)
- locate an **ERC20 allowance** row
- click the edit pencil icon in the row (take note of the current allowance before clicking)
    - the edit allowance modal should pop up
    - the selected option should reflect the existing allowance; if the allowance is a number, the `Custom` radio should be selected with that number filled. If the allowance is `Unlimited`, that radio should be selected, and the `Custom` input should be disabled and showing 0
- type in an allowance greater than (2^256)-1, e.g. `9,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999,999`
    - you should see an error under the input saying the number is too big
    - the submit button should be disabled
- type in another amount
- click Confirm
    -  your wallet should pop a transaction
- cancel the transaction
    - you should see a "you cancelled the action" notification
- click Confirm again
- approve the tx in your wallet
    - a notification should pop saying that {symbol} allowance is being updated
    - the modal should show a loading state until the tx completes
    - after the tx is successful, the modal should close and the table should show the correct new allowance
- now locate a **single ERC721 allowance** (an allowance which shows a single NFT icon)
- click the edit icon for that row
    - a modal should pop showing 2 options, `Allowed` and `Not Allowed`
    - the correct option (`Allowed`) should be selected already
    - the Confirm button should be disabled
    - the text in the modal should show `Collection Name #{tokenId}` as well as some text about single ERC721 approvals
- click `Not Allowed`
    - the Confirm button should become enabled
- click Confirm
    -  your wallet should pop a transaction
- cancel the transaction
    - you should see a "you cancelled the action" notification
- click Confirm again
- approve the tx in your wallet
    - you should see a notification saying the approval is being updated for `Collection Name #{tokenId}` and the operator address
    - the modal should show a loading state until the tx completes
    - after the tx is successful, the modal should close and the table should no longer show that allowance
- now locate an **ERC721 collection** row, such as `Telosians`
- click the edit icon for that row
    - a modal should pop showing 2 options, `Allowed` and `Not Allowed`
    - the correct option (`Allowed`) should be selected already
    - the Confirm button should be disabled
    - the text in the modal should show `{collection name} (Entire Collection)`
- click `Not Allowed`
    - the Confirm button should become enabled
- click Confirm
    -  your wallet should pop a transaction
- cancel the transaction
    - you should see a "you cancelled the action" notification
- click Confirm again
- approve the tx in your wallet
    - you should see a notification saying the approval is being updated for `{Collection Name}` and the operator address
    - the modal should show a loading state until the tx completes
    - after the tx is successful, the modal should close and the table should no longer show that allowance
- now locate an **ERC1155 collection** row, such as "Telos Arcade Token"
- click the edit icon for that row
    - a modal should pop showing 2 options, `Allowed` and `Not Allowed`
    - the correct option (`Allowed`) should be selected already
    - the Confirm button should be disabled
    - the text in the modal should show `{collection name} (Entire Collection)`
- click `Not Allowed`
    - the Confirm button should become enabled
- click Confirm
    -  your wallet should pop a transaction
- cancel the transaction
    - you should see a "you cancelled the action" notification
- click Confirm again
- approve the tx in your wallet
    - you should see a notification saying the approval is being updated for `{Collection Name}` and the operator address
    - the modal should show a loading state until the tx completes
    - after the tx is successful, the modal should close and the table should no longer show that allowance

**Batch Revoke**
- with no rows selected, the Revoke Selected button above the table should be disabled
- select multiple rows on the approvals table
    - the Revoke Selected button should become enabled
- click the Revoke Selected button
    - a modal should pop showing a message like "Revoking X allowances (Y Remaining)" where X and Y are both the amount  of rows you selected
    - there should also be some text explaining the revoke process and a Cancel button
    - your wallet should pop a transaction
- Reject the transaction
    - you should see a "you cancelled the action" notification
    - after a few seconds, the modal should dismiss itself
- select multiple rows on the approvals table again
- click the Cancel button
    - the modal should close 
- select multiple rows on the approvals table, making sure to select at least one each of ERC20, single ERC721, ERC721 Collection, and ERC1155 collection
- approve the transactions as they come up
    - the text in the modal should update each time you approve a TX so that "Y Remaining" reflects the number of approvals already approved
    - once all are approved, the modal should go into a loading state
    - after a few seconds, the modal should close
    - when the modal is closed, those revoked rows should disappear from the table




## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
