### PR TITLE
#848 | Transaction history is always fetched

### DIFF
--- a/src/antelope/stores/history.ts
+++ b/src/antelope/stores/history.ts
@@ -102,6 +102,7 @@ export const useHistoryStore = defineStore(store_name, {
             const ant = getAntelope();
             self.clearEvmNftTransfers(CURRENT_CONTEXT);
             self.clearEvmTransactions(CURRENT_CONTEXT);
+            self.clearEVMTransactionsFilter();
             ant.events.onAccountChanged.subscribe({
                 next: ({ account }) => {
                     if (account) {
@@ -112,6 +113,7 @@ export const useHistoryStore = defineStore(store_name, {
             ant.events.onClear.subscribe(({ label }) => {
                 self.clearEvmTransactions(label);
                 self.clearEvmNftTransfers(label);
+                self.clearEVMTransactionsFilter();
             });
         },
         // actions ---
@@ -451,6 +453,13 @@ export const useHistoryStore = defineStore(store_name, {
         setEVMTransactionsFilter(filter: IndexerTransactionsFilter) {
             this.trace('setEVMFilter', filter);
             useHistoryStore().__evm_filter = filter;
+        },
+        clearEVMTransactionsFilter() {
+            this.trace('clearEVMFilter');
+            this.__evm_last_filter_used = null;
+            this.__evm_filter = {
+                address: '',
+            };
         },
         setEVMTransactions(label: Label, transactions: EvmTransaction[]) {
             this.trace('setTransactions', label, transactions);


### PR DESCRIPTION
# Fixes #848

## Description
There's a filter used to fetch a specific transactions page, and it is remembered until the next fetch attempt. If that filter remains the same, the actual fetch does not happen.

The problem with logging out and logging in again is that this remembered filter was not cleared on logout.

## Test scenarios
- Go to https://deploy-preview-849--wallet-staging.netlify.app
- Login using Metamask
- go to the Transactions tab
  - You should see the transactions first page
- Log out, Login and go again to Transactions tab
  - You should see the transactions' first page again
- Refresh the page without leaving
  - You should see the transactions' first page again

## Screenshots

![image](https://github.com/user-attachments/assets/36586f4b-450b-48ae-8151-f39ae442e989)

