### PR TITLE
Avoid fetching data from the wrong chain

### DIFF
--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -230,6 +230,11 @@ export const useAllowancesStore = defineStore(store_name, {
 
             const chainSettings = useChainStore().currentChain.settings as EVMChainSettings;
 
+            if (chainSettings.isNative()) {
+                this.trace('fetchAllowancesForAccount', 'Native chain does not have allowances');
+                return;
+            }
+
             const erc20AllowancesPromise   = chainSettings.fetchErc20Allowances(account, { limit: ALLOWANCES_LIMIT });
             const erc721AllowancesPromise  = chainSettings.fetchErc721Allowances(account, { limit: ALLOWANCES_LIMIT });
             const erc1155AllowancesPromise = chainSettings.fetchErc1155Allowances(account, { limit: ALLOWANCES_LIMIT });

--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -198,11 +198,14 @@ export const useHistoryStore = defineStore(store_name, {
             const contractStore = useContractStore();
 
             this.trace('fetchEvmNftTransfersForAccount', label);
-
-            feedbackStore.setLoading('history.fetchEvmNftTransfersForAccount');
-
             const chainSettings = useChainStore().getChain(label).settings as EVMChainSettings;
 
+            if (chainSettings.isNative()) {
+                this.trace('fetchEvmNftTransfersForAccount', 'Native networks not supported yet');
+                return;
+            }
+
+            feedbackStore.setLoading('history.fetchEvmNftTransfersForAccount');
             try {
                 // get all erc721 and erc1155 transfers for the given account
                 const [

--- a/src/antelope/stores/rex.ts
+++ b/src/antelope/stores/rex.ts
@@ -121,14 +121,26 @@ export const useRexStore = defineStore(store_name, {
             return this.getContractInstance(label, address);
         },
         /**
+         * This method should be called to check if the REX system is available for a given context.
+         * @param label identifies the context (network on this case) for the data
+         * @returns true if the REX system is available for the given context
+         */
+        isNetworkEVM(label: string) {
+            return !useChainStore().getChain(label).settings.isNative();
+        },
+        /**
          * This method queries the total amount of staked tokens in the system and maintains it in the store.
          * @param label identifies the context (network on this case) for the data
          */
         async updateTotalStaking(label: string) {
             this.trace('updateTotalStaking', label);
-            const contract = await this.getStakedSystemContractInstance(label);
-            const totalStaking = await contract.totalAssets();
-            this.setTotalStaking(label, totalStaking);
+            if (this.isNetworkEVM(label)) {
+                const contract = await this.getStakedSystemContractInstance(label);
+                const totalStaking = await contract.totalAssets();
+                this.setTotalStaking(label, totalStaking);
+            } else {
+                this.trace('updateTotalStaking', label, 'not supported for native chains yet');
+            }
         },
 
         /**
@@ -137,9 +149,13 @@ export const useRexStore = defineStore(store_name, {
          */
         async updateUnstakingPeriod(label: string) {
             this.trace('updateUnstakingPeriod', label);
-            const contract = await this.getEscrowContractInstance(label);
-            const period = await contract.lockDuration();
-            this.setUnstakingPeriod(label, period.toNumber());
+            if (this.isNetworkEVM(label)) {
+                const contract = await this.getEscrowContractInstance(label);
+                const period = await contract.lockDuration();
+                this.setUnstakingPeriod(label, period.toNumber());
+            } else {
+                this.trace('updateUnstakingPeriod', label, 'not supported for native chains yet');
+            }
         },
 
         /**
@@ -182,10 +198,14 @@ export const useRexStore = defineStore(store_name, {
          */
         async updateWithdrawable(label: string) {
             this.trace('updateWithdrawable', label);
-            const contract = await this.getEscrowContractInstance(label);
-            const address = useAccountStore().getAccount(label).account;
-            const withdrawable = await contract.maxWithdraw(address);
-            this.setWithdrawable(label, withdrawable);
+            if (this.isNetworkEVM(label)) {
+                const contract = await this.getEscrowContractInstance(label);
+                const address = useAccountStore().getAccount(label).account;
+                const withdrawable = await contract.maxWithdraw(address);
+                this.setWithdrawable(label, withdrawable);
+            } else {
+                this.trace('updateWithdrawable', label, 'not supported for native chains yet');
+            }
         },
         /**
          * This method queries the deposits for a given account and maintains it in the store.
@@ -195,10 +215,14 @@ export const useRexStore = defineStore(store_name, {
          */
         async updateDeposits(label: string) {
             this.trace('updateDeposits', label);
-            const contract = await this.getEscrowContractInstance(label);
-            const address = useAccountStore().getAccount(label).account;
-            const deposits = await contract.depositsOf(address);
-            this.setDeposits(label, deposits);
+            if (this.isNetworkEVM(label)) {
+                const contract = await this.getEscrowContractInstance(label);
+                const address = useAccountStore().getAccount(label).account;
+                const deposits = await contract.depositsOf(address);
+                this.setDeposits(label, deposits);
+            } else {
+                console.error('updateDeposits', label, 'not supported for native chains yet');
+            }
         },
         /**
          * This method queries the balance for a given account and maintains it in the store.
@@ -207,10 +231,14 @@ export const useRexStore = defineStore(store_name, {
          */
         async updateBalance(label: string) {
             this.trace('updateBalance', label);
-            const contract = await this.getEscrowContractInstance(label);
-            const address = useAccountStore().getAccount(label).account;
-            const balance = await contract.balanceOf(address);
-            this.setBalance(label, balance);
+            if (this.isNetworkEVM(label)) {
+                const contract = await this.getEscrowContractInstance(label);
+                const address = useAccountStore().getAccount(label).account;
+                const balance = await contract.balanceOf(address);
+                this.setBalance(label, balance);
+            } else {
+                console.error('updateBalance', label, 'not supported for native chains yet');
+            }
         },
         /**
          * utility function to get the number of decimals for the staked system token


### PR DESCRIPTION
# Fixes #815

## Description
this PR adds some checks to avoid fetching data from the wrong chain or fetching the same data repeatedly, avoiding it crashing and having erratic behavior.

## Test scenarios
- Go to [this link](https://deploy-preview-821--wallet-staging.netlify.app/)
- open the console
- change tabs from EVM to Zero and back
  - you should see no errors on the console
