### PR TITLE
Global getWeb3Provider fixed

### DIFF
--- a/src/antelope/chains/EVMChainSettings.ts
+++ b/src/antelope/chains/EVMChainSettings.ts
@@ -47,6 +47,7 @@ import { dateIsWithinXMinutes } from 'src/antelope/stores/utils/date-utils';
 import { CURRENT_CONTEXT, getAntelope, useContractStore, useNftsStore } from 'src/antelope';
 import { WEI_PRECISION, PRICE_UPDATE_INTERVAL_IN_MIN } from 'src/antelope/stores/utils';
 import { BehaviorSubject, filter } from 'rxjs';
+import { createTraceFunction } from 'src/antelope/config';
 
 
 export default abstract class EVMChainSettings implements ChainSettings {
@@ -96,6 +97,9 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // This observable is used to check if the indexer health state was already checked
     indexerChecked$ = new BehaviorSubject(false);
+
+    // This function is used to trace the execution of the code
+    trace = createTraceFunction('EVMChainSettings');
 
     simulateIndexerDown(isBad: boolean) {
         this.indexerBadHealthSimulated = isBad;
@@ -152,6 +156,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
     }
 
     async init(): Promise<void> {
+        this.trace('init');
         // this is called only when this chain is needed to avoid initialization of all chains
         if (this.ready) {
             return this.initPromise;
@@ -302,6 +307,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
     }
 
     async getBalances(account: string): Promise<TokenBalance[]> {
+        this.trace('getBalances', account);
         if (!this.hasIndexerSupport()) {
             console.error('Indexer API not supported for this chain:', this.getNetwork());
             return [];
@@ -366,6 +372,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // get the NFTs belonging to a particular contract (collection)
     async getNftsForCollection(collection: string, params: IndexerCollectionNftsFilter): Promise<Collectible[]> {
+        this.trace('getNftsForCollection', collection, params);
         if (!this.hasIndexerSupport()) {
             console.error('Error fetching NFTs, Indexer API not supported for this chain:', this.getNetwork());
             return [];
@@ -384,6 +391,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
             supply: nftResponse.supply,
             owner: nftResponse.owner,
         }));
+        this.trace('getNftsForCollection', { shapedIndexerNftData, response });
 
         // we fix the supportedInterfaces property if it is undefined in the response but present in the request
         Object.values(response.contracts).forEach((contract) => {
@@ -392,7 +400,10 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
         this.processNftContractsCalldata(response.contracts);
         const shapedNftData = this.shapeNftRawData(shapedIndexerNftData, response.contracts);
-        return this.processNftRawData(shapedNftData);
+        this.trace('getNftsForCollection', { shapedNftData });
+        const finalNftData =  this.processNftRawData(shapedNftData);
+        this.trace('getNftsForCollection', { finalNftData });
+        return finalNftData;
     }
 
     // get the NFTs belonging to a particular account
@@ -471,6 +482,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
     // process the shaped raw data into NFTs
     async processNftRawData(shapedRawNfts: NftRawData[]): Promise<Collectible[]> {
+        this.trace('processNftRawData', shapedRawNfts);
         const contractStore = useContractStore();
         const nftsStore = useNftsStore();
 
@@ -502,6 +514,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
                 return nft;
             });
+        this.trace('processNftRawData', 'erc1155Nfts', erc1155Nfts);
 
         const erc721RawData = shapedRawNfts.filter(({ contract }) => contract.supportedInterfaces.includes('erc721'));
         const erc721Nfts = erc721RawData.map(async ({ data, contract }) => {
@@ -519,6 +532,7 @@ export default abstract class EVMChainSettings implements ChainSettings {
 
             return nft;
         });
+        this.trace('processNftRawData', 'erc721Nfts', erc721Nfts);
 
         const settledPromises = await Promise.allSettled([...erc1155Nfts, ...erc721Nfts]);
 
@@ -529,7 +543,10 @@ export default abstract class EVMChainSettings implements ChainSettings {
             console.error('Error constructing NFT', reason);
         });
 
-        return fulfilledPromises.map(result => result.value as Collectible);
+        const nfts = fulfilledPromises.map(result => result.value as Collectible);
+        this.trace('processNftRawData', 'nfts', nfts);
+
+        return nfts;
     }
 
     constructTokenId(token: TokenSourceInfo): string {

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -217,15 +217,6 @@ export const useAllowancesStore = defineStore(store_name, {
         init: () => {
             const allowancesStore = useAllowancesStore();
             const ant = getAntelope();
-            ant.events.onAccountChanged.pipe(
-                filter(({ label, account }) => !!label && !!account),
-            ).subscribe({
-                next: ({ label, account }) => {
-                    if (label === CURRENT_CONTEXT && account?.account) {
-                        allowancesStore.fetchAllowancesForAccount(account?.account);
-                    }
-                },
-            });
 
             ant.events.onClear.subscribe(({ label }) => {
                 allowancesStore.clearAllowances(label);

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -546,9 +546,13 @@ export const useAllowancesStore = defineStore(store_name, {
 
                 const tokenContract = await useContractStore().getContract(CURRENT_CONTEXT, data.contract);
 
-                const maxSupply = await tokenContract?.getMaxSupply();
+                const maxSupply = tokenContract?.maxSupply;
+
                 const balancesStore = useBalancesStore();
-                let balance = balancesStore.__balances[CURRENT_CONTEXT]?.find(balance => balance.token.address.toLowerCase() === data.contract.toLowerCase())?.amount;
+                let balance = balancesStore.__balances[CURRENT_CONTEXT]?.find(
+                    balance => balance.token.address.toLowerCase() === data.contract.toLowerCase(),
+                )?.amount;
+
                 if (!balance) {
                     const tokenContractInstance = await tokenContract?.getContractInstance();
                     balance = await tokenContractInstance?.balanceOf(data.owner) as BigNumber | undefined;

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -554,8 +554,10 @@ export const useAllowancesStore = defineStore(store_name, {
                 )?.amount;
 
                 if (!balance) {
-                    const tokenContractInstance = await tokenContract?.getContractInstance();
-                    balance = await tokenContractInstance?.balanceOf(data.owner) as BigNumber | undefined;
+                    const indexer = (useChainStore().loggedChain.settings as EVMChainSettings).getIndexer();
+                    const balanceString = (await indexer.get(`/v1/token/${data.contract}/holders?account=${data.owner}`)).data.results[0].balance;
+
+                    balance = BigNumber.from(balanceString);
                 }
 
                 if (!balance || !tokenInfo || !maxSupply) {

--- a/src/antelope/stores/contract.ts
+++ b/src/antelope/stores/contract.ts
@@ -609,10 +609,8 @@ export const useContractStore = defineStore(store_name, {
 
 
             this.__accounts[network].processing[addressLower] = new Promise(async (resolve) => {
-                const provider = await getAntelope().wallets.getWeb3Provider();
-                const code = await provider.getCode(address);
-
-                const isContract = code !== '0x';
+                const indexer = (useChainStore().loggedChain.settings as EVMChainSettings).getIndexer();
+                const isContract = (await indexer.get(`/v1/contract/${addressLower}`)).data.results.length > 0;
 
                 if (!isContract && !this.__accounts[network].addresses.includes(addressLower)) {
                     this.__accounts[network].addresses.push(addressLower);

--- a/src/antelope/stores/contract.ts
+++ b/src/antelope/stores/contract.ts
@@ -61,9 +61,13 @@ export interface ContractStoreState {
             processing: Record<string, Promise<EvmContract | null>>
         },
     }
-    // addresses which have been checked and are known not to be contract addresses
     __accounts: {
-        [network: string]: string[],
+        [network: string]: {
+            // addresses which are being checked to see if they are account (non-contract) addresses
+            processing: Record<string, Promise<boolean>>,
+            // addresses which have been checked and are known not to be contract addresses
+            addresses: string[],
+        },
     },
 }
 
@@ -583,24 +587,44 @@ export const useContractStore = defineStore(store_name, {
 
         async addressIsContract(network: string, address: string) {
             const addressLower = address.toLowerCase();
-            if (!this.__accounts[network]) {
-                this.__accounts[network] = [];
+
+            if (this.__contracts[network]?.cached[addressLower] || this.__contracts[network]?.metadata[addressLower]) {
+                return true;
             }
 
-            if (this.__accounts[network].includes(addressLower)) {
+            if (!this.__accounts[network]) {
+                this.__accounts[network] = {
+                    processing: {},
+                    addresses: [],
+                };
+            }
+
+            if (this.__accounts[network].addresses.includes(addressLower)) {
                 return false;
             }
 
-            const provider = await getAntelope().wallets.getWeb3Provider();
-            const code = await provider.getCode(address);
-
-            const isContract = code !== '0x';
-
-            if (!isContract && !this.__accounts[network].includes(addressLower)) {
-                this.__accounts[network].push(addressLower);
+            if (!!this.__accounts[network].processing[addressLower]) {
+                return this.__accounts[network].processing[addressLower];
             }
 
-            return isContract;
+
+            this.__accounts[network].processing[addressLower] = new Promise(async (resolve) => {
+                const provider = await getAntelope().wallets.getWeb3Provider();
+                const code = await provider.getCode(address);
+
+                const isContract = code !== '0x';
+
+                if (!isContract && !this.__accounts[network].addresses.includes(addressLower)) {
+                    this.__accounts[network].addresses.push(addressLower);
+                }
+
+                resolve(isContract);
+            });
+
+            return this.__accounts[network].processing[addressLower].then((isContract) => {
+                delete this.__accounts[network].processing[addressLower];
+                return isContract;
+            });
         },
     },
 });

--- a/src/antelope/stores/nfts.ts
+++ b/src/antelope/stores/nfts.ts
@@ -230,6 +230,7 @@ export const useNftsStore = defineStore(store_name, {
                     tokenId,
                     type,
                 };
+                this.trace('fetchNftDetails', 'filter:', new_filter);
 
                 // If we already have a contract for that network and contract, we search for the NFT in that list first
                 this.__contracts[network] = this.__contracts[network] || {};
@@ -246,6 +247,7 @@ export const useNftsStore = defineStore(store_name, {
                         nft => nft.contractAddress.toLowerCase() === contract.toLowerCase() && nft.id === tokenId,
                     );
                     if (nft) {
+                        this.trace('fetchNftDetails', 'found in cache:', nft);
                         return nft;
                     }
                 } else {
@@ -260,6 +262,7 @@ export const useNftsStore = defineStore(store_name, {
                 // we don't have the NFT on any cache, we fetch it from the indexer
                 useFeedbackStore().setLoading('updateNFTsForAccount');
                 if (chain.settings.isNative() || (chain.settings as EVMChainSettings).hasIndexerSupport()) {
+                    this.trace('fetchNftDetails', 'fetching from indexer');
                     promise = chain.settings.getNftsForCollection(contract, new_filter).then((nfts) => {
                         const contractLower = contract.toLowerCase();
 
@@ -273,6 +276,7 @@ export const useNftsStore = defineStore(store_name, {
                     if (!chain.settings.isNative()) {
                         // this means we have the indexer down
                         // we have the contract and the address so we try to fetch the NFT from the contract
+                        this.trace('fetchNftDetails', 'indexer down, fetching from contract');
                         useEVMStore().getNFT(
                             contract,
                             tokenId,

--- a/src/antelope/stores/rex.ts
+++ b/src/antelope/stores/rex.ts
@@ -74,7 +74,7 @@ export const useRexStore = defineStore(store_name, {
                 filter(({ label, account }) => !!label && !!account),
             ).subscribe({
                 next: async ({ label, account }) => {
-                    if (label === 'current') {
+                    if (label === CURRENT_CONTEXT) {
                         await useRexStore().updateRexDataForAccount(label, toRaw(account));
                     }
                 },

--- a/src/antelope/stores/utils/contracts/EvmContract.ts
+++ b/src/antelope/stores/utils/contracts/EvmContract.ts
@@ -239,6 +239,10 @@ export default class EvmContract {
     }
 
     async getMaxSupply() {
+        if (!this.isToken()) {
+            return 0;
+        }
+
         if (this.maxSupply) {
             return this.maxSupply;
         }

--- a/src/antelope/stores/utils/contracts/EvmContract.ts
+++ b/src/antelope/stores/utils/contracts/EvmContract.ts
@@ -1,4 +1,4 @@
-import { ContractInterface, ethers } from 'ethers';
+import { BigNumber, ContractInterface, ethers } from 'ethers';
 import { markRaw } from 'vue';
 import {
     AntelopeError, EvmContractCalldata,
@@ -27,6 +27,7 @@ export default class EvmContract {
     private readonly _token?: TokenSourceInfo | null;
 
     private contractInstance?: ethers.Contract;
+    private maxSupply?: BigNumber;
     private _verified?: boolean;
 
     constructor({
@@ -235,6 +236,16 @@ export default class EvmContract {
         } else {
             throw new AntelopeError('antelope.utils.error_parsing_log_event', log);
         }
+    }
+
+    async getMaxSupply() {
+        if (this.maxSupply) {
+            return this.maxSupply;
+        }
+
+        const maxSupply = (await this.getContractInstance()).totalSupply();
+        this.maxSupply = maxSupply;
+        return maxSupply;
     }
 }
 

--- a/src/antelope/stores/utils/contracts/EvmContract.ts
+++ b/src/antelope/stores/utils/contracts/EvmContract.ts
@@ -26,6 +26,7 @@ export default class EvmContract {
     private readonly _manager?: EvmContractManagerI;
     private readonly _token?: TokenSourceInfo | null;
 
+    private contractInstance?: ethers.Contract;
     private _verified?: boolean;
 
     constructor({
@@ -137,6 +138,11 @@ export default class EvmContract {
         if (!this.abi){
             throw new AntelopeError('antelope.utils.error_contract_instance');
         }
+
+        if (this.contractInstance) {
+            return this.contractInstance;
+        }
+
         const signer = await this._manager?.getSigner();
         let provider;
 
@@ -145,6 +151,7 @@ export default class EvmContract {
         }
 
         const contract = new ethers.Contract(this.address, this.abi, signer ?? provider ?? undefined);
+        this.contractInstance = contract;
 
         return contract;
     }

--- a/src/antelope/wallets/AntelopeWallets.ts
+++ b/src/antelope/wallets/AntelopeWallets.ts
@@ -43,8 +43,8 @@ export class AntelopeWallets {
             await jsonRpcProvider.ready;
             const web3Provider = jsonRpcProvider as ethers.providers.Web3Provider;
             return web3Provider;
-        } catch (e3) {
-            this.trace('getWeb3Provider authenticator.web3Provider() Failed!', e3);
+        } catch (e) {
+            this.trace('getWeb3Provider authenticator.web3Provider() Failed!', e);
             throw new AntelopeError('antelope.evn.error_no_provider');
         }
     }

--- a/src/antelope/wallets/AntelopeWallets.ts
+++ b/src/antelope/wallets/AntelopeWallets.ts
@@ -12,6 +12,9 @@ export class AntelopeWallets {
 
     private trace: AntelopeDebugTraceType;
     private authenticators: Map<string, EVMAuthenticator> = new Map();
+    private web3Provider: ethers.providers.Web3Provider | null = null;
+    private web3ProviderInitializationPromise: Promise<ethers.providers.Web3Provider> | null = null;
+
     constructor() {
         this.trace = createTraceFunction(name);
     }
@@ -36,16 +39,34 @@ export class AntelopeWallets {
 
     async getWeb3Provider(label = CURRENT_CONTEXT): Promise<ethers.providers.Web3Provider> {
         this.trace('getWeb3Provider');
-        try {
-            const p:RpcEndpoint = this.getChainSettings(label).getRPCEndpoint();
-            const url = `${p.protocol}://${p.host}:${p.port}${p.path ?? ''}`;
-            const jsonRpcProvider = new ethers.providers.JsonRpcProvider(url);
-            await jsonRpcProvider.ready;
-            const web3Provider = jsonRpcProvider as ethers.providers.Web3Provider;
-            return web3Provider;
-        } catch (e) {
-            this.trace('getWeb3Provider authenticator.web3Provider() Failed!', e);
-            throw new AntelopeError('antelope.evn.error_no_provider');
+
+        // If a provider instance already exists, return it immediately.
+        if (this.web3Provider) {
+            return this.web3Provider;
         }
+
+        // If an initialization is already underway, wait for it to complete.
+        if (this.web3ProviderInitializationPromise) {
+            return this.web3ProviderInitializationPromise;
+        }
+
+        // Start the initialization.
+        this.web3ProviderInitializationPromise = (async () => {
+            try {
+                const p: RpcEndpoint = this.getChainSettings(label).getRPCEndpoint();
+                const url = `${p.protocol}://${p.host}:${p.port}${p.path ?? ''}`;
+                const jsonRpcProvider = new ethers.providers.JsonRpcProvider(url);
+                await jsonRpcProvider.ready;
+                this.web3Provider = jsonRpcProvider as ethers.providers.Web3Provider;
+                return this.web3Provider;
+            } catch (e) {
+                this.trace('getWeb3Provider authenticator.web3Provider() Failed!', e);
+                this.web3ProviderInitializationPromise = null; // Reset to allow retries.
+                throw new AntelopeError('antelope.evn.error_no_provider');
+            }
+        })();
+
+        return this.web3ProviderInitializationPromise;
     }
+
 }

--- a/src/antelope/wallets/AntelopeWallets.ts
+++ b/src/antelope/wallets/AntelopeWallets.ts
@@ -1,5 +1,4 @@
 import { EVMAuthenticator } from 'src/antelope/wallets/authenticators/EVMAuthenticator';
-import { useAccountStore } from 'src/antelope/stores/account';
 import { CURRENT_CONTEXT, useChainStore } from 'src/antelope';
 import { RpcEndpoint } from 'universal-authenticator-library';
 import { ethers } from 'ethers';
@@ -35,31 +34,10 @@ export class AntelopeWallets {
         return (useChainStore().getChain(label).settings as EVMChainSettings);
     }
 
-    async getWeb3Provider(): Promise<ethers.providers.Web3Provider> {
+    async getWeb3Provider(label = CURRENT_CONTEXT): Promise<ethers.providers.Web3Provider> {
         this.trace('getWeb3Provider');
-        const account = useAccountStore().getAccount(CURRENT_CONTEXT);
         try {
-            // we try first the best solution which is taking the provider from the current authenticator
-            const authenticator = account.authenticator as EVMAuthenticator;
-            const provider = authenticator.web3Provider();
-            return provider;
-        } catch(e1) {
-            this.trace('getWeb3Provider authenticator.web3Provider() Failed!', e1);
-        }
-
-        // we try to build a web3 provider from a local injected provider it it exists
-        try {
-            if (window.ethereum) {
-                const web3Provider = new ethers.providers.Web3Provider(window.ethereum);
-                await web3Provider.ready;
-                return web3Provider;
-            }
-        } catch(e2) {
-            this.trace('getWeb3Provider authenticator.web3Provider() Failed!', e2);
-        }
-
-        try {
-            const p:RpcEndpoint = this.getChainSettings(CURRENT_CONTEXT).getRPCEndpoint();
+            const p:RpcEndpoint = this.getChainSettings(label).getRPCEndpoint();
             const url = `${p.protocol}://${p.host}:${p.port}${p.path ?? ''}`;
             const jsonRpcProvider = new ethers.providers.JsonRpcProvider(url);
             await jsonRpcProvider.ready;

--- a/src/pages/evm/staking/StakingPageHeader.vue
+++ b/src/pages/evm/staking/StakingPageHeader.vue
@@ -13,7 +13,6 @@ import { useRoute } from 'vue-router';
 
 const route = useRoute();
 
-const label = 'current';
 const { t: $t } = useI18n();
 const userStore = useUserStore();
 const balancesStore = useBalancesStore();
@@ -29,7 +28,7 @@ const stakedToken = chainSettings.getStakedSystemToken();
 
 
 // First cell: Staked
-const unstakedRatio = computed(() => chainStore.getUnstakedRatio(label));
+const unstakedRatio = computed(() => chainStore.getUnstakedRatio(CURRENT_CONTEXT));
 const isStakedLoading = computed(() => stakedTokenBalanceBn.value === undefined || unstakedRatio.value.isZero());
 const stakedExpressedInSystemBalanceBn = computed(() => {
     if (stakedTokenBalanceBn.value && !unstakedRatio.value.isZero()) {

--- a/src/pages/evm/staking/StakingPageHeader.vue
+++ b/src/pages/evm/staking/StakingPageHeader.vue
@@ -47,7 +47,7 @@ const stakedFiatValueBn = computed(() => {
     }
 });
 const stakedTokenBalanceBn = computed(() => {
-    const balances = balancesStore.getBalances(label);
+    const balances = balancesStore.getBalances(CURRENT_CONTEXT);
     const stakedTokenBalance = balances.find(balance => balance.token.symbol === stakedToken.symbol)?.amount;
     if (stakedTokenBalance) {
         return stakedTokenBalance;
@@ -56,7 +56,7 @@ const stakedTokenBalanceBn = computed(() => {
     }
 });
 const systemTokenPrice = computed(() => {
-    const balances = balancesStore.getBalances(label);
+    const balances = balancesStore.getBalances(CURRENT_CONTEXT);
     const systemTokenPriceBalance = balances.find(balance => balance.token.symbol === systemToken.symbol)?.token.price.value;
     if (systemTokenPriceBalance) {
         return systemTokenPriceBalance;
@@ -67,7 +67,7 @@ const systemTokenPrice = computed(() => {
 
 // Second cell: Unstaking
 const unstakingBalanceBn = computed(() => {
-    const rexData = useRexStore().getRexData(label);
+    const rexData = useRexStore().getRexData(CURRENT_CONTEXT);
     if (rexData) {
         const totalBalance = rexData.balance;
         const withdrawableBalance = rexData.withdrawable;
@@ -91,7 +91,7 @@ const unstakingFiatValueBn = computed(() => {
 const isUnstakingLoading = computed(() => unstakingBalanceBn.value === undefined);
 
 // Third cell: Withdrawable
-const withdrawableBalanceBn = computed(() => useRexStore().getRexData(label)?.withdrawable);
+const withdrawableBalanceBn = computed(() => useRexStore().getRexData(CURRENT_CONTEXT)?.withdrawable);
 const withdrawableFiatValueBn = computed(() => {
     if (withdrawableBalanceBn.value && systemTokenPrice.value && !systemTokenPrice.value.isZero()) {
         const ratioNumber = ethers.utils.formatUnits(systemTokenPrice.value, systemToken.price.decimals);
@@ -117,7 +117,7 @@ const unlockPeriod = computed(() => rexStore.getUnstakingPeriodString(CURRENT_CO
 const unlockPeriodLoading = computed(() => unlockPeriod.value === '--');
 
 const tvlAmountBn = computed(() => {
-    const totalStaking = useRexStore().getRexData(label)?.totalStaking;
+    const totalStaking = useRexStore().getRexData(CURRENT_CONTEXT)?.totalStaking;
     if (totalStaking) {
         return totalStaking;
     } else {
@@ -188,21 +188,21 @@ const intervalTimer = setInterval(() => {
     if (isStakedLoading.value) {
         // if staked balance is still undefined we force the balances update
         if (stakedTokenBalanceBn.value === undefined) {
-            balancesStore.updateBalances(label);
+            balancesStore.updateBalances(CURRENT_CONTEXT);
         }
         // if unstaked ratio is still zero we force the chain update
         if (unstakedRatio.value.isZero()) {
-            chainStore.updateStakedRatio(label);
+            chainStore.updateStakedRatio(CURRENT_CONTEXT);
         }
     }
     // is unstaking still loading?
     if (isUnstakingLoading.value || isWithdrawableLoading.value || unlockPeriodLoading.value) {
         // we need to update rex data
-        useRexStore().updateRexData(label);
+        useRexStore().updateRexData(CURRENT_CONTEXT);
     }
     if (apyisLoading.value) {
         // force apy update
-        chainStore.updateApy(label);
+        chainStore.updateApy(CURRENT_CONTEXT);
     }
 
     if (

--- a/src/pages/evm/staking/StakingTab.vue
+++ b/src/pages/evm/staking/StakingTab.vue
@@ -19,7 +19,6 @@ import ConversionRateBadge from 'src/components/ConversionRateBadge.vue';
 import CurrencyInput from 'src/components/evm/inputs/CurrencyInput.vue';
 import { WEI_PRECISION, formatWei } from 'src/antelope/stores/utils';
 
-const label = 'current';
 
 const { t: $t } = useI18n();
 const uiDecimals = 2;
@@ -43,7 +42,7 @@ const oneEth = ethers.BigNumber.from('1'.concat('0'.repeat(systemTokenDecimals))
 const inputModelValue = ref(ethers.constants.Zero);
 const estimatedGas = ref(ethers.constants.Zero);
 // computed
-const stakedRatio = computed(() => chainStore.getStakedRatio(label));
+const stakedRatio = computed(() => chainStore.getStakedRatio(CURRENT_CONTEXT));
 const outputModelValue = computed(() => {
     if (stakedRatio.value.isZero()) {
         return ethers.constants.Zero;

--- a/src/pages/evm/staking/UnstakingTab.vue
+++ b/src/pages/evm/staking/UnstakingTab.vue
@@ -19,8 +19,6 @@ import ConversionRateBadge from 'src/components/ConversionRateBadge.vue';
 import CurrencyInput from 'src/components/evm/inputs/CurrencyInput.vue';
 import { formatWei } from 'src/antelope/stores/utils';
 
-const label = 'current';
-
 const { t: $t } = useI18n();
 const uiDecimals = 2;
 const ant = getAntelope();
@@ -44,7 +42,7 @@ const oneEth = ethers.BigNumber.from('1'.concat('0'.repeat(systemTokenDecimals))
 const inputModelValue = ref(ethers.constants.Zero);
 
 // computed
-const unstakedRatio = computed(() => chainStore.getUnstakedRatio(label));
+const unstakedRatio = computed(() => chainStore.getUnstakedRatio(CURRENT_CONTEXT));
 const outputModelValue = computed(() => {
     if (unstakedRatio.value.isZero()) {
         return ethers.constants.Zero;


### PR DESCRIPTION
# Fixes #772

## Description
This PR fixes the bug described in the issue #772. The problem was that the global getWeb3Provider was returning the current authenticator's provider as the first option not taking into account that you may be using Metamask but at this moment it is pointing to another blockchain. So it does not work.

Now the only possible answer is a JsonRpcProvider which works pretty well for reading the blockchain contracts.

## Test scenarios
- Login into your Metamask and change the network to Ethereum
- Then visit this link. You will get a "not found" sign:
https://wallet.telos.net/evm/collectible-details?contract=0x63F8948c2Ee0670758A4E60EED80aAa6Cf093356&id=1141&tab=attributes

- Try then this link and you should see the NFT with no problems:
https://deploy-preview-775--wallet-develop-mainnet.netlify.app/evm/collectible-details?contract=0x63F8948c2Ee0670758A4E60EED80aAa6Cf093356&id=1141&tab=attributes

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
