### PR TITLE
We remove deprecated validation on fuel response

### DIFF
--- a/src/api/fuel.js
+++ b/src/api/fuel.js
@@ -137,15 +137,6 @@ class FuelUserWrapper extends User {
 
                 const fee/*: string | null*/ = data.fee;
 
-                // Ensure the modified transaction is what the application expects
-                // These validation methods will throw an exception if invalid data exists
-                validateTransaction(
-                    signer,
-                    modifiedTransaction,
-                    transaction,
-                    data.costs,
-                );
-
                 // validate with the user whether to use the service at all
                 try {
                     await confirmWithUser(this.user, fee);


### PR DESCRIPTION
# Fixes #817

## Description
This PR removes the validation of fuel service response because of a change in the policy. The previous validation was based on the fact that any RAM acquisition was charged to the user but now it's not clear when their rule applies.

## Test scenarios
Use a fresh account, send some TLOS to it and try to transfer those some to any valid account.
- You should not get an error
- You should get the needed resources covered by the Fuel service