### PR TITLE
#791 | unstaked period says 10 days

### DIFF
--- a/src/antelope/stores/rex.ts
+++ b/src/antelope/stores/rex.ts
@@ -64,6 +64,10 @@ export const useRexStore = defineStore(store_name, {
                 state.__rexData[label]?.period ?? null,
                 // translation function only takes the key name, without the path and adds the prefix
                 (key:string) => getAntelope().config.localizationHandler(`antelope.words.${key}`),
+                // force to show days instead of being dynamic,
+                'days',
+                // force to round the number
+                true,
             ),
 
     },

--- a/src/antelope/stores/utils/date-utils.ts
+++ b/src/antelope/stores/utils/date-utils.ts
@@ -43,7 +43,7 @@ export function dateIsWithinXMinutes(epochMs: number, minutes: number) {
  * @param {function} $t translation function. Should accept a string (just the keyname without a path) and return a translated string
  * @returns {string} plain english time period
  */
-export function prettyTimePeriod(seconds: number|null, $t: (key: string) => string, round = false) {
+export function prettyTimePeriod(seconds: number|null, $t: (key: string) => string, units = '', round = false) {
     if (seconds === null) {
         return '--';
     }
@@ -51,19 +51,19 @@ export function prettyTimePeriod(seconds: number|null, $t: (key: string) => stri
     let quantity;
     let unit;
 
-    if (seconds < HOUR_SECONDS) {
+    if (seconds < HOUR_SECONDS || units === 'minutes') {
         quantity = seconds / MINUTE_SECONDS;
         unit = $t('minutes');
-    } else if (seconds < DAY_SECONDS) {
+    } else if (seconds < DAY_SECONDS || units === 'hours') {
         quantity = seconds / HOUR_SECONDS;
         unit = $t('hours');
-    } else if (seconds < WEEK_SECONDS) {
+    } else if (seconds < WEEK_SECONDS || units === 'days') {
         quantity = seconds / DAY_SECONDS;
         unit = $t('days');
-    } else if (seconds < MONTH_SECONDS) {
+    } else if (seconds < MONTH_SECONDS || units === 'weeks') {
         quantity = seconds / WEEK_SECONDS;
         unit = $t('weeks');
-    } else if (seconds < YEAR_SECONDS) {
+    } else if (seconds < YEAR_SECONDS || units === 'months') {
         quantity = seconds / MONTH_SECONDS;
         unit = $t('months');
     } else {


### PR DESCRIPTION
# Fixes #791

## Description
This PR changes the units of the unstaking period from weeks to days.

## Test scenarios
- https://deploy-preview-810--wallet-develop-mainnet.netlify.app/
- Go to Staking section
  - You should see 10 days instead of 1.4 weeks

## Screenshots

![image](https://github.com/telosnetwork/telos-wallet/assets/4420760/3a3c70f3-fe74-4549-bd97-63835692c1bd)

