### PR TITLE
feat: add Telos Privacy network option redirect

### DIFF
--- a/src/pages/home/HomePage.vue
+++ b/src/pages/home/HomePage.vue
@@ -22,7 +22,11 @@ interface Network {
     value: string;
     tab: string;
     chain: ChainSettings;
+    redirectUrl?: string;
+    display?: string;
 }
+
+const TELOS_PRIVACY_URL = 'https://zkwallet.telos.net';
 
 const networks = [
     {
@@ -44,6 +48,13 @@ const networks = [
         value: 'telos-testnet',
         tab: 'zero',
         chain: settings['telos-testnet'],
+    },
+    {
+        value: 'telos-privacy',
+        tab: 'zero',
+        chain: settings['telos'],
+        display: 'Telos Privacy',
+        redirectUrl: TELOS_PRIVACY_URL,
     },
 ] as Network[];
 
@@ -73,6 +84,11 @@ onMounted(() => {
 
 watch(selectedNetwork, () => {
     if (selectedNetwork.value) {
+        if (selectedNetwork.value.redirectUrl) {
+            window.location.href = selectedNetwork.value.redirectUrl;
+            return;
+        }
+
         chainStore.setChain(CURRENT_CONTEXT, selectedNetwork.value.value);
         const login = selectedNetwork.value.tab;
         const network = selectedNetwork.value.value;
@@ -109,7 +125,7 @@ watch(selectedNetwork, () => {
                             label-color="grey"
                         >
                             <template v-slot:selected>
-                                <span>{{ selectedNetwork?.chain.getDisplay() }}</span>
+                                <span>{{ selectedNetwork?.display || selectedNetwork?.chain.getDisplay() }}</span>
                             </template>
 
                             <template v-slot:option="scope">
@@ -117,7 +133,7 @@ watch(selectedNetwork, () => {
                                     <q-avatar :size="'32px'" :src="scope.opt.chain.getSmallLogoPath()" class="c-home__network-selector-op-icon">
                                         <img class="c-home__network-selector-op-icon" :src="scope.opt.chain.getSmallLogoPath()">
                                     </q-avatar>
-                                    <q-item-label class="c-home__network-selector-op-name">{{ scope.opt.chain.getDisplay() }}</q-item-label>
+                                    <q-item-label class="c-home__network-selector-op-name">{{ scope.opt.display || scope.opt.chain.getDisplay() }}</q-item-label>
                                 </q-item>
                             </template>
                         </q-select>

--- a/src/pages/home/HomePage.vue
+++ b/src/pages/home/HomePage.vue
@@ -35,6 +35,13 @@ const networks = [
         chain: settings['telos-evm'],
     },
     {
+        value: 'telos-privacy',
+        tab: 'zero',
+        chain: settings['telos'],
+        display: 'Telos Privacy',
+        redirectUrl: TELOS_PRIVACY_URL,
+    },
+    {
         value: 'telos',
         tab: 'zero',
         chain: settings['telos'],
@@ -48,13 +55,6 @@ const networks = [
         value: 'telos-testnet',
         tab: 'zero',
         chain: settings['telos-testnet'],
-    },
-    {
-        value: 'telos-privacy',
-        tab: 'zero',
-        chain: settings['telos'],
-        display: 'Telos Privacy',
-        redirectUrl: TELOS_PRIVACY_URL,
     },
 ] as Network[];
 


### PR DESCRIPTION
## Summary\n- add a "Telos Privacy" option to the home network dropdown\n- redirect users to https://zkwallet.telos.net when selected\n- preserve existing in-app chain switching for all other network options\n\n## Testing\n- verified the dropdown renders the new option label\n- verified selection path special-cases redirect options instead of calling setChain()\n