### PR TITLE
#804 | update the access token for getting app list

### DIFF
--- a/src/pages/native/DappSearch.vue
+++ b/src/pages/native/DappSearch.vue
@@ -30,7 +30,7 @@ export default {
                 {
                     method: 'get',
                     headers: new Headers({
-                        Authorization: 'Bearer keyNqmiYA23tKoaYg',
+                        Authorization: 'Bearer patz11dDKRINCR9Zx.089980dbdb33422392f08c7a1f4938aa8f5a40be43fd88adf64784aa180f46bf',
                         'Content-Type': 'application/x-www-form-urlencoded',
                     }),
                 },


### PR DESCRIPTION
# Fixes #804 

## Description
This PR updates the access token for getting the server's dApps list.

## Test scenarios
- go to this [link](https://deploy-preview-806--wallet-develop-mainnet.netlify.app)https://deploy-preview-806--wallet-develop-mainnet.netlify.app/
- select Telos Zero tab
- login or view any account
- go to dApps on the menu
  - you should see a short list of old dapps

![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/c61925d6-3bf7-4b53-96db-e3914ebb4823)
