### PR TITLE
#118 | cleos command message updated

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -530,6 +530,7 @@ export default {
         '0x7825e833D495F3d1c28872415a4aee339D26AC88',
         is_sent_to: '{quantity} is sent to {address}',
         failed_to_send: 'Failed to send {quantity} to {address}',
+        execute_cleos_command: 'Execute your transaction in CLEOS to proceed',
         to_network: 'To Network',
         memo: 'Memo',
         minimun_to_transfer: 'Minimum of $100 for mainnet TLOS to Ethereum Transfers',

--- a/src/pages/native/balance/SendConfirm.vue
+++ b/src/pages/native/balance/SendConfirm.vue
@@ -131,10 +131,14 @@ export default {
                     actions,
                     `Send ${quantityStr} to ${this.toAddress}`,
                 );
-                this.$successNotification(this.$t('components.is_sent_to', {
-                    quantity: quantityStr,
-                    address: this.toAddress,
-                }));
+                if (transaction.wasBroadcast) {
+                    this.$successNotification(this.$t('components.is_sent_to', {
+                        quantity: quantityStr,
+                        address: this.toAddress,
+                    }));
+                } else {
+                    this.$successNotification(this.$t('components.execute_cleos_command'));
+                }
                 this.$emitter.emit('successfully_sent', this.sendAmount, this.toAddress);
             } catch (error) {
                 this.$errorNotification(error);


### PR DESCRIPTION
# Fixes #118

## Description
This PR fixes the message displayed when instead of actually sending a signed transaction the cleos authenticator is used.

![image](https://github.com/user-attachments/assets/6edcc039-8b4e-4457-a01c-aa97685f70fa)
