### PR TITLE
#750 | Add empty allowances state

### DIFF
--- a/src/components/evm/CollapsibleAside.vue
+++ b/src/components/evm/CollapsibleAside.vue
@@ -5,6 +5,7 @@ const props = defineProps<{
     header: string;
     content: { text: string; bold?: boolean; }[];
     alwaysOpen?: boolean, // if true, the expansion item will always be open with no toggle
+    centerOnDesktop?: boolean, // if true, the aside will be centered on large screens (default is off to the side)
 }>();
 
 // data
@@ -25,6 +26,7 @@ function handleExpansionItemUpdate() {
     :class="{
         'c-collapsible-aside': true,
         'c-collapsible-aside--always-open': alwaysOpen,
+        'c-collapsible-aside--centered': centerOnDesktop,
     }"
 >
     <q-expansion-item
@@ -55,6 +57,13 @@ function handleExpansionItemUpdate() {
     &--always-open {
         .q-item.q-item-type {
             pointer-events: none;
+        }
+    }
+
+    &--centered {
+        @include md-and-up {
+            display: flex;
+            justify-content: center;
         }
     }
 

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -321,6 +321,7 @@ export default {
         revoking_allowances_title: 'Revoking {total} allowance(s) ({remaining} remaining)',
         revoking_allowances_description: 'Please wait while we revoke the selected allowance(s). You will need to approve each transaction in your wallet.',
         revoking_allowances_cancel_note: 'Note: clicking \'Cancel\' will not cancel transactions which have already been approved. Any pending transaction(s) must be cancelled in your wallet.',
+        no_allowances: 'You don\'t have any approvals yet',
     },
     notification:{
         success_title_trx: 'Success',

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -253,18 +253,20 @@ function handleRevokeSelectedClicked() {
     </template>
 
     <div class="c-allowances-page__body">
-        <CollapsibleAside
-            :header="asideHeader"
-            :content="asideContent"
-            class="q-mb-lg"
-        />
+        <template v-if="loading || shapedAllowanceRows.length > 0">
+            <CollapsibleAside
+                :header="asideHeader"
+                :content="asideContent"
+                class="q-mb-lg"
+            />
 
-        <AllowancesPageControls
-            :enable-revoke-button="enableRevokeButton"
-            @search-updated="handleSearchUpdated"
-            @include-cancelled-updated="handleIncludeCancelledUpdated"
-            @revoke-selected="handleRevokeSelectedClicked"
-        />
+            <AllowancesPageControls
+                :enable-revoke-button="enableRevokeButton"
+                @search-updated="handleSearchUpdated"
+                @include-cancelled-updated="handleIncludeCancelledUpdated"
+                @revoke-selected="handleRevokeSelectedClicked"
+            />
+        </template>
 
         <div v-if="loading" class="q-mt-lg">
             <q-skeleton
@@ -273,6 +275,11 @@ function handleRevokeSelectedClicked() {
                 class="c-allowances-page__skeleton-row"
                 type="rect"
             />
+        </div>
+        <div v-else-if="!loading && shapedAllowanceRows.length === 0">
+            <h2 class="c-allowances-page__empty-title">
+                {{ $t('evm_allowances.no_allowances') }}
+            </h2>
         </div>
         <AllowancesTable
             v-else
@@ -318,6 +325,11 @@ function handleRevokeSelectedClicked() {
 
 <style lang="scss">
 .c-allowances-page {
+    &__empty-title {
+        text-align: center;
+        margin-top: 32px;
+    }
+
     &__body {
         max-width: 1000px;
         margin: auto;

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -70,6 +70,7 @@ const numberOfAllowancesToBatchRevoke = ref(0);
 
 // computed
 const userAddress = computed(() => useAccountStore().currentAccount.account);
+const showEmptyState = computed(() => !loading.value && shapedAllowanceRows.value.length === 0);
 const shapedAllowanceRows = computed(() => {
     const {
         asset,
@@ -253,20 +254,20 @@ function handleRevokeSelectedClicked() {
     </template>
 
     <div class="c-allowances-page__body">
-        <template v-if="loading || shapedAllowanceRows.length > 0">
-            <CollapsibleAside
-                :header="asideHeader"
-                :content="asideContent"
-                class="q-mb-lg"
-            />
+        <CollapsibleAside
+            :header="asideHeader"
+            :content="asideContent"
+            :center-on-desktop="showEmptyState"
+            class="q-mb-lg"
+        />
 
-            <AllowancesPageControls
-                :enable-revoke-button="enableRevokeButton"
-                @search-updated="handleSearchUpdated"
-                @include-cancelled-updated="handleIncludeCancelledUpdated"
-                @revoke-selected="handleRevokeSelectedClicked"
-            />
-        </template>
+        <AllowancesPageControls
+            v-if="!showEmptyState"
+            :enable-revoke-button="enableRevokeButton"
+            @search-updated="handleSearchUpdated"
+            @include-cancelled-updated="handleIncludeCancelledUpdated"
+            @revoke-selected="handleRevokeSelectedClicked"
+        />
 
         <div v-if="loading" class="q-mt-lg">
             <q-skeleton
@@ -276,7 +277,7 @@ function handleRevokeSelectedClicked() {
                 type="rect"
             />
         </div>
-        <div v-else-if="!loading && shapedAllowanceRows.length === 0">
+        <div v-else-if="showEmptyState">
             <h2 class="c-allowances-page__empty-title">
                 {{ $t('evm_allowances.no_allowances') }}
             </h2>


### PR DESCRIPTION
## Description
This PR adds an empty state for the allowance page, resolves #750 

## Test scenarios
- go to https://deploy-preview-749--wallet-develop-mainnet.netlify.app/
- sign in with an account which has approvals (e.g. team account)
- go to approvals page
    - page should be unchanged
- switch account to one with no approvals
    -  you should see an empty state

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
