### PR TITLE
#729 | Improve liquid balance display

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -570,6 +570,7 @@ export default {
         'LOSS OF FUNDS. THIS PRIVATE KEY IS NOT AVAILABLE.',
         i_understand: 'I Understand',
         copied_ok: 'Copied it to the clipboard successfully',
+        balance_fiat_tooltip: 'Total includes non-liquid TLOS, such as TLOS staked to resources',
     },
     dapps: {
         title: 'Telos Native dApps',

--- a/src/pages/native/BalanceInfo.vue
+++ b/src/pages/native/BalanceInfo.vue
@@ -104,6 +104,9 @@ export default {
                 )
                 .reduce((a, b) => a + b, 0);
         },
+        telosBalance() {
+            return this.coins.find(coin => coin.symbol === 'TLOS' && coin.account === 'eosio.token').totalAmount;
+        },
         availableHeight() {
             return (
                 window.innerHeight - (this.isAuthenticated ? this.footerHeight : 0)
@@ -713,6 +716,9 @@ export default {
                             <q-icon name="o_info" size="sm" />
                             <q-tooltip>{{ $t('balance.balance_fiat_tooltip') }}</q-tooltip>
                         </div>
+                    </div>
+                    <div v-if="typeof telosBalance === 'number'"  class="full-width">
+                        {{ getFixed(telosBalance, 4) }} TLOS
                     </div>
                 </div>
 

--- a/src/pages/native/BalanceInfo.vue
+++ b/src/pages/native/BalanceInfo.vue
@@ -704,7 +704,7 @@ export default {
                 <!-- Account Amount -->
                 <div class="full-width items-center balance-div row">
                     <div class="full-width"></div>
-                    <div class="full-width">
+                    <div class="full-width balance-text">
                         <label
                             class="text-white items-center"
                             :style="`font-size: ${balanceTextSize}px; font-weight: 200; font-size: 50px; white-space: nowrap;`"
@@ -713,6 +713,10 @@ export default {
                                 displayAmount.toFixed(2).slice(-2)
                             }}
                         </label>
+                        <div>
+                            <q-icon name="o_info" size="sm" />
+                            <q-tooltip>{{ $t('balance.balance_fiat_tooltip') }}</q-tooltip>
+                        </div>
                     </div>
                 </div>
 
@@ -985,6 +989,13 @@ export default {
   background-color: #00000000;
   display: inline-flex;
   justify-content: space-between;
+}
+
+.balance-text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
 }
 
 .balanceBtn {

--- a/src/pages/native/balance/SendCoins.vue
+++ b/src/pages/native/balance/SendCoins.vue
@@ -21,7 +21,23 @@ export default {
             ));
         },
         availableCoins() {
-            return this.coins.filter(coin => coin.amount > 0);
+            let filteredCoins = this.coins.filter(coin => coin.amount > 0);
+
+            if (filteredCoins.findIndex(coin => coin.symbol === 'TLOS' && coin.account === 'eosio.token') === -1) {
+                filteredCoins = [{
+                    name: 'Telos',
+                    symbol: 'TLOS',
+                    amount: 0,
+                    price: 0,
+                    icon: 'telos',
+                    network: 'eos',
+                }, ...filteredCoins];
+            }
+
+            return filteredCoins;
+        },
+        showEmptyTelos() {
+            return this.availableCoins.findIndex(coin => coin.symbol === 'TLOS' && coin.account === 'eosio.token') === -1;
         },
         showDlg: {
             get() {
@@ -34,6 +50,9 @@ export default {
     },
     methods: {
         selectCoin(coin) {
+            if (this.showEmptyTelos) {
+                return;
+            }
             this.$emit('update:showSendAmountDlg', true);
             this.$emit('update:selectedCoin', coin);
         },


### PR DESCRIPTION
# Fixes #729 

## Description
This PR improves how liquid balance is displayed in the Telos Zero UI

## Test scenarios
- go to https://deploy-preview-731--wallet-develop-mainnet.netlify.app/
- click Telos Zero
- click View Any Account
- enter `ezrazero.gm`
- click Send
    - you should see a TLOS row with a 0 balance
- click the empty TLOS row
    - nothing should happen
- close the send dialog
- click Disconnect
- click Telos Zero
- click View Any Account
- enter `gverntelos21`
    - you should see a tooltip next to the total fiat balance at the top
    - the TLOS row in balances should show the correct _liquid_ balance (1 TLOS at the time of writing - you can check current amount on OBE [here](https://explorer.telos.net/account/gverntelos21))
- click Send
    - the TLOS row should have the correct amount (the liquid amount)
- click the TLOS row
- you should be taken to the Send page for TLOS

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
