### PR TITLE
Fix withdraw button state after failed request

### DIFF
--- a/src/antelope/stores/utils/abi/escrowAbi.ts
+++ b/src/antelope/stores/utils/abi/escrowAbi.ts
@@ -18,6 +18,6 @@ export const escrowAbiRead: any[] = [
     'function lockDuration() view returns (uint256)',
     'function maxWithdraw(address owner) view returns (uint256)',
     'function balanceOf(address account) view returns (uint256)',
-    'function depositsOf(address account) view returns (tuple(uint256 amount, uint256 timestamp)[])',
+    'function depositsOf(address account) view returns (tuple(uint256 amount, uint256 until)[])',
     'function withdraw()',
 ];

--- a/src/pages/evm/staking/WithdrawTab.vue
+++ b/src/pages/evm/staking/WithdrawTab.vue
@@ -35,24 +35,26 @@ const loading = computed(() => feed.isLoading('withdrawEVMSystemTokens'));
 const allWithdrawals = computed(() => rexStore.getEvmRexData(CURRENT_CONTEXT)?.deposits ?? []);
 
 // prettyPrintToken(unstakingBalanceBn.value, systemToken.symbol)
-const withdrawableBalanceBn = computed(() => useRexStore().getRexData(CURRENT_CONTEXT)?.withdrawable ?? ethers.constants.Zero);
+const withdrawableBalanceBn = computed(() => rexStore.getRexData(CURRENT_CONTEXT)?.withdrawable ?? ethers.constants.Zero);
 
 // enable only if withdrawableBalanceBn > 0 and not loading
-const withdrawEnabled = computed(() => !waitingForResult.value && withdrawableBalanceBn.value.gt(ethers.constants.Zero) && !loading.value);
+const hasWithdrawableBalance = computed(() => withdrawableBalanceBn.value.gt(ethers.constants.Zero));
+const withdrawEnabled = computed(() => hasWithdrawableBalance.value && !waitingForResult.value && !loading.value);
+const withdrawButtonLabel = computed(() => (hasWithdrawableBalance.value ? 'evm_stake.withdraw_button_enabled' : 'evm_stake.withdraw_button_disabled'));
 
 // hadle withdraw button click
 const handleWithdrawClick = async () => {
-    if (!withdrawEnabled.value || loading.value) {
+    if (!withdrawEnabled.value) {
         return;
     }
     const label = CURRENT_CONTEXT;
-    if (!await useAccountStore().assertNetworkConnection(label)) {
+    if (!await accountStore.assertNetworkConnection(label)) {
         return;
     }
 
     try {
         waitingForResult.value = true;
-        const tx = await useRexStore().withdrawEVMSystemTokens(CURRENT_CONTEXT, withdrawableBalanceBn.value);
+        const tx = await rexStore.withdrawEVMSystemTokens(CURRENT_CONTEXT, withdrawableBalanceBn.value);
         const formattedAmount = formatWei(withdrawableBalanceBn.value, systemTokenDecimals, 4);
 
         const dismiss = ant.config.notifyNeutralMessageHandler(
@@ -63,13 +65,14 @@ const handleWithdrawClick = async () => {
             ant.config.notifySuccessfulTrxHandler(
                 `${chainSettings.getExplorerUrl()}/tx/${tx.hash}`,
             );
-            waitingForResult.value = false;
         }).catch((err) => {
             console.error(err);
         }).finally(() => {
+            waitingForResult.value = false;
             dismiss();
         });
     } catch (err) {
+        waitingForResult.value = false;
         console.error(err);
     }
 };
@@ -88,7 +91,7 @@ updateRexData();
 <div class="c-withdraw-tab">
     <div class="c-withdraw-tab__withdraw-btn">
         <q-btn
-            :label="$t(withdrawEnabled ? 'evm_stake.withdraw_button_enabled' : 'evm_stake.withdraw_button_disabled', {
+            :label="$t(withdrawButtonLabel, {
                 amount: formatWei(withdrawableBalanceBn, systemTokenDecimals, uiDecimals),
                 symbol: systemTokenSymbol
             })"


### PR DESCRIPTION
## Summary
- Reset the withdraw tab's local waiting state when `withdrawEVMSystemTokens` fails before a transaction hash is returned.
- Keep the withdraw button label based on actual withdrawable balance, so provider failures do not relabel a positive balance as "Nothing to withdraw".
- Fix the escrow `depositsOf` read ABI field name from `timestamp` to `until`, matching `EvmRexDeposit` and `WithdrawRaw`.

## Root cause
The reported withdraw call is valid on-chain, but the wallet/provider can reject or expire the request before broadcast. The old withdraw tab set `waitingForResult` before the write call and never cleared it if the write threw. That left the button disabled and using the no-balance label even though `maxWithdraw` was positive.

A second withdraw rendering issue came up during live UAT: the escrow read ABI named the deposit unlock field `timestamp`, while the UI reads `withdrawal.until`. Ethers only exposes the tuple property name from the ABI, so withdraw rows threw `until.toNumber()` / invalid date errors even though the chain data was present.

## Validation
- `./node_modules/.bin/eslint --ext .ts,.vue src/antelope/stores/utils/abi/escrowAbi.ts src/pages/evm/staking/WithdrawTab.vue src/pages/evm/staking/WithdrawRaw.vue`
- `yarn build` succeeded with existing project warnings.
- Live read-only RPC checks showed the original `withdraw()` and `depositTLOS(200 TLOS)` calls both pass `eth_call` and `eth_estimateGas`.
- Live PR preview UAT with a disposable funded Telos EVM wallet:
  - MetaMask-style injected login succeeded.
  - Staked `0.1 TLOS`; tx `0x3436e7f2c5c070edb480cfb9925a5111d839c90851e59c2fb7d7d747fbfb886d`, receipt status `1`.
  - Unstaked `0.03 STLOS`; tx `0x9eaad6b519ad2177eb2cd1eb97e9d81c1b44afbc442f3b242b3299367e0ac50c`, receipt status `1`.
  - Simulated the original account's withdraw request expiry against production and this PR preview: production changed the positive withdraw button to disabled "Nothing to withdraw"; PR preview kept `WITHDRAW 94053.36 TLOS` enabled after the error.
