### PR TITLE
Fix stale Telos EVM RPC URLs

### DIFF
--- a/src/antelope/chains/evm/telos-evm-testnet/index.ts
+++ b/src/antelope/chains/evm/telos-evm-testnet/index.ts
@@ -58,6 +58,7 @@ const ECOSYSTEM_URL = 'https://www.telos.net/ecosystem';
 const BRIDGE_URL = 'https://telos-bridge-testnet.netlify.app/bridge';
 
 const NETWORK_EVM_ENDPOINT = 'https://testnet.telos.net';
+const EVM_RPC_ENDPOINT = 'https://rpc.testnet.telos.net';
 const INDEXER_ENDPOINT = 'https://api.testnet.teloscan.io';
 const CONTRACTS_BUCKET = 'https://verified-evm-contracts-testnet.s3.amazonaws.com';
 
@@ -82,6 +83,10 @@ export default class TelosEVMTestnet extends EVMChainSettings {
 
     getHyperionEndpoint(): string {
         return NETWORK_EVM_ENDPOINT;
+    }
+
+    getEvmRpcEndpoint(): string | null {
+        return EVM_RPC_ENDPOINT;
     }
 
     getRPCEndpoint(): RpcEndpoint {

--- a/src/antelope/chains/evm/telos-evm/index.ts
+++ b/src/antelope/chains/evm/telos-evm/index.ts
@@ -53,9 +53,9 @@ const RPC_ENDPOINT = {
 
 // Fallback RPC endpoints for redundancy
 const FALLBACK_RPC_ENDPOINTS = [
-    { protocol: 'https', host: 'mainnet.telos.net', port: 443, path: '/evm' },
+    { protocol: 'https', host: 'rpc1.us.telos.net', port: 443, path: '/' },
     { protocol: 'https', host: 'telos.drpc.org', port: 443, path: '/' },
-    { protocol: 'https', host: 'rpc1.us.telos.net', port: 443, path: '/evm' },
+    { protocol: 'https', host: 'rpc.telos.net', port: 443, path: '/' },
 ];
 const ESCROW_CONTRACT_ADDRESS = '0x95F5713A1422Aa3FBD3DCB8D553945C128ee3855';
 const API_ENDPOINT = 'https://api.telos.net/v1';

--- a/src/boot/wagmi.ts
+++ b/src/boot/wagmi.ts
@@ -1,10 +1,53 @@
 import { boot } from 'quasar/wrappers';
 import { configureChains, createConfig } from '@wagmi/core';
-import { telos, telosTestnet } from '@wagmi/core/chains';
+import type { Chain } from '@wagmi/core/chains';
 import { w3mProvider, w3mConnectors, EthereumClient } from '@web3modal/ethereum';
 import { Web3ModalConfig } from '@web3modal/html';
 
 const projectId = process.env.PROJECT_ID || '';
+const telos: Chain = {
+    id: 40,
+    name: 'Telos',
+    network: 'telos',
+    nativeCurrency: {
+        decimals: 18,
+        name: 'Telos',
+        symbol: 'TLOS',
+    },
+    rpcUrls: {
+        default: { http: ['https://rpc.telos.net'] },
+        public: { http: ['https://rpc.telos.net'] },
+    },
+    blockExplorers: {
+        default: { name: 'Teloscan', url: 'https://www.teloscan.io/' },
+    },
+    contracts: {
+        multicall3: {
+            address: '0xcA11bde05977b3631167028862bE2a173976CA11' as `0x${string}`,
+            blockCreated: 246530709,
+        },
+    },
+};
+
+const telosTestnet: Chain = {
+    id: 41,
+    name: 'Telos',
+    network: 'telosTestnet',
+    nativeCurrency: {
+        decimals: 18,
+        name: 'Telos',
+        symbol: 'TLOS',
+    },
+    rpcUrls: {
+        default: { http: ['https://rpc.testnet.telos.net'] },
+        public: { http: ['https://rpc.testnet.telos.net'] },
+    },
+    blockExplorers: {
+        default: { name: 'Teloscan (testnet)', url: 'https://testnet.teloscan.io/' },
+    },
+    testnet: true,
+};
+
 const chains = [telos, telosTestnet];
 
 const { publicClient } = configureChains(chains, [w3mProvider({ projectId })]);

--- a/src/pages/native/balance/DepositEVM.vue
+++ b/src/pages/native/balance/DepositEVM.vue
@@ -42,7 +42,7 @@ export default {
                             symbol: 'TLOS',
                             decimals: 4,
                         },
-                        rpcUrls: ['https://testnet.telos.net/evm'],
+                        rpcUrls: ['https://rpc.testnet.telos.net'],
                         blockExplorerUrls: ['https://testnet.teloscan.io'],
                     },
                 ];
@@ -56,7 +56,7 @@ export default {
                             symbol: 'TLOS',
                             decimals: 4,
                         },
-                        rpcUrls: ['https://mainnet.telos.net/evm'],
+                        rpcUrls: ['https://rpc.telos.net'],
                         blockExplorerUrls: ['https://teloscan.io'],
                     },
                 ];


### PR DESCRIPTION
Follow-up to #866.

## Summary
- Define local Telos wagmi chain metadata so wagmi/viem uses `https://rpc.telos.net` and `https://rpc.testnet.telos.net` instead of dependency-provided stale URLs.
- Update `wallet_addEthereumChain` RPC URLs for Telos mainnet/testnet.
- Remove the deprecated `/evm` endpoints from the Telos EVM chain fallbacks and add a testnet EVM RPC override.

## Root Cause
The earlier RPC fix only changed the app's own `EVMChainSettings.doRPC()` path. WalletConnect/wagmi balance calls still used Telos chain metadata imported from `@wagmi/core/chains`, and that dependency metadata still pointed at deprecated endpoints: `https://mainnet.telos.net/evm` and `https://testnet.telos.net/evm`. Those endpoints now return 404, which caused EVM staking and token balance calls to fail even though other app-owned RPC calls had already been moved to `rpc.telos.net`.

## Validation
- `git diff --check`
- Source scan confirms no remaining `mainnet.telos.net/evm` or `testnet.telos.net/evm` references outside generated/vendor assets.
- `yarn build`
- Verified the old `/evm` endpoints return 404 and the replacement RPC endpoints respond to JSON-RPC calls.