### PR TITLE
#725 | Fix rows per page dropdown visibility

### DIFF
--- a/src/components/evm/TableControls.vue
+++ b/src/components/evm/TableControls.vue
@@ -93,7 +93,7 @@ function changePageNumber(direction: 'next' | 'prev' | 'first' | 'last') {
             @keypress.space.enter.prevent="showRowsPerPageDropdown = !showRowsPerPageDropdown"
         >
             <q-popup-proxy ref="rowsPerPagePopup" transition-show="scale" transition-hide="scale">
-                <q-list>
+                <q-list class="c-table-controls__rows-per-page-list">
                     <q-item v-for="size in rowsPerPageOptions" :key="size" class="cursor-pointer">
                         <q-item-section
                             tabindex="0"
@@ -178,6 +178,10 @@ function changePageNumber(direction: 'next' | 'prev' | 'first' | 'last') {
         @media only screen and (min-width: $breakpoint-md-min) {
             margin: unset;
         }
+    }
+
+    &__rows-per-page-list {
+        background: $white;
     }
 }
 </style>


### PR DESCRIPTION
# Fixes #725

## Description
On mobile, the rows per page dropdown on tables is not legible. this is because the dropdown component automatically switches to a modal display on smaller devices, and the modal version was unstyled

## Test scenarios
- on a mobile device, go to https://deploy-preview-726--wallet-staging.netlify.app/
- go to any page with a table on it, like transaction history
- tap the rows per page dropdown
    - the rows per page dropdown should be legible

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
