### PR TITLE
#837 | approvals page is hitting the rate limit

### DIFF
--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -46,9 +46,9 @@ const W_TOKEN = new TokenClass({
 
 const RPC_ENDPOINT = {
     protocol: 'https',
-    host: 'testnet.telos.net',
+    host: 'rpc.testnet.telos.net',
     port: 443,
-    path: '/evm',
+    path: '/',
 };
 const ESCROW_CONTRACT_ADDRESS = '0x7E9cF9fBc881652B05BB8F26298fFAB538163b6f';
 const API_ENDPOINT = 'https://api-dev.telos.net/v1';

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -46,9 +46,9 @@ const W_TOKEN = new TokenClass({
 
 const RPC_ENDPOINT = {
     protocol: 'https',
-    host: 'mainnet.telos.net',
+    host: 'rpc.telos.net',
     port: 443,
-    path: '/evm',
+    path: '/',
 };
 const ESCROW_CONTRACT_ADDRESS = '0x95F5713A1422Aa3FBD3DCB8D553945C128ee3855';
 const API_ENDPOINT = 'https://api.telos.net/v1';

--- a/src/antelope/stores/allowances.ts
+++ b/src/antelope/stores/allowances.ts
@@ -21,7 +21,7 @@ import {
     TransactionResponse,
     isErc20AllowanceRow,
     isErc721SingleAllowanceRow,
-    isNftCollectionAllowanceRow,
+    isNftCollectionAllowanceRow, EvmContractFactoryData,
 } from 'src/antelope/types';
 import { createTraceFunction } from 'src/antelope/config';
 import EVMChainSettings from 'src/antelope/chains/EVMChainSettings';
@@ -252,6 +252,13 @@ export const useAllowancesStore = defineStore(store_name, {
             const erc20AllowancesData   = (allowancesResults[0] as IndexerAllowanceResponseErc20)?.results ?? [];
             const erc721AllowancesData  = (allowancesResults[1] as IndexerAllowanceResponseErc721)?.results ?? [];
             const erc1155AllowancesData = (allowancesResults[2] as IndexerAllowanceResponseErc1155)?.results ?? [];
+
+            // Load these in the cache so they're available later and we don't abuse the indexer API
+            allowancesResults.map((result) => {
+                for (const [address, contract] of Object.entries(result.contracts)) {
+                    useContractStore().createAndStoreContract(CURRENT_CONTEXT, address, contract as EvmContractFactoryData);
+                }
+            });
 
             const shapedErc20AllowanceRowPromises   = Promise.allSettled(erc20AllowancesData.map(allowanceData => this.shapeErc20AllowanceRow(allowanceData)));
             const shapedErc721AllowanceRowPromises  = Promise.allSettled(erc721AllowancesData.map(allowanceData => this.shapeErc721AllowanceRow(allowanceData)));

--- a/src/boot/antelope.ts
+++ b/src/boot/antelope.ts
@@ -78,7 +78,6 @@ export default boot(({ app }) => {
         next: async () => {
             // first recreate the authenticators based on the new network
             const zeroAuthenticators = app.config.globalProperties.recreateAuthenticator();
-            console.log('zeroAuthenticators', zeroAuthenticators);
             // set the new authenticators list
             ant.config.setAuthenticatorsGetter(() => zeroAuthenticators);
             for (const authenticator of zeroAuthenticators) {

--- a/src/boot/ual.js
+++ b/src/boot/ual.js
@@ -137,11 +137,9 @@ export default boot(async ({ app, store }) => {
 
 
     app.config.globalProperties.recreateAuthenticator = function() {
-        console.log('UAL.recreateAuthenticator()');
 
         if (useChainStore().currentChain.settings.isNative()) {
             const settings = useChainStore().currentNativeChain.settings;
-            console.log('UAL.recreateAuthenticator()', { settings });
 
             const ual_chain = {
                 chainId: settings.getChainId(),
@@ -164,7 +162,6 @@ export default boot(async ({ app, store }) => {
 
             return authenticators;
         } else {
-            console.log('UAL.recreateAuthenticator() - not native chain');
             return [];
         }
     };

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -301,6 +301,7 @@ export default {
         aside_content_fragment_4_bold: 'approvals ',
         aside_content_fragment_5: 'enable app functionality and enhance your user experience. However, it\'s prudent to review and manage these permissions to deter unauthorized transactions, adding a layer of security to your wallet.',
         revoke_selected: 'Revoke selected',
+        refresh: 'Refresh',
         search_label: 'Filter by token, allowance, spender, or contract address',
         includes_cancelled_allowances: 'Includes cancelled allowances',
         excludes_cancelled_allowances: 'Does not include cancelled allowances',

--- a/src/pages/evm/allowances/AllowancesPage.vue
+++ b/src/pages/evm/allowances/AllowancesPage.vue
@@ -149,23 +149,21 @@ const shapedAllowanceRows = computed(() => {
 
 const enableRevokeButton = computed(() => selectedRows.value.length > 0);
 
+const updateAllowances = () => {
+    loading.value = true;
+    return useAllowancesStore().fetchAllowancesForAccount(userAddress.value).then(() => {
+        loading.value = false;
+    });
+};
+
 // watchers
 watch(userAddress, (address) => {
     if (address) {
-        loading.value = true;
-        useAllowancesStore().fetchAllowancesForAccount(address).then(() => {
-            loading.value = false;
-        });
+        updateAllowances();
     }
 
 }, { immediate: true });
 
-// methods
-onMounted(() => {
-    timeout.value = setTimeout(() => {
-        useAllowancesStore().fetchAllowancesForAccount(userAddress.value);
-    }, 13000);
-});
 
 onBeforeUnmount(() => {
     if (timeout.value) {
@@ -230,7 +228,7 @@ function handleRevokeSelectedClicked() {
         cancelBatchRevokeButtonLoading.value = true;
 
         setTimeout(() => {
-            useAllowancesStore().fetchAllowancesForAccount(userAddress.value).finally(() => {
+            updateAllowances().finally(() => {
                 cancelBatchRevokeButtonLoading.value = false;
                 showRevokeInProgressModal.value = false;
 
@@ -264,9 +262,11 @@ function handleRevokeSelectedClicked() {
         <AllowancesPageControls
             v-if="!showEmptyState"
             :enable-revoke-button="enableRevokeButton"
+            :loading="loading"
             @search-updated="handleSearchUpdated"
             @include-cancelled-updated="handleIncludeCancelledUpdated"
             @revoke-selected="handleRevokeSelectedClicked"
+            @refresh="updateAllowances"
         />
 
         <div v-if="loading" class="q-mt-lg">

--- a/src/pages/evm/allowances/AllowancesPageControls.vue
+++ b/src/pages/evm/allowances/AllowancesPageControls.vue
@@ -5,11 +5,17 @@ import { useI18n } from 'vue-i18n';
 
 const { t: $t } = useI18n();
 
-const props = defineProps<{
+defineProps<{
     enableRevokeButton: boolean;
+    loading: boolean;
 }>();
 
-const emit = defineEmits(['revoke-selected', 'search-updated', 'include-cancelled-updated']);
+const emit = defineEmits([
+    'refresh',
+    'revoke-selected',
+    'search-updated',
+    'include-cancelled-updated',
+]);
 
 // data
 const searchText = ref('');
@@ -24,6 +30,11 @@ const includeCancelledLabel = computed(
 function handleRevokeSelected() {
     emit('revoke-selected');
 }
+
+function handleRefresh() {
+    emit('refresh');
+}
+
 </script>
 
 <template>
@@ -41,14 +52,33 @@ function handleRevokeSelected() {
         </template>
     </q-input>
 
-    <q-btn
-        :disable="!enableRevokeButton"
-        color="primary"
-        class="c-allowances-page-controls__revoke-button"
-        @click="handleRevokeSelected"
+    <div
+        class="c-allowances-page-controls__buttons"
     >
-        {{ $t('evm_allowances.revoke_selected') }}
-    </q-btn>
+        <!-- revoke button -->
+        <q-btn
+            :disable="!enableRevokeButton"
+            color="primary"
+            class="c-allowances-page-controls__buttons-btn"
+            @click="handleRevokeSelected"
+        >
+            {{ $t('evm_allowances.revoke_selected') }}
+        </q-btn>
+
+        <!-- refresh button -->
+        <q-btn
+            color="primary"
+            class="c-allowances-page-controls__buttons-btn"
+            icon="refresh"
+            :disable="loading"
+            :loading="loading"
+            @click="handleRefresh"
+        >
+            {{ $t('evm_allowances.refresh') }}
+        </q-btn>
+
+    </div>
+
 </div>
 
 <!-- https://github.com/telosnetwork/telos-wallet/issues/719 -->
@@ -80,7 +110,7 @@ function handleRevokeSelected() {
                 order: 2;
             }
 
-            #{$this}__revoke-button {
+            #{$this}__buttons {
                 order: 1;
             }
         }
@@ -92,9 +122,10 @@ function handleRevokeSelected() {
         max-width: 580px;
     }
 
-    &__revoke-button {
-        width: max-content;
+    &__buttons {
         flex-shrink: 0;
+        display: flex;
+        gap: 16px;
     }
 }
 </style>


### PR DESCRIPTION
# Fixes #837

## Description
This PR removes the update loop on the approvals page. Instead, a Refresh button was added to allow the user to update the approvals data without reloading the whole website.

[telos-wallet--approvals-refresh-btn.webm](https://github.com/user-attachments/assets/a9a635bb-5218-4924-9bad-7e2719955fd4)
