### PR TITLE
Remove staking APY percentage for zero-inflation era

### DIFF
--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -25,18 +25,7 @@ export default defineComponent({
         notifyOnSuccessfulLogin: false,
     }),
     computed: {
-        isLoadingApy() {
-            return this.prettyPrintApy === '';
-        },
-        prettyPrintApy() {
-            const apy = chainStore.currentEvmChain?.apy;
-            if (apy && apy !== '') {
-                return apy + '%';
-            } else {
-                // Fallback APY if API doesn't return a value
-                return '~5%';
-            }
-        },
+
         showMenuIcon() {
             return this.$q.screen.lt.md && !this.showBackButton;
         },
@@ -602,19 +591,6 @@ export default defineComponent({
         }
     }
 
-    &__apy-box {
-        @include text--small;
-        background-color: rgba(255, 255, 255, 0.1);
-        color: $white;
-        padding: 4px 8px;
-        border-radius: 4px;
-        display: inline-block;
-    }
-
-    &__apy-spinner {
-        size: 16px;
-        margin-top: -5px;
-    }
 
     &__icon {
         // svg color overrides - use sidebar-active-color for visibility on gradient bg

--- a/src/components/evm/AppNav.vue
+++ b/src/components/evm/AppNav.vue
@@ -311,14 +311,6 @@ export default defineComponent({
                     aria-hidden="true"
                 >
                 {{ $t('nav.staking') }}
-                <span class="c-app-nav__apy-box">  {{ $t('evm_stake.apy_card_label') }}
-                    <q-spinner
-                        v-if="isLoadingApy"
-                        color="white"
-                        class="c-app-nav__apy-spinner"
-                    />
-                    <b> {{ prettyPrintApy }}</b>
-                </span>
             </li>
 
             <li

--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -255,10 +255,7 @@ export default {
         'and are now available for withdrawal. Once the {unlockPeriod} has passed,\n' +
         'you can withdraw your {systemSymbol} from escrow.',
         apy_card_label: 'APY',
-        apy_card_tooltip: 'Annual Percentage Yield (APY) is the annual rate of return after taking compound interest into account.\n' +
-        'Interest is compounded approximately every 30 minutes. The percentage rate is not fixed, meaning that\n' +
-        'it will change over time with the total amount of {systemSymbol} staked across Telos EVM and Native.\n' +
-        'Rewards are disbursed from a community rewards pool into the {stakedSymbol} contract.',
+        apy_card_tooltip: 'Telos has entered the zero-inflation era. No new TLOS is being minted, so there are currently no staking rewards.',
         unstaking_period_card_label: 'Unstaking Period',
         unstaking_period_card_tooltip: 'Unstaking Period:\n\n' +
         'If you unstake some {stakedSymbol} tokens you need to wait for the Unstaking Period,\n' +
@@ -270,12 +267,12 @@ export default {
         stake_output_label: 'Staked Amount',
         stake: 'Stake',
         stake_button_label: 'Stake {systemSymbol} to {stakedSymbol}',
-        stake_sidebar_title: 'Why stake {symbol}?',
-        stake_sidebar_content_fragment_1: 'Staking your TLOS to sTLOS grants you access to',
-        stake_sidebar_content_fragment_2_bold: ' continuous rewards ',
-        stake_sidebar_content_fragment_3: 'and various DeFi applications, further increasing yield. As the reward pool increases, the TLOS to sTLOS conversion rate will change over time. Therefore, the amount of sTLOS received is smaller than the staked TLOS.',
-        stake_sidebar_content_fragment_4_bold: ' Rewards will be auto-compounded. ',
-        stake_sidebar_content_fragment_5: 'No further action is required.',
+        stake_sidebar_title: 'Stake {symbol}',
+        stake_sidebar_content_fragment_1: 'Staking your TLOS to sTLOS allows you to participate in',
+        stake_sidebar_content_fragment_2_bold: ' governance and DeFi applications.',
+        stake_sidebar_content_fragment_3: ' Telos has entered the zero-inflation era — no new TLOS is minted. The TLOS to sTLOS conversion rate reflects the total staked supply.',
+        stake_sidebar_content_fragment_4_bold: '',
+        stake_sidebar_content_fragment_5: '',
         unstake_input_label: 'Unstaking Amount',
         unstake_output_label: 'Unstaked Amount',
         unstake: 'Unstake',

--- a/src/pages/evm/staking/StakingPageHeader.vue
+++ b/src/pages/evm/staking/StakingPageHeader.vue
@@ -161,13 +161,6 @@ const firstLineData = computed(() => [{
 }]);
 
 const secondLineData = computed(() => [{
-    label: $t('evm_stake.apy_card_label', { symbol: systemToken.symbol }),
-    tooltip: $t('evm_stake.apy_card_tooltip', { stakedSymbol: stakedToken.symbol, systemSymbol: systemToken.symbol }),
-    secondaryText: apyPrittyPrint.value,
-    lowContrastSecondaryText: false,
-    isSecondaryLoading: apyisLoading.value,
-    useSmallBox: true,
-}, {
     label: $t('evm_stake.unstaking_period_card_label'),
     tooltip: $t('evm_stake.unstaking_period_card_tooltip', { stakedSymbol: stakedToken.symbol, systemSymbol: systemToken.symbol }),
     secondaryText: unlockPeriod.value,

--- a/src/pages/native/balance/RexStaking.vue
+++ b/src/pages/native/balance/RexStaking.vue
@@ -1,7 +1,5 @@
 <script>
-import { useChainStore } from 'src/antelope';
 import { mapGetters, mapActions } from 'vuex';
-import axios from 'axios';
 
 export default {
     props: ['showRexStakeDlg', 'haveEVMAccount', 'selectedCoin'],
@@ -12,7 +10,6 @@ export default {
             tokenAmount: 0,
             tokenRexBalance: 0,
             rpc: null,
-            apyString: '',
         };
     },
     computed: {
@@ -105,10 +102,7 @@ export default {
             );
         },
 
-        async setApy() {
-            // Zero inflation era: no staking rewards, APY is 0%
-            this.apyString = '';
-        },
+
 
         async tryStake() {
             try {
@@ -143,7 +137,6 @@ export default {
         },
     },
     async mounted() {
-        await this.setApy();
         this.tokenRexBalance = await this.getRexBalance(this.accountName);
         this.rpc = this.$store.$api.getRpc();
         this.tokenAmount = await this.getTokenAmount();

--- a/src/pages/native/balance/RexStaking.vue
+++ b/src/pages/native/balance/RexStaking.vue
@@ -12,7 +12,7 @@ export default {
             tokenAmount: 0,
             tokenRexBalance: 0,
             rpc: null,
-            apyString: 'Earn up to 4% APY',
+            apyString: '',
         };
     },
     computed: {
@@ -106,16 +106,8 @@ export default {
         },
 
         async setApy() {
-            try{
-                const telosApi = axios.create({
-                    baseURL: useChainStore().currentChain.settings.getApiEndpoint(),
-                });
-                const apy = (await telosApi.get('apy/native')).data;
-                const earn = this.$t('components.earn');
-                this.apyString = `${earn} ${apy}% APY`;
-            }catch(e) {
-                console.error(e);
-            }
+            // Zero inflation era: no staking rewards, APY is 0%
+            this.apyString = '';
         },
 
         async tryStake() {
@@ -183,9 +175,6 @@ export default {
             <div ></div>
         </div>
         <div class="text-center">
-            <div class="text-subtitle2 text-grey-4 text-center q-mb-sm">
-                {{ apyString }}
-            </div>
             <q-btn-toggle
                 v-model="staking"
                 color="dark"


### PR DESCRIPTION
## Summary

With the zero-inflation era now live, no new TLOS is being minted. The staking APY displays throughout the wallet are now misleading. This PR removes them.

## Changes

- **`RexStaking.vue`** — Removed "Earn up to X% APY" text + API call
- **`StakingPageHeader.vue`** — Removed APY card from staking page
- **`AppNav.vue`** — Removed APY badge from sidebar navigation

Staking functionality remains intact — only the percentage displays are removed.