### PR TITLE
Remove staking APY percentage for zero-inflation era

### DIFF
--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -305,14 +305,6 @@ export default defineComponent({
                     aria-hidden="true"
                 >
                 {{ $t('nav.staking') }}
-                <span class="c-app-nav__apy-box">  {{ $t('evm_stake.apy_card_label') }}
-                    <q-spinner
-                        v-if="isLoadingApy"
-                        color="white"
-                        class="c-app-nav__apy-spinner"
-                    />
-                    <b> {{ prettyPrintApy }}</b>
-                </span>
             </li>
 
             <li

--- a/src/pages/evm/staking/StakingPageHeader.vue
+++ b/src/pages/evm/staking/StakingPageHeader.vue
@@ -160,13 +160,6 @@ const firstLineData = computed(() => [{
 }]);
 
 const secondLineData = computed(() => [{
-    label: $t('evm_stake.apy_card_label', { symbol: systemToken.symbol }),
-    tooltip: $t('evm_stake.apy_card_tooltip', { stakedSymbol: stakedToken.symbol, systemSymbol: systemToken.symbol }),
-    secondaryText: apyPrittyPrint.value,
-    lowContrastSecondaryText: false,
-    isSecondaryLoading: apyisLoading.value,
-    useSmallBox: true,
-}, {
     label: $t('evm_stake.unstaking_period_card_label'),
     tooltip: $t('evm_stake.unstaking_period_card_tooltip', { stakedSymbol: stakedToken.symbol, systemSymbol: systemToken.symbol }),
     secondaryText: unlockPeriod.value,

--- a/src/pages/native/balance/RexStaking.vue
+++ b/src/pages/native/balance/RexStaking.vue
@@ -12,7 +12,7 @@ export default {
             tokenAmount: 0,
             tokenRexBalance: 0,
             rpc: null,
-            apyString: 'Earn up to 13% APY',
+            apyString: '',
         };
     },
     computed: {
@@ -106,16 +106,8 @@ export default {
         },
 
         async setApy() {
-            try{
-                const telosApi = axios.create({
-                    baseURL: useChainStore().currentChain.settings.getApiEndpoint(),
-                });
-                const apy = (await telosApi.get('apy/native')).data;
-                const earn = this.$t('components.earn');
-                this.apyString = `${earn} ${apy}% APY`;
-            }catch(e) {
-                console.error(e);
-            }
+            // Zero inflation era: no staking rewards, APY is 0%
+            this.apyString = '';
         },
 
         async tryStake() {
@@ -183,9 +175,6 @@ export default {
             <div ></div>
         </div>
         <div class="text-center">
-            <div class="text-subtitle2 text-grey-4 text-center q-mb-sm">
-                {{ apyString }}
-            </div>
             <q-btn-toggle
                 v-model="staking"
                 color="dark"


### PR DESCRIPTION
## Summary

With the zero-inflation era now live, no new TLOS is being minted. The staking APY displays throughout the wallet are now misleading (showing outdated percentages from the API). This PR removes the APY percentage displays.

## Changes

### `src/pages/native/balance/RexStaking.vue`
- Removed "Earn up to X% APY" text from REX staking dialog
- Removed API call to fetch native APY

### `src/pages/evm/staking/StakingPageHeader.vue`
- Removed APY card from the staking page second row

### `src/components/evm/AppNav.vue`
- Removed APY percentage badge from the staking navigation item

## What remains
- All staking/unstaking functionality is unchanged
- Users can still stake TLOS to sTLOS and unstake
- Only the misleading APY percentage displays are removed

## Context
Telos has entered the zero-inflation era — no new TLOS tokens are minted. The previous staking rewards came from inflation, which no longer exists.