### PR TITLE
fix: pick up Rabby when Brave/MetaMask own window.ethereum

### DIFF
--- a/scripts/injected-providers-smoke.cjs
+++ b/scripts/injected-providers-smoke.cjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Standalone smoke for injected provider discovery (no jsdom/canvas).
+const { EventEmitter } = require('events');
+
+class FakeWindow extends EventEmitter {
+    constructor() {
+        super();
+        this.ethereum = undefined;
+        this.rabby = undefined;
+    }
+    addEventListener(type, fn) { this.on(type, fn); }
+    removeEventListener(type, fn) { this.off(type, fn); }
+    dispatchEvent(event) {
+        this.emit(event.type, event);
+        return true;
+    }
+}
+
+function fakeProvider(flags = {}) {
+    return { request() {}, on() {}, __initialized: false, ...flags };
+}
+
+function loadFresh() {
+    delete require.cache[require.resolve('../src/antelope/wallets/utils/injectedProviders.ts')];
+}
+
+// ts via experimental strip or just eval by requiring compiled? use node --experimental-strip-types if available
+// fallback: duplicate tiny logic check by importing after setting global window
+
+async function main() {
+    global.window = new FakeWindow();
+    let mod;
+    try {
+        mod = require('../src/antelope/wallets/utils/injectedProviders.ts');
+    } catch (e) {
+        // transpile-less: run with ts-node/tsx if present
+        try {
+            require('tsx/cjs');
+            mod = require('../src/antelope/wallets/utils/injectedProviders.ts');
+        } catch (e2) {
+            console.error('Cannot load TS helper', e.message, e2.message);
+            process.exit(1);
+        }
+    }
+
+    const {
+        findRabbyProvider,
+        startInjectedProviderDiscovery,
+        _resetInjectedProviderDiscovery,
+        RABBY_RDNS,
+    } = mod;
+
+    const assert = (cond, msg) => {
+        if (!cond) {
+            console.error('FAIL', msg);
+            process.exit(1);
+        }
+        console.log('ok', msg);
+    };
+
+    _resetInjectedProviderDiscovery();
+    assert(findRabbyProvider() === null, 'empty window → null');
+
+    const rabby = fakeProvider({ isRabby: true });
+    global.window.ethereum = rabby;
+    assert(findRabbyProvider() === rabby, 'window.ethereum.isRabby');
+
+    const brave = fakeProvider({ isBraveWallet: true, isMetaMask: true });
+    const hiddenRabby = fakeProvider({ isRabby: true });
+    global.window.ethereum = Object.assign(brave, { providers: [brave, hiddenRabby] });
+    assert(findRabbyProvider() === hiddenRabby, 'providers[] when Brave owns ethereum');
+
+    global.window.ethereum = fakeProvider({ isMetaMask: true });
+    global.window.rabby = hiddenRabby;
+    assert(findRabbyProvider() === hiddenRabby, 'window.rabby fallback');
+
+    delete global.window.rabby;
+    global.window.ethereum = fakeProvider({ isBraveWallet: true, isMetaMask: true });
+    startInjectedProviderDiscovery();
+    global.window.dispatchEvent({
+        type: 'eip6963:announceProvider',
+        detail: { info: { rdns: RABBY_RDNS, name: 'Rabby Wallet' }, provider: rabby },
+    });
+    assert(findRabbyProvider() === rabby, 'EIP-6963 announce');
+
+    console.log('ALL PASSED');
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/src/antelope/wallets/authenticators/RabbyAuth.ts
+++ b/src/antelope/wallets/authenticators/RabbyAuth.ts
@@ -1,5 +1,6 @@
 import { EthereumProvider } from 'src/antelope/types';
 import { EVMAuthenticator, InjectedProviderAuth } from 'src/antelope/wallets';
+import { findRabbyProvider } from 'src/antelope/wallets/utils/injectedProviders';
 
 const name = 'Rabby';
 export const RabbyAuthName = name;
@@ -13,12 +14,9 @@ export class RabbyAuth extends InjectedProviderAuth {
     // InjectedProviderAuth API ------------------------------------------------------
 
     getProvider(): EthereumProvider | null {
-        const eth = window.ethereum as unknown as EthereumProvider & { isRabby?: boolean };
-        // Rabby injects window.ethereum with isRabby flag
-        if (eth && eth.isRabby) {
-            return eth;
-        }
-        return null;
+        // Do not read only window.ethereum — Brave/MetaMask often occupy that
+        // slot while Rabby sits on ethereum.providers, window.rabby, or EIP-6963.
+        return findRabbyProvider() as EthereumProvider | null;
     }
 
     // EVMAuthenticator API ----------------------------------------------------------

--- a/src/antelope/wallets/index.ts
+++ b/src/antelope/wallets/index.ts
@@ -5,4 +5,5 @@ export * from 'src/antelope/wallets/authenticators/WalletConnectAuth';
 export * from 'src/antelope/wallets/authenticators/SafePalAuth';
 export * from 'src/antelope/wallets/authenticators/BraveAuth';
 export * from 'src/antelope/wallets/authenticators/RabbyAuth';
+export * from 'src/antelope/wallets/utils/injectedProviders';
 export * from 'src/antelope/wallets/AntelopeWallets';

--- a/src/antelope/wallets/utils/injectedProviders.ts
+++ b/src/antelope/wallets/utils/injectedProviders.ts
@@ -1,0 +1,112 @@
+export type InjectedWalletLike = {
+    isRabby?: boolean
+    isMetaMask?: boolean
+    isBraveWallet?: boolean
+    isSafePal?: boolean
+    _isSafePal?: boolean
+    providers?: InjectedWalletLike[]
+    request?: (...args: unknown[]) => Promise<unknown>
+    on?: (...args: unknown[]) => unknown
+    __initialized?: boolean
+}
+
+export const RABBY_RDNS = 'io.rabby';
+
+const eip6963ByRdns = new Map<string, InjectedWalletLike>();
+const discoveryListeners = new Set<() => void>();
+let discoveryHooked = false;
+
+function notifyDiscoveryListeners(): void {
+    discoveryListeners.forEach((fn) => {
+        try {
+            fn();
+        } catch {
+            // listener errors must not break discovery
+        }
+    });
+}
+
+function onAnnounceProvider(event: Event): void {
+    const detail = (event as CustomEvent).detail as {
+        info?: { rdns?: string }
+        provider?: InjectedWalletLike
+    } | undefined;
+    const rdns = detail?.info?.rdns;
+    const provider = detail?.provider;
+    if (!rdns || !provider) {
+        return;
+    }
+    eip6963ByRdns.set(String(rdns), provider);
+    notifyDiscoveryListeners();
+}
+
+/** Start (or re-request) EIP-6963 provider announcements. Safe to call more than once. */
+export function startInjectedProviderDiscovery(onChange?: () => void): () => void {
+    if (onChange) {
+        discoveryListeners.add(onChange);
+    }
+    if (typeof window !== 'undefined') {
+        if (!discoveryHooked) {
+            discoveryHooked = true;
+            window.addEventListener('eip6963:announceProvider', onAnnounceProvider);
+        }
+        window.dispatchEvent(new Event('eip6963:requestProvider'));
+    }
+    return () => {
+        if (onChange) {
+            discoveryListeners.delete(onChange);
+        }
+    };
+}
+
+export function findInjectedProvider(
+    pred: (provider: InjectedWalletLike) => boolean,
+): InjectedWalletLike | null {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    const seen = new Set<InjectedWalletLike>();
+    const queue: InjectedWalletLike[] = [];
+    const eth = window.ethereum as InjectedWalletLike | undefined;
+    if (eth) {
+        queue.push(eth);
+    }
+    if (Array.isArray(eth?.providers)) {
+        queue.push(...eth.providers);
+    }
+    const rabbyWin = (window as Window & { rabby?: InjectedWalletLike }).rabby;
+    if (rabbyWin) {
+        queue.push(rabbyWin);
+    }
+    for (const provider of eip6963ByRdns.values()) {
+        queue.push(provider);
+    }
+
+    for (const provider of queue) {
+        if (!provider || seen.has(provider)) {
+            continue;
+        }
+        seen.add(provider);
+        if (pred(provider)) {
+            return provider;
+        }
+    }
+    return null;
+}
+
+export function findRabbyProvider(): InjectedWalletLike | null {
+    return findInjectedProvider(provider => !!provider.isRabby)
+        ?? eip6963ByRdns.get(RABBY_RDNS)
+        ?? null;
+}
+
+/** Test-only: wipe EIP-6963 cache and listeners. */
+export function _resetInjectedProviderDiscovery(): void {
+    eip6963ByRdns.clear();
+    discoveryListeners.clear();
+    if (typeof window !== 'undefined' && discoveryHooked) {
+        window.removeEventListener('eip6963:announceProvider', onAnnounceProvider);
+    }
+    discoveryHooked = false;
+}

--- a/src/antelope/wallets/utils/injectedProviders.ts
+++ b/src/antelope/wallets/utils/injectedProviders.ts
@@ -72,8 +72,9 @@ export function findInjectedProvider(
     if (eth) {
         queue.push(eth);
     }
-    if (Array.isArray(eth?.providers)) {
-        queue.push(...eth.providers);
+    const extraProviders = eth?.providers;
+    if (Array.isArray(extraProviders)) {
+        queue.push(...extraProviders);
     }
     const rabbyWin = (window as Window & { rabby?: InjectedWalletLike }).rabby;
     if (rabbyWin) {

--- a/src/boot/antelope.ts
+++ b/src/boot/antelope.ts
@@ -11,6 +11,7 @@ import {
 } from 'src/antelope/wallets';
 import { BraveAuth } from 'src/antelope/wallets/authenticators/BraveAuth';
 import { RabbyAuth } from 'src/antelope/wallets/authenticators/RabbyAuth';
+import { startInjectedProviderDiscovery } from 'src/antelope/wallets/utils/injectedProviders';
 import { App } from 'vue';
 import { Router } from 'vue-router';
 import { resetNativeApi } from 'src/boot/api';
@@ -104,6 +105,9 @@ export default boot(({ app }) => {
             ant.config.notifyFailureMessage(ant.config.localizationHandler('evm_wallet.general_error'));
         }
     });
+
+    // Discover multi-injected wallets (EIP-6963 / providers[]) before authenticators init
+    startInjectedProviderDiscovery();
 
     // set evm authenticators --
     const options: Web3ModalConfig = app.config.globalProperties.$wagmiOptions as Web3ModalConfig;

--- a/src/pages/home/LoginButtons.vue
+++ b/src/pages/home/LoginButtons.vue
@@ -12,8 +12,11 @@ import {
     computed,
     defineComponent,
     getCurrentInstance,
+    onBeforeUnmount,
+    onMounted,
     ref,
 } from 'vue';
+import { findRabbyProvider, startInjectedProviderDiscovery } from 'src/antelope/wallets/utils/injectedProviders';
 import { QSpinnerFacebook } from 'quasar';
 import InlineSvg from 'vue-inline-svg';
 
@@ -36,6 +39,17 @@ export default defineComponent({
         const globalProps = (getCurrentInstance() as ComponentInternalInstance).appContext.config.globalProperties;
         const isMobile = ref(usePlatformStore().isMobile);
         const isBraveBrowser = ref((navigator as any).brave && (navigator as any).brave.isBrave());
+        const injectedEpoch = ref(0);
+        let stopInjectedDiscovery: (() => void) | undefined;
+        onMounted(() => {
+            stopInjectedDiscovery = startInjectedProviderDiscovery(() => {
+                injectedEpoch.value += 1;
+            });
+            injectedEpoch.value += 1;
+        });
+        onBeforeUnmount(() => {
+            stopInjectedDiscovery?.();
+        });
 
         const showEVMButtons = computed(() =>
             props.chain === 'evm');
@@ -61,8 +75,8 @@ export default defineComponent({
         });
 
         const supportsRabby = computed(() => {
-            const e = window.ethereum as unknown as { [key:string]: boolean };
-            return e && e.isRabby;
+            void injectedEpoch.value;
+            return !!findRabbyProvider();
         });
 
         const showMetamaskButton = computed(() => !isMobile.value || supportsMetamask.value);

--- a/test/jest/__tests__/antelope/wallets/injectedProviders.spec.ts
+++ b/test/jest/__tests__/antelope/wallets/injectedProviders.spec.ts
@@ -1,0 +1,81 @@
+import { jest } from '@jest/globals';
+import {
+    findInjectedProvider,
+    findRabbyProvider,
+    startInjectedProviderDiscovery,
+    _resetInjectedProviderDiscovery,
+    RABBY_RDNS,
+} from 'src/antelope/wallets/utils/injectedProviders';
+
+function fakeProvider(flags: Record<string, unknown> = {}) {
+    return {
+        request: jest.fn(),
+        on: jest.fn(),
+        __initialized: false,
+        ...flags,
+    };
+}
+
+describe('injectedProviders', () => {
+    const originalEthereum = (window as { ethereum?: unknown }).ethereum;
+
+    beforeEach(() => {
+        _resetInjectedProviderDiscovery();
+        delete (window as { ethereum?: unknown }).ethereum;
+        delete (window as { rabby?: unknown }).rabby;
+    });
+
+    afterAll(() => {
+        (window as { ethereum?: unknown }).ethereum = originalEthereum;
+        _resetInjectedProviderDiscovery();
+    });
+
+    it('returns null when nothing is injected', () => {
+        expect(findRabbyProvider()).toBeNull();
+    });
+
+    it('finds Rabby on window.ethereum.isRabby', () => {
+        const rabby = fakeProvider({ isRabby: true });
+        (window as { ethereum?: unknown }).ethereum = rabby;
+        expect(findRabbyProvider()).toBe(rabby);
+    });
+
+    it('finds Rabby in window.ethereum.providers when Brave owns window.ethereum', () => {
+        const brave = fakeProvider({ isBraveWallet: true, isMetaMask: true });
+        const rabby = fakeProvider({ isRabby: true });
+        (window as { ethereum?: unknown }).ethereum = {
+            ...brave,
+            providers: [brave, rabby],
+        };
+        expect(findRabbyProvider()).toBe(rabby);
+        expect(findInjectedProvider(p => !!p.isBraveWallet)).toBeTruthy();
+    });
+
+    it('finds window.rabby when ethereum is another wallet', () => {
+        const metamask = fakeProvider({ isMetaMask: true });
+        const rabby = fakeProvider({ isRabby: true });
+        (window as { ethereum?: unknown }).ethereum = metamask;
+        (window as { rabby?: unknown }).rabby = rabby;
+        expect(findRabbyProvider()).toBe(rabby);
+    });
+
+    it('finds Rabby from EIP-6963 announce', () => {
+        const rabby = fakeProvider({ isRabby: true });
+        startInjectedProviderDiscovery();
+        window.dispatchEvent(new CustomEvent('eip6963:announceProvider', {
+            detail: {
+                info: { rdns: RABBY_RDNS, name: 'Rabby Wallet' },
+                provider: rabby,
+            },
+        }));
+        expect(findRabbyProvider()).toBe(rabby);
+    });
+
+    it('does not treat Brave/MetaMask as Rabby', () => {
+        (window as { ethereum?: unknown }).ethereum = fakeProvider({
+            isBraveWallet: true,
+            isMetaMask: true,
+        });
+        expect(findRabbyProvider()).toBeNull();
+    });
+});


### PR DESCRIPTION
## Bug Description

On wallet.telos.net EVM login, Rabby shows as **Install Rabby** even when the extension is installed. Screenshot from Brave: Brave Wallet and MetaMask are detected; Rabby is not.

## Root Cause

Detection was `window.ethereum.isRabby` only. When Brave (or MetaMask) is the selected injected provider, it occupies `window.ethereum`. Rabby is still available on `ethereum.providers[]`, `window.rabby`, or EIP-6963 (`io.rabby`).

## Fix

- Shared `findRabbyProvider()` scans all of the above
- Login button uses that helper and refreshes on EIP-6963 announce
- `RabbyAuth.getProvider()` uses the same lookup so login talks to Rabby, not Brave
- Boot requests EIP-6963 providers before authenticators init

## How to Verify

1. Brave + Rabby + MetaMask installed.
2. Open `wallet.telos.net/?login=evm&network=telos-evm`.
3. Button should say **Rabby**, not **Install Rabby**.
4. Clicking it should open Rabby, not the Brave wallet.

## Test Plan

- [x] `node --experimental-strip-types scripts/injected-providers-smoke.cjs`
- [x] Jest spec added (`injectedProviders.spec.ts`) — local Jest blocked on `canvas` native bind
- [ ] Manual Brave + Rabby login on preview

## Risk Assessment

Low — only changes Rabby detection/login. Other authenticators unchanged.