### PR TITLE
#845 | The "bridging" banner remembers if the close button was used to not be shown again.

### DIFF
--- a/src/pages/native/BalanceInfo.vue
+++ b/src/pages/native/BalanceInfo.vue
@@ -771,6 +771,7 @@ export default {
                     rounded
                     :inline-actions="!$q.screen.lt.md || showEVMBridgeWarningTitle"
                     class="bg-purple-8 text-white"
+                    @click="showEVMBridgeWarningTitle = false"
                 >
 
                     <template v-slot:avatar>
@@ -784,7 +785,6 @@ export default {
                     <span
                         v-if="showEVMBridgeWarningTitle"
                         class="text-h6"
-                        @click="showEVMBridgeWarningTitle = false"
                     >
                         Bridging your TLOS
                     </span>

--- a/src/pages/native/BalanceInfo.vue
+++ b/src/pages/native/BalanceInfo.vue
@@ -158,8 +158,7 @@ export default {
             ) {
                 await this.getUserProfile(this.accountName);
             }
-            const accountProfile =
-        this.$store.state.account.profiles[this.accountName];
+            const accountProfile = this.$store.state.account.profiles[this.accountName];
             if (!accountProfile) {
                 return;
             }
@@ -588,6 +587,11 @@ export default {
             await this.loadNftTokenItems();
             this.loadNftTokenTags();
         },
+        setShowEVMBridgeWarning(value) {
+            this.showEVMBridgeWarning = value;
+            this.showEVMBridgeWarningTitle = value;
+            localStorage.setItem('showEVMBridgeWarning', value);
+        },
     },
     created: async function () {
         this.interval = setInterval(() => {
@@ -640,10 +644,14 @@ export default {
         this.showEVMBridgeWarningTitle = this.$q.screen.lt.md;
     },
     beforeMount() {
-        this.coinViewHeight =
-      window.innerHeight - this.footerHeight - this.maxSpace;
+        this.coinViewHeight = window.innerHeight - this.footerHeight - this.maxSpace;
     },
     async mounted() {
+        const showEVMBridgeWarning = localStorage.getItem('showEVMBridgeWarning');
+        if (showEVMBridgeWarning === 'false') {
+            this.showEVMBridgeWarning = false;
+            this.showEVMBridgeWarningTitle = false;
+        }
         this.loadUserProfile();
         this.$emitter.on('successfully_sent', (sendAmount, toAddress) => {
             this.showSendAmountDlg = false;
@@ -796,7 +804,7 @@ export default {
                             flat
                             round
                             icon="close"
-                            @click="showEVMBridgeWarning = false"
+                            @click="setShowEVMBridgeWarning(false)"
                         />
                     </template>
                 </q-banner>


### PR DESCRIPTION
# Fixes #845

## Description
The sign with the "Bridging" text now remembers if the user presses the close button, so it will never be shown again.

## Test scenarios
- Login on Telos Zero
- close the "Bridging" text
- Reload the page
- The sign should not be visible again
https://deploy-preview-846--wallet-develop-mainnet.netlify.app/
![image](https://github.com/user-attachments/assets/dd4d6e14-2af7-4389-b051-2378f9f4ff98)

