### PR TITLE
(DON'T MERGE) Restore OreId for Telos Cloud Wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telos-web-wallet",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A Web Wallet for Telos",
   "productName": "Telos Web Wallet",
   "private": true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import { TELOS_CHAIN_IDS } from 'src/antelope/chains/chain-constants';
 import packageInfo from '../package.json';
 import { defineComponent } from 'vue';
 
-export const isTodayBeforeTelosCloudDown = new Date().getTime() < new Date('2023-12-31').getTime();
+export const isTodayBeforeTelosCloudDown = new Date().getTime() < new Date('2024-12-31').getTime();
 
 export default defineComponent({
     name: 'App',

--- a/src/boot/ual.js
+++ b/src/boot/ual.js
@@ -149,6 +149,11 @@ export default boot(async ({ app, store }) => {
             loginHandler,
             signHandler,
         }),
+        new OreIdAuthenticator([chain], {
+            appId: process.env.OREID_APP_ID_NATIVE,
+            plugins: { popup: WebPopup() },
+        },
+        AuthProvider.Google),
     ];
 
     const ual = new UAL([chain], 'ual', authenticators);

--- a/src/pages/home/EVMLoginButtons.vue
+++ b/src/pages/home/EVMLoginButtons.vue
@@ -178,6 +178,38 @@ export default defineComponent({
 <div class="c-evm-login-buttons">
     <!-- main menu -->
     <template v-if="showMainMenu">
+
+        <!-- Google OAuth Provider -->
+        <div class="c-evm-login-buttons__option c-evm-login-buttons__option--telos-cloud" @click="setCloudMenu()">
+            <div class="c-evm-login-buttons__cloud-btn-container">
+                <div class="c-evm-login-buttons__cloud-btn-line-title">
+                    <img
+                        width="24"
+                        class="c-evm-login-buttons__icon c-evm-login-buttons__icon--cloud"
+                        src="~assets/icon--telos-cloud.svg"
+                    >
+                    <span>{{ $t('home.login_with_social_media') }}</span>
+                </div>
+                <div class="c-evm-login-buttons__cloud-btn-line-icons">
+                    <img
+                        width="12"
+                        class="c-evm-login-buttons__icon c-evm-login-buttons__icon--social"
+                        src="~assets/icon--google.svg"
+                    >
+                    <img
+                        width="12"
+                        class="c-evm-login-buttons__icon c-evm-login-buttons__icon--social"
+                        src="~assets/icon--facebook.svg"
+                    >
+                    <img
+                        width="12"
+                        class="c-evm-login-buttons__icon c-evm-login-buttons__icon--social"
+                        src="~assets/icon--twitter.svg"
+                    >
+                </div>
+            </div>
+        </div>
+
         <!-- Brave Authenticator button -->
         <div
             v-if="showBraveButton"


### PR DESCRIPTION
# Access your old Telos Cloud Wallet before it gets discontinued

The previous service we were using under the hud to offer this great functionality is going to be discontinued, therefore all accounts managed by this service are not going to be accessible anymore.

If you own own of those accounts, you still can access the old version on this [special website for old Telos Cloud Wallet access](https://deploy-preview-733--wallet-develop-mainnet.netlify.app/)
