### PR TITLE
fix: update EVM RPC endpoint from mainnet.telos.net to rpc.telos.net

### DIFF
--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -56,7 +56,7 @@ const WEI_PRECISION = 18;
 const EXPLORER_URL = 'https://teloscan.io';
 const ECOSYSTEM_URL = 'https://www.telos.net/ecosystem';
 const BRIDGE_URL = 'https://bridge.telos.net/bridge';
-const NETWORK_EVM_ENDPOINT = 'https://mainnet.telos.net';
+const NETWORK_EVM_ENDPOINT = 'https://rpc.telos.net';
 const INDEXER_ENDPOINT = 'https://api.teloscan.io';
 const CONTRACTS_BUCKET = 'https://verified-evm-contracts.s3.amazonaws.com';
 

--- a/src/pages/native/balance/DepositEVM.vue
+++ b/src/pages/native/balance/DepositEVM.vue
@@ -56,7 +56,7 @@ export default {
                             symbol: 'TLOS',
                             decimals: 4,
                         },
-                        rpcUrls: ['https://mainnet.telos.net/evm'],
+                        rpcUrls: ['https://rpc.telos.net'],
                         blockExplorerUrls: ['https://teloscan.io'],
                     },
                 ];


### PR DESCRIPTION
The mainnet.telos.net/evm endpoint is no longer available (returns 404). Updated to use rpc.telos.net which is the current EVM RPC endpoint.